### PR TITLE
introduce a function concept

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -40,7 +40,7 @@ ReturnsDuals
 SupportsAddConstraintAfterSolve
 SupportsDeleteConstraint
 SupportsAddVariableAfterSolve
-SupportsQuadraticObjective
+SupportsObjective
 SupportsConicThroughQuadratic
 ```
 
@@ -62,9 +62,7 @@ List of solver instance attributes
 RawSolver
 Sense
 NumberOfVariables
-NumberOfVariablewiseConstraints
-NumberOfAffineConstraints
-NumberOfQuadraticConstraints
+NumberOfConstraints
 ResultCount
 ObjectiveValue
 ObjectiveBound
@@ -135,9 +133,7 @@ VariableBasisStatus
 Constraint references and functions for adding, modifying, and removing constraints.
 
 ```@docs
-VariablewiseConstraintReference
-AffineConstraintReference
-QuadraticConstraintReference
+ConstraintReference
 candelete(::AbstractSolverInstance,::ConstraintReference)
 isvalid(::AbstractSolverInstance,::ConstraintReference)
 delete!(::AbstractSolverInstance,::ConstraintReference)
@@ -159,7 +155,20 @@ ConstraintDual
 ConstraintBasisStatus
 ```
 
-### Sets
+## Functions
+
+List of recognized functions.
+```@docs
+AbstractFunction
+ScalarVariablewiseFunction
+VectorVariablewiseFunction
+ScalarAffineFunction
+VectorAffineFunction
+ScalarQuadraticFunction
+VectorQuadraticFunction
+```
+
+## Sets
 
 List of recognized sets.
 

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -31,6 +31,7 @@ setattribute!
 
 ```@docs
 AbstractSolver
+supportsproblem
 ```
 
 List of solver attributes
@@ -40,7 +41,6 @@ ReturnsDuals
 SupportsAddConstraintAfterSolve
 SupportsDeleteConstraint
 SupportsAddVariableAfterSolve
-SupportsObjective
 SupportsConicThroughQuadratic
 ```
 
@@ -63,6 +63,7 @@ RawSolver
 Sense
 NumberOfVariables
 NumberOfConstraints
+ListOfPresentConstraints
 ResultCount
 ObjectiveValue
 ObjectiveBound

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -65,6 +65,7 @@ NumberOfVariables
 NumberOfConstraints
 ListOfPresentConstraints
 ResultCount
+ObjectiveFunction
 ObjectiveValue
 ObjectiveBound
 RelativeGap
@@ -106,16 +107,22 @@ The value of the attribute is of type `BasisStatusCode`.
 BasisStatusCode
 ```
 
-### Variables
 
-Variable references and functions for adding and deleting variables.
+### References
 
-[attribute that points to the (scalar) variable domain??? eg GreaterThan, NonNegatives, ZeroOne, SemiInteger]
 ```@docs
 VariableReference
-candelete(::AbstractSolverInstance,::VariableReference)
-isvalid(::AbstractSolverInstance,::VariableReference)
-delete!(::AbstractSolverInstance,::VariableReference)
+ConstraintReference
+candelete
+isvalid
+delete!(::AbstractSolverInstance,::AnyReference)
+```
+
+### Variables
+
+Functions for adding variables. For deleting, see references section.
+
+```@docs
 addvariables!
 addvariable!
 ```
@@ -131,22 +138,16 @@ VariableBasisStatus
 
 ### Constraints
 
-Constraint references and functions for adding, modifying, and removing constraints.
+Functions for adding and modifying constraints.
 
 ```@docs
-ConstraintReference
-candelete(::AbstractSolverInstance,::ConstraintReference)
 isvalid(::AbstractSolverInstance,::ConstraintReference)
-delete!(::AbstractSolverInstance,::ConstraintReference)
 addconstraint!
 modifyconstraint!
-getconstraintconstant
-getconstraintaffine
-getconstraintquadratic
 ```
 
 List of attributes associated with constraints. [category AbstractConstraintAttribute]
-Calls to `getattribute` and `setattribute!` should include as an argument a single `ConstraintReference` or a vector of `ConstraintReference{T}` objects.
+Calls to `getattribute` and `setattribute!` should include as an argument a single `ConstraintReference` or a vector of `ConstraintReference{F,S}` objects.
 
 ```@docs
 ConstraintPrimalStart
@@ -154,6 +155,8 @@ ConstraintDualStart
 ConstraintPrimal
 ConstraintDual
 ConstraintBasisStatus
+ConstraintFunction
+ConstraintSet
 ```
 
 ## Functions
@@ -167,6 +170,11 @@ ScalarAffineFunction
 VectorAffineFunction
 ScalarQuadraticFunction
 VectorQuadraticFunction
+```
+
+List of function modifications.
+```@docs
+ScalarConstantChange
 ```
 
 ## Sets
@@ -208,6 +216,4 @@ Functions for adding and modifying objectives.
 ```@docs
 setobjective!
 modifyobjective!
-getobjectiveconstant
-getobjectiveaffine
 ```

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -19,7 +19,7 @@ abstract type AbstractSolverInstance end
 """
     SolverInstance(solver::AbstractSolver)
 
-Create a solver instance of `AbstractSolverInstance` using the given solver.
+Create a solver instance from the given solver.
 """
 function SolverInstance end
 
@@ -48,6 +48,52 @@ Supported file types are solver-dependent.
 """
 function writeproblem end
 
+"""
+    supportsproblem(s::AbstractSolver, objective_types::Vector, constriant_types::Vector)::Bool
+
+Return `true` if the solver supports optimizing a problem with objective types listed in `objective_types` (which should have one element except for the case of multiobjective optimization) and constraints of the types specified by `constraint_types` which is a list of tuples `(F,S)` for `F`-in-`S` constraints. Return false if the solver does not support this problem class.
+
+    supportsproblem(s::AbstractSolver, objective_type::F, constriant_types::Vector)::Bool
+
+Return `true` if the solver supports optimizing a problem with objective type `F` and constraints of the types specified by `constraint_types` which is a list of tuples `(F,S)` for `F`-in-`S` constraints. Return false if the solver does not support this problem class.
+### Examples
+
+```julia
+supportsproblem(s, ScalarAffineFunction,
+    [(ScalarAffineFunction,Zeros),
+    (ScalarAffineFunction,LessThan),
+    (ScalarAffineFunction,GreaterThan)])
+```
+should be `true` for a linear programming solver.
+
+```julia
+supportsproblem(s, ScalarQuadraticFunction,
+    [(ScalarAffineFunction,Zeros),
+    (ScalarAffineFunction,LessThan),
+    (ScalarAffineFunction,GreaterThan)])
+```
+should be `true` for a quadratic programming solver.
+
+```julia
+supportsproblem(s, ScalarAffineFunction,
+    [(ScalarAffineFunction,Zeros),
+    (ScalarAffineFunction,LessThan),
+    (ScalarAffineFunction,GreaterThan),
+    (ScalarVariablewiseFunction,ZeroOne)])
+```
+should be `true` for a mixed-integer linear programming solver.
+
+```julia
+supportsproblem(s, ScalarAffineFunction,
+    [(ScalarAffineFunction,Zeros),
+    (ScalarAffineFunction,LessThan),
+    (ScalarAffineFunction,GreaterThan),
+    (VectorAffineFunction,SecondOrderCone)])
+```
+should be `true` for a second-order cone solver.
+
+"""
+function supportsproblem end
 
 include("attributes.jl")
 include("constraints.jl")

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -53,6 +53,7 @@ include("attributes.jl")
 include("constraints.jl")
 include("objectives.jl")
 include("references.jl")
+include("functions.jl")
 include("sets.jl")
 include("variables.jl")
 

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -59,36 +59,36 @@ Return `true` if the solver supports optimizing a problem with objective type `F
 ### Examples
 
 ```julia
-supportsproblem(s, ScalarAffineFunction,
-    [(ScalarAffineFunction,Zeros),
-    (ScalarAffineFunction,LessThan),
-    (ScalarAffineFunction,GreaterThan)])
+supportsproblem(s, ScalarAffineFunction{Float64},
+    [(ScalarAffineFunction{Float64},Zeros),
+    (ScalarAffineFunction{Float64},LessThan),
+    (ScalarAffineFunction{Float64},GreaterThan)])
 ```
 should be `true` for a linear programming solver.
 
 ```julia
-supportsproblem(s, ScalarQuadraticFunction,
-    [(ScalarAffineFunction,Zeros),
-    (ScalarAffineFunction,LessThan),
-    (ScalarAffineFunction,GreaterThan)])
+supportsproblem(s, ScalarQuadraticFunction{Float64},
+    [(ScalarAffineFunction{Float64},Zeros),
+    (ScalarAffineFunction{Float64},LessThan),
+    (ScalarAffineFunction{Float64},GreaterThan)])
 ```
 should be `true` for a quadratic programming solver.
 
 ```julia
-supportsproblem(s, ScalarAffineFunction,
-    [(ScalarAffineFunction,Zeros),
-    (ScalarAffineFunction,LessThan),
-    (ScalarAffineFunction,GreaterThan),
-    (ScalarVariablewiseFunction,ZeroOne)])
+supportsproblem(s, ScalarAffineFunction{Float64},
+    [(ScalarAffineFunction{Float64},Zeros),
+    (ScalarAffineFunction{Float64},LessThan),
+    (ScalarAffineFunction{Float64},GreaterThan),
+    (ScalarVariablewiseFunction{Float64},ZeroOne)])
 ```
 should be `true` for a mixed-integer linear programming solver.
 
 ```julia
-supportsproblem(s, ScalarAffineFunction,
-    [(ScalarAffineFunction,Zeros),
-    (ScalarAffineFunction,LessThan),
-    (ScalarAffineFunction,GreaterThan),
-    (VectorAffineFunction,SecondOrderCone)])
+supportsproblem(s, ScalarAffineFunction{Float64},
+    [(ScalarAffineFunction{Float64},Zeros),
+    (ScalarAffineFunction{Float64},LessThan),
+    (ScalarAffineFunction{Float64},GreaterThan),
+    (VectorAffineFunction{Float64},SecondOrderCone)])
 ```
 should be `true` for a second-order cone solver.
 

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -49,10 +49,6 @@ Supported file types are solver-dependent.
 function writeproblem end
 
 """
-    supportsproblem(s::AbstractSolver, objective_types::Vector, constriant_types::Vector)::Bool
-
-Return `true` if the solver supports optimizing a problem with objective types listed in `objective_types` (which should have one element except for the case of multiobjective optimization) and constraints of the types specified by `constraint_types` which is a list of tuples `(F,S)` for `F`-in-`S` constraints. Return false if the solver does not support this problem class.
-
     supportsproblem(s::AbstractSolver, objective_type::F, constriant_types::Vector)::Bool
 
 Return `true` if the solver supports optimizing a problem with objective type `F` and constraints of the types specified by `constraint_types` which is a list of tuples `(F,S)` for `F`-in-`S` constraints. Return false if the solver does not support this problem class.
@@ -64,7 +60,7 @@ supportsproblem(s, ScalarAffineFunction{Float64},
     (ScalarAffineFunction{Float64},LessThan),
     (ScalarAffineFunction{Float64},GreaterThan)])
 ```
-should be `true` for a linear programming solver.
+should be `true` for a linear programming solver `s`.
 
 ```julia
 supportsproblem(s, ScalarQuadraticFunction{Float64},
@@ -72,7 +68,7 @@ supportsproblem(s, ScalarQuadraticFunction{Float64},
     (ScalarAffineFunction{Float64},LessThan),
     (ScalarAffineFunction{Float64},GreaterThan)])
 ```
-should be `true` for a quadratic programming solver.
+should be `true` for a quadratic programming solver `s`.
 
 ```julia
 supportsproblem(s, ScalarAffineFunction{Float64},
@@ -81,7 +77,7 @@ supportsproblem(s, ScalarAffineFunction{Float64},
     (ScalarAffineFunction{Float64},GreaterThan),
     (ScalarVariablewiseFunction{Float64},ZeroOne)])
 ```
-should be `true` for a mixed-integer linear programming solver.
+should be `true` for a mixed-integer linear programming solver `s`.
 
 ```julia
 supportsproblem(s, ScalarAffineFunction{Float64},
@@ -90,7 +86,7 @@ supportsproblem(s, ScalarAffineFunction{Float64},
     (ScalarAffineFunction{Float64},GreaterThan),
     (VectorAffineFunction{Float64},SecondOrderCone)])
 ```
-should be `true` for a second-order cone solver.
+should be `true` for a second-order cone solver `s`.
 
 """
 function supportsproblem end

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -216,16 +216,13 @@ struct SupportsConicThroughQuadratic <: AbstractSolverAttribute end
 ## Solver instance attributes
 
 """
-    ObjectiveValue(resultidx::Int=1, objectiveindex::Int=1)
+    ObjectiveValue(resultidx::Int=1)
 
-The objective value of the `resultindex`th primal result of the `objectiveindex`th objective.
-
-Both `resultindex` and `objectiveindex` default to 1.
+The objective value of the `resultindex`th primal result.
 """
 struct ObjectiveValue <: AbstractSolverInstanceAttribute
     resultindex::Int
-    objectiveindex::Int
-    (::Type{ObjectiveValue})(resultindex=1, objectiveindex=1) = new(resultindex, objectiveindex)
+    (::Type{ObjectiveValue})(resultindex=1) = new(resultindex)
 end
 
 """
@@ -316,6 +313,13 @@ and `S` is a set type indicating that the attribute `NumberOfConstraints{F,S}()`
 has value greater than zero.
 """
 struct ListOfPresentConstraints <: AbstractSolverInstanceAttribute end
+
+"""
+    ObjectiveFunction()
+
+An `AbstractFunction` instance which represents the objective function.
+"""
+struct ObjectiveFunction <: AbstractSolverInstanceAttribute end
 ## Variable attributes
 
 """
@@ -404,6 +408,20 @@ ConstraintDual() = ConstraintDual(1)
 Returns the `BasisStatusCode` of a given constraint, with respect to an available optimal solution basis.
 """
 struct ConstraintBasisStatus <: AbstractConstraintAttribute end
+
+"""
+    ConstraintFunction()
+
+Return the `AbstractFunction` object used to define the constraint.
+"""
+struct ConstraintFunction <: AbstractConstraintAttribute end
+
+"""
+    ConstraintSet()
+
+Return the `AbstractSet` object used to define the constraint.
+"""
+struct ConstraintSet <: AbstractConstraintAttribute end
 
 ## Termination status
 """

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -207,11 +207,15 @@ struct SupportsAddVariableAfterSolve <: AbstractSolverAttribute end
 # TODO: supports modify objective
 
 """
-    SupportsQuadraticObjective()
+    SupportsObjective{F}()
 
-A `Bool` indicating if the solver supports quadratic objectives.
+A `Bool` indicating if the solver supports objectives with functions of the type `F`.
+
+### Examples
+
+`SupportsObjective{ScalarQuadraticFunction}` would be `true` if the solver supports quadratic objective functions.
 """
-struct SupportsQuadraticObjective <: AbstractSolverAttribute end
+struct SupportsObjective{F} <: AbstractSolverAttribute end
 
 """
     SupportsConicThroughQuadratic()
@@ -307,25 +311,11 @@ The number of variables in the solver instance.
 struct NumberOfVariables <: AbstractSolverInstanceAttribute end
 
 """
-    NumberOfVariablewiseConstraints{T}()
+    NumberOfConstraints{F,S}()
 
-The number of variablewise constraints of type `T` in the solver instance.
+The number of constraints of the type `F`-in-`S`.
 """
-struct NumberOfVariablewiseConstraints{T} <: AbstractSolverInstanceAttribute end
-
-"""
-    NumberOfAffineConstraints{T}()
-
-The number of affine constraints of type `T` in the solver instance.
-"""
-struct NumberOfAffineConstraints{T} <: AbstractSolverInstanceAttribute end
-
-"""
-    NumberOfQuadraticConstraints{T}()
-
-The number of quadratic constraints of type `T` in the solver instance.
-"""
-struct NumberOfQuadraticConstraints{T} <: AbstractSolverInstanceAttribute end
+struct NumberOfConstraints{F,S} <: AbstractSolverInstanceAttribute end
 
 ## Variable attributes
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -163,7 +163,7 @@ function setattribute!(m, attr::AnyAttribute, args...)
     throw(ArgumentError("SolverInstance of type $(typeof(m)) does not support setting the attribute $attr"))
 end
 
-## Solver or solver instance attributes
+## Solver attributes
 
 """
     ReturnsDuals()
@@ -207,22 +207,13 @@ struct SupportsAddVariableAfterSolve <: AbstractSolverAttribute end
 # TODO: supports modify objective
 
 """
-    SupportsObjective{F}()
-
-A `Bool` indicating if the solver supports objectives with functions of the type `F`.
-
-### Examples
-
-`SupportsObjective{ScalarQuadraticFunction}` would be `true` if the solver supports quadratic objective functions.
-"""
-struct SupportsObjective{F} <: AbstractSolverAttribute end
-
-"""
     SupportsConicThroughQuadratic()
 
 A `Bool` indicating if the solver interprets certain quadratic constraints as second-order cone constraints.
 """
 struct SupportsConicThroughQuadratic <: AbstractSolverAttribute end
+
+## Solver instance attributes
 
 """
     ObjectiveValue(resultidx::Int=1, objectiveindex::Int=1)
@@ -313,10 +304,18 @@ struct NumberOfVariables <: AbstractSolverInstanceAttribute end
 """
     NumberOfConstraints{F,S}()
 
-The number of constraints of the type `F`-in-`S`.
+The number of constraints of the type `F`-in-`S` present in the solver instance.
 """
 struct NumberOfConstraints{F,S} <: AbstractSolverInstanceAttribute end
 
+"""
+    ListOfPresentConstraints()
+
+A list of tuples of the form `(F,S)`, where `F` is a function type
+and `S` is a set type indicating that the attribute `NumberOfConstraints{F,S}()`
+has value greater than zero.
+"""
+struct ListOfPresentConstraints <: AbstractSolverInstanceAttribute end
 ## Variable attributes
 
 """

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -11,111 +11,49 @@ function addconstraint! end
 
 # TODO: method to query if solver supports this type of modification
 
-"""
-    getconstraintconstant(m::AbstractSolverInstance, c::ConstraintReference)
-
-Return the ``b`` vector of the constraint `c`.
-
-    getconstraintconstant(m::AbstractSolverInstance, c::ConstraintReference, k::Int)
-
-Return the constant term of the `k`th row of the constraint `c`.
-"""
-function getconstraintconstant end
 
 """
-    getconstraintaffine(m::AbstractSolverInstance, c::ConstraintReference)
+## Modify Function
 
-Return the ``A_i`` matrix of the constraint corresponding to `c` in triplet form `(i, v, coef)`, where `v` is a `VariableReference`, and `coef` is a coefficient value.
-Output is a tuple of three vectors.
+    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference, func::F)
 
-    getconstraintaffine(m::AbstractSolverInstance, c::ConstraintReference, k::Int)
-
-Return the `k`th row of the ``A_k`` matrix of the constraint corresponding to `c` in tuple form `(v, coef)`, where `v` is a `VariableReference`, and `coef` is a coefficient value.
-Output is a tuple of two vectors.
-
-    getconstraintaffine(m::AbstractSolverInstance, c::ConstraintReference, k::Int, v::VariableReference)
-
-Return the element of the ``A_k`` matrix of the constraint corresponding to `c` in row `k` and variable `v`.
-"""
-function getconstraintaffine end
-
-"""
-    getconstraintquadratic(m::AbstractSolverInstance, c::ConstraintReference, k::Int)
-
-Return the ``Q_{i,k}`` matrix of the `k`th row of the constraint corresponding to `c` in triplet form `(v_1, v_2, coef)`, where `v_1, v_2` are `VariableReference`s, and `coef` is a coefficient value.
-Output is a tuple of three vectors.
-The ``Q_{i,k}`` matrix must be symmetric, and only one element is returned.
-
-    getconstraintquadratic(m::AbstractSolverInstance, c::ConstraintReference, k::Int, v_1::VariableReference, v_2::VariableReference)
-
-Return the element corresponding to `(v_1, v_2)` of the ``Q_{i,k}`` matrix of the `k`th row of the constraint corresponding to `c`.
-"""
-function getconstraintquadratic end
-
-"""
-    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference, k::Int, args...)
-
-Modify elements of the `k`th row of the constraint `c` depending on the arguments `args`.
-The `k`th row will have the form ``q_{i,k}(x) + A_{i,k}^T x + b_{i,k}``.
-There are four cases.
-
-## Modify Constant term
-
-    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference, k::Int, b)
-
-Set the constant term of the `k`th row in the constraint `c` to `b`.
+Replace the function in constraint `c` with `func`. `F` must match the original function
+type used to define the constraint.
 
 ### Examples
 
-```julia
-modifyconstraint!(m, c, 1, 1.0)
-```
-
-## Modify Linear term
-
-    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference, k::Int, a_v::Vector{VariableReference}, a_coef)
-
-Set elements given by `a_v` in the linear term of the `k`th row in the constraint `c` to `a_coef`.
-Either `a_v` and `a_coef` are both singletons, or they should be collections with equal length.
-The behavior of duplicate entries in `a_v` is undefined.
-
-### Examples
+If `c` is a `ConstraintReference{ScalarAffineFunction,S}` and `v1` and `v2` are `VariableReference` objects,
 
 ```julia
-modifyconstraint!(m, c, v, 1.0)
-modifyconstraint!(m, c, [v_1, v_2], [1.0, 2.0])
+modifyconstraint!(m, c, ScalarAffineFunction([v1,v2],[1.0,2.0],5.0))
+modifyconstraint!(m, c, ScalarVariablewiseFunction(v1)) # Error
 ```
 
-## Modify Quadratic term
-
-    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference, k::Int, Q_vari, Q_varj, Q_coef)
-
-Set the elements in the quadratic term of the `k`th row of the constraint `c` specified by the triplets `Q_vari, Q_varj, Q_coef`.
-Off-diagonal entries will be mirrored.
-`Q_vari, Q_varj` should be collections of `VariableReference` objects.
-The behavior of duplicate entries is undefined.
-If entries for both ``(i,j)`` and ``(j,i)`` are provided, these are considered duplicate terms.
-
-### Examples
-
-```julia
-modifyconstraint!(m, c, v_1, v_2, 1.0)
-modifyconstraint!(m, c, [v_1, v_2], [v_1, v_1], [1.0, 2.0])
-```
 
 ## Modify Set
 
-    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference{Set}, S::Set)
+    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference, S::S)
 
 Change the set of constraint `c` to the new set `S` which should be of the same type as the original set.
 
 ### Examples
 
-If `c` is a `ConstraintReference{Interval}`
+If `c` is a `ConstraintReference{F,Interval}`
 
 ```julia
 modifyconstraint!(m, c, Interval(0, 5))
-modifyconstraint!(m, c, NonPositives) # errors
+modifyconstraint!(m, c, NonPositives) # Error
+
+## Partial Modifications
+
+    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference, change::AbstractFunctionModification)
+
+Apply the modification specified by `change` to the function of constraint `c`.
+
+### Examples
+
+```julia
+modifyconstraint!(m, c, ScalarConstantChange(10.0))
 ```
 """
 function modifyconstraint! end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,60 +1,11 @@
 # Constraints
 
 """
-    addconstraint!(m::AbstractSolverInstance, b, a_constridx, a_v::Vector{VariableReference}, a_coef, Q_constridx, Q_vari::Vector{VariableReference}, Q_varj::Vector{VariableReference}, Q_coef, S::AbstractSet)::QuadraticConstraintReference{typeof(S)}
+    addconstraint!(m::AbstractSolverInstance, func::F, set::S)::ConstraintReference{F,S}
 
-Add the vector quadratic-in-set constraint ``q_i(x) + A_i^T x + b_i \\in \\mathcal{S}_i``, where:
-* ``A_i`` is a sparse matrix specified in triplet form by `a_constridx, a_v, a_coef`
-* ``b_i`` is a vector specified by `b`
-* ``q_i(x)`` is a vector with component ``(q_i(x))_k`` defined as ``\\frac{1}{2} x^T Q_{i,k} x``, where each symmetric matrix ``Q_{i,k}`` has `Q_constridx` equal to `k` and is specified in triplet form by `Q_vari, Q_varj, Q_coef`
-* ``\\mathcal{S}_i`` is a pre-defined set specified as `S`
+Add the constraint ``f(x) \\in \\mathcal{S}`` where ``f`` is defined by `func`,
+and ``\\mathcal{S}`` is defined by `set`.
 
-Duplicate indices in either the ``A_i`` matrix or any ``Q_{i,k}`` matrix are accepted and will be summed together.
-Off-diagonal entries of ``Q_{i,k}`` will be mirrored, so either the upper triangular or lower triangular entries of ``Q_{i,k}`` should be provided.
-If entries for both ``(i,j)`` and ``(j,i)`` are provided, these are considered duplicate terms.
-`a_v`, `Q_vari`, `Q_varj` should be collections of `VariableReference` objects.
-
-    addconstraint!(m::AbstractSolverInstance, b, a_v::Vector{VariableReference}, a_coef, Q_vari::Vector{VariableReference}, Q_varj::Vector{VariableReference}, Q_coef, S::AbstractSet)::QuadraticConstraintReference{typeof(S)}
-
-Add the scalar quadratic-in-set constraint ``q_i(x) + a_i^T x + b_i \\in \\mathcal{S}_i``, where:
-* ``a_i`` is a sparse vector specified in tuple form by `a_v, a_coef`
-* ``b_i`` is a scalar specified by `b`
-* ``q_i(x)`` is defined as ``\\frac{1}{2} x^T Q_{i} x``, where the symmetric matrix ``Q_{i}`` is specified in triplet form by `Q_vari, Q_varj, Q_coef`
-* ``\\mathcal{S}_i`` is a pre-defined *scalar* set specified as `S`
-
-Duplicate indices in the ``a_i`` or the ``Q_{i,k}`` are accepted and will be summed together.
-
-    addconstraint!(m::AbstractSolverInstance, b, a_constridx, a_v::Vector{VariableReference}, a_coef, S::AbstractSet)::AffineConstraintReference{typeof(S)}
-
-Add the vector affine-in-set constraint ``A_i^T x + b_i \\in \\mathcal{S}_i``, where:
-* ``A_i`` is a sparse matrix specified in triplet form by `a_constridx, a_v, a_coef`
-* ``b_i`` is a vector specified by `b`
-* ``\\mathcal{S}_i`` is a pre-defined set specified as `S`
-
-Duplicate indices in the ``A_i`` are accepted and will be summed together.
-
-    addconstraint!(m::AbstractSolverInstance, b, a_v::Vector{VariableReference}, a_coef, S::AbstractSet)::AffineConstraintReference{typeof(S)}
-
-Add the scalar affine-in-set constraint ``a_i^T x + b_i \\in \\mathcal{S}_i``, where:
-* ``a_i`` is a sparse vector specified in tuple form by `a_v, a_coef`
-* ``b_i`` is a scalar specified by `b`
-* ``\\mathcal{S}_i`` is a pre-defined *scalar* set specified as `S`
-
-Duplicate indices in the ``a_i`` are accepted and will be summed together.
-
-    addconstraint!(m::AbstractSolverInstance, vs::Vector{VariableReference}, S::AbstractSet)::VariablewiseConstraintReference{typeof(S)}
-
-Add the vector variable-wise constraint ``(x_j)_{j \\in v_i} \\in \\mathcal{S}_i``, where:
-* ``v_i`` is a list of variable indices specified as a vector of variable references `vs`
-* ``\\mathcal{S}_i`` is a pre-defined set specified as `S`
-
-Behavior is not defined for duplicate indices in the ``v_i``.
-
-    addconstraint!(m::AbstractSolverInstance, v::VariableReference, S::AbstractSet)::VariablewiseConstraintReference{typeof(S)}
-
-Add the scalar variable-wise constraint ``x_j \\in \\mathcal{S}_i``, where:
-* ``x_j`` is variable specified as a variable reference `v`
-* ``\\mathcal{S}_i`` is a pre-defined *scalar* set specified as `S`
 """
 function addconstraint! end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -100,5 +100,26 @@ struct VectorQuadraticFunction{T} <: AbstractFunction
     constant::Vector{T}
 end
 
+# Function modifications
+
+
+"""
+    AbstractFunctionModification
+
+An abstract supertype for structs which specify partial modifications
+to functions, to be used for making small modifications instead of
+replacing the functions entirely.
+"""
+abstract type AbstractFunctionModification end
+
+"""
+    ScalarConstantChange{T}(new_constant)
+
+A struct used to request a change in the constant term of a scalar-valued
+function. Applicable to `ScalarAffineFunction` and `ScalarQuadraticFunction`.
+"""
+struct ScalarConstantChange{T} <: AbstractFunctionModification
+    new_constant::T
+end
 
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,0 +1,104 @@
+
+
+"""
+    AbstractFunction
+
+Abstract supertype for function objects.
+"""
+abstract type AbstractFunction end
+
+"""
+    ScalarVariablewiseFunction(variable)
+
+The function that extracts the scalar variable referenced by `variable`, a `VariableReference`.
+This function would naturally be used for single variable bounds or integrality constraints.
+"""
+struct ScalarVariablewiseFunction <: AbstractFunction
+    variable::VariableReference
+end
+
+"""
+    VectorVariablewiseFunction(variables)
+
+The function that extracts the vector of variables referenced by `variables`, a `Vector{VariableReference}`.
+This function would naturally be used for constraints that apply to groups of variables, such
+as an "all different" constraint from constraint programming.
+"""
+struct VectorVariablewiseFunction <: AbstractFunction
+    variables::Vector{VariableReference}
+end
+
+"""
+    ScalarAffineFunction{T}(variables, coefficients, constant)
+    
+The scalar-valued affine function ``a^T x + b``, where:
+* ``a`` is a sparse vector specified in tuple form by `variables::Vector{VariableReference}` and `coefficients::Vector{T}`
+* ``b`` is a scalar specified by `constant::T`
+
+Duplicate variable references in `variables` are accepted, and the corresponding coefficients are summed together.
+"""
+struct ScalarAffineFunction{T} <: AbstractFunction
+    varables::Vector{VariableReference}
+    coefficients::Vector{T}
+    constant::T
+end
+
+"""
+    VectorAffineFunction{T}(outputindex, variables, coefficients, constant)
+
+The vector-valued affine function ``A x + b``, where:
+* ``A`` is a sparse matrix specified in triplet form by `outputindex, variables, coefficients`
+* ``b`` is a vector specified by `constant`
+
+Duplicate indices in the ``A`` are accepted, and the corresponding coefficients are summed together.
+"""
+struct VectorAffineFunction{T} <: AbstractFunction
+    outputindex::Vector{Int}
+    variables::Vector{VariableReference}
+    coefficients::Vector{T}
+    constant::Vector{T}
+end
+
+"""
+    ScalarQuadraticFunction{T}(affine_variables, affine_coefficients, quadratic_rowvariables, quadratic_colvariables, quadratic_coefficients, constant)
+
+The scalar-valued quadratic function ``\\frac{1}{2}x^TQx + a^T x + b``, where:
+* ``a`` is a sparse vector specified in tuple form by `affine_variables, affine_coefficients`
+* ``b`` is a scalar specified by `constant`
+* ``Q`` is a symmetric matrix is specified in triplet form by `quadratic_rowvariables, quadratic_colvariables, quadratic_coefficients`
+
+Duplicate indices in ``a`` or ``Q`` are accepted, and the corresponding coefficients are summed together. "Mirrored" indices `(r,q)` and `(r,q)` (where `r` and `q` are `VariableReferences`) are considered duplicates; only one need be specified.
+"""
+struct ScalarQuadraticFunction{T} <: AbstractFunction
+    affine_variables::Vector{VariableReference}
+    affine_coefficients::Vector{T}
+    quadratic_rowvariables::Vector{VariableReference}
+    quadratic_colvariables::Vector{VariableReference}
+    quadratic_coefficients::Vector{T}
+    constant::T
+end
+
+
+"""
+    VectorQuadraticFunction{T}(affine_variables, affine_coefficients, quadratic_rowvariables, quadratic_colvariables, quadratic_coefficients, constant)
+
+The vector-valued quadratic function with i`th` component ("output index") defined as ``\\frac{1}{2}x^TQ_ix + a_i^T x + b_i``, where:
+* ``a_i`` is a sparse vector specified in tuple form by the subset of `affine_variables, affine_coefficients` for the indices `k` where `affine_outputindex[k] == i`.
+* ``b_i`` is a scalar specified by `constant[i]`
+* ``Q_i`` is a symmetric matrix is specified in triplet form by the subset of `quadratic_rowvariables, quadratic_colvariables, quadratic_coefficients` for the indices `k` where `quadratic_outputindex[k] == i`
+
+Duplicate indices in ``a_i`` or ``Q_i`` are accepted, and the corresponding coefficients are summed together. "Mirrored" indices `(q,r)` and `(r,q)` (where `r` and `q` are `VariableReferences`) are considered duplicates; only one need be specified.
+"""
+struct VectorQuadraticFunction{T} <: AbstractFunction
+    affine_outputindex::Vector{Int}
+    affine_variables::Vector{VariableReference}
+    affine_coefficients::Vector{T}
+    quadratic_outputindex::Vector{Int}
+    quadratic_rowvariables::Vector{VariableReference}
+    quadratic_colvariables::Vector{VariableReference}
+    quadratic_coefficients::Vector{T}
+    constant::Vector{T}
+end
+
+
+

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -22,7 +22,7 @@ end
 
 The function that extracts the vector of variables referenced by `variables`, a `Vector{VariableReference}`.
 This function would naturally be used for constraints that apply to groups of variables, such
-as an "all different" constraint from constraint programming.
+as an "all different" constraint, an indicator constraint, or a complementarity constraint.
 """
 struct VectorVariablewiseFunction <: AbstractFunction
     variables::Vector{VariableReference}

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -1,25 +1,9 @@
 # Objectives
 
 """
-    setobjective!(m::AbstractSolverInstance, b, a_varref::Vector{VariableReference}, a_coef, Q_vari::Vector{VariableReference}, Q_varj::Vector{VariableReference}, Q_coef, N::Int=1)
+    setobjective!(m::AbstractSolverInstance, func::F, N::Int=1)
 
-Set the `N`th objective in the solver instance `m` to be ``\\frac{1}{2} x^T Q_0 x + a_0^T x + b_0``, where:
-* ``a_0`` is a sparse vector specified in tuple form by `a_varref, a_coef`
-* ``b_0`` is a scalar
-* the symmetric matrix ``Q_0`` is defined by the triplets in `Q_vari, Q_varj, Q_coef`
-
-Duplicate indices (sparse) in either the ``a_0`` vector or the ``Q_0`` matrix are accepted and will be summed together.
-Off-diagonal entries of ``Q_0`` will be mirrored, so either the upper triangular or lower triangular entries of ``Q_0`` should be provided.
-If entries for both ``(i,j)`` and ``(j,i)`` are provided, these are considered duplicate terms.
-`a_varref`, `Q_vari`, `Q_varj` should be collections of `VariableReference` objects.
-
-    setobjective!(m::AbstractSolverInstance, b, a_varref::Vector{VariableReference}, a_coef, N::Int=1)
-
-Set the `N`th objective in the solver instance `m` to be ``a_0^T x + b_0``, where:
-* ``a_0`` is a sparse vector specified in tuple form by `a_varref, a_coef`
-* ``b_0`` is a scalar
-
-Duplicate indices (sparse) in either the ``a_0`` vector or the ``Q_0`` matrix are accepted and will be summed together.
+Set the `N`th objective in the solver instance `m` to be ``f(x)`` where ``f`` is a function specified by ``func``.
 """
 function setobjective! end
 

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -1,83 +1,22 @@
 # Objectives
 
 """
-    setobjective!(m::AbstractSolverInstance, func::F, N::Int=1)
+    setobjective!(m::AbstractSolverInstance, func::F)
 
-Set the `N`th objective in the solver instance `m` to be ``f(x)`` where ``f`` is a function specified by ``func``.
+Set the objective function in the solver instance `m` to be ``f(x)`` where ``f`` is a function specified by `func`.
 """
 function setobjective! end
 
 """
-    getobjectiveconstant(m, N::Int=1)
+    modifyobjective!(m::AbstractSolverInstance, change::AbstractFunctionModification)
 
-Return the constant term in the `N`th objective.
-"""
-function getobjectiveconstant end
-
-"""
-    getobjectiveaffine(m, N::Int=1)
-
-Return the affine part of the `N`th objective in tuple form `(varref, coef)` where `varref` is a `VariableReference` and `coef` is a coefficient.
-Output is a tuple of two vectors.
-
-    getobjectiveaffine(m, v::VariableReference, N::Int=1)
-
-Return the coefficient for the variable `v` in the affine part of the `N`th objective.
-"""
-function getobjectiveaffine end
-
-## TODO: getobjectivequadratic
-
-"""
-    modifyobjective!(m::AbstractSolverInstance, N::Int, args...)
-
-Modify elements of the `N`th objective depending on the arguments `args`.
-The `N`th objective has the form ``\\frac{1}{2} x^T Q_0 x + a_0^T x + b_0``.
-
-There are three cases, below.
-
-## Modify Constant term
-
-    modifyobjective!(m::AbstractSolverInstance, N::Int, b)
-
-Set the constant term ``b_0`` of the `N`th objective to `b`.
+Apply the modification specified by `change` to the objective function of `m`.
+To change the function completely, call `setobjective!` instead.
 
 ### Examples
 
 ```julia
-modifyobjective!(m, 1, 1.0)
-```
-
-## Modify Linear term
-
-    modifyobjective!(m::AbstractSolverInstance, N::Int, a_varidx, a_coef)
-
-Set elements given by `a_varidx` in the linear term of the `N`th objective to `a_coef`.
-Either `a_varidx` and `a_coef` are both singletons, or they should be collections with equal length.
-The behavior of duplicate entries in `a_varidx` is undefined.
-
-### Examples
-
-```julia
-modifyobjective!(m, 1, v, 1.0)
-modifyobjective!(m, 1, [v1, v2], [1.0, 2.0])
-```
-
-## Modify Quadratic term
-
-    modifyobjective!(m::AbstractSolverInstance, N::Int, Q_vari, Q_varj, Q_coef)
-
-Set the elements in the quadratic term of the `N`th objective specified by the triplets `Q_vari, Q_varj, Q_coef`.
-Off-diagonal entries will be mirrored.
-`Q_vari, Q_varj` should be collections of `VariableReference` objects.
-The behavior of duplicate entries is undefined.
-If entries for both ``(i,j)`` and ``(j,i)`` are provided, these are considered duplicate terms.
-
-### Examples
-
-```julia
-modifyobjective!(m, 1, v1, v2, 1.0)
-modifyobjective!(m, 1, [v1, v2], [v1, v1], [1.0, 2.0])
+modifyobjective!(m, ScalarConstantChange(10.0))
 ```
 """
 function modifyobjective! end

--- a/src/references.jl
+++ b/src/references.jl
@@ -11,32 +11,6 @@ struct ConstraintReference{F,S}
 end
 
 """
-    candelete(m::AbstractSolverInstance, ref::ConstraintReference)::Bool
-
-Return a `Bool` indicating whether this constraint can be removed from the solver instance `m`.
-"""
-candelete(m::AbstractSolverInstance, ref::ConstraintReference) = throw(MethodError())
-
-"""
-    isvalid(m::AbstractSolverInstance, ref::ConstraintReference)::Bool
-
-Return a `Bool` indicating whether this reference is valid for an active constraint in the solver instance `m`.
-"""
-isvalid(m::AbstractSolverInstance, ref::ConstraintReference) = throw(MethodError())
-
-"""
-    delete!(m::AbstractSolverInstance, ref::ConstraintReference)
-
-Delete the referenced constraint from the solver instance.
-
-    delete!(m::AbstractSolverInstance, refs::Vector{ConstraintReference})
-
-Delete the referenced constraints in the vector `refs` from the solver instance.
-"""
-Base.delete!(m::AbstractSolverInstance, ref::ConstraintReference) = throw(MethodError())
-Base.delete!(m::AbstractSolverInstance, refs::Vector{ConstraintReference}) = throw(MethodError())
-
-"""
     VariableReference
 
 A lightweight object used to reference variables in a solver instance.
@@ -45,28 +19,31 @@ struct VariableReference
     value::UInt64
 end
 
-"""
-    candelete(m::AbstractSolverInstance, ref::VariableReference)::Bool
-
-Return a `Bool` indicating whether this variable can be removed from the solver instance `m`.
-"""
-candelete(m::AbstractSolverInstance, ref::VariableReference) = throw(MethodError())
+const AnyReference = Union{ConstraintReference,VariableReference}
 
 """
-    isvalid(m::AbstractSolverInstance, ref::VariableReference)::Bool
+    candelete(m::AbstractSolverInstance, ref::AnyReference)::Bool
 
-Return a `Bool` indicating whether this reference is valid for an active variable in the solver instance `m`.
+Return a `Bool` indicating whether the object referred to by `ref` can be removed from the solver instance `m`.
 """
-isvalid(m::AbstractSolverInstance, ref::VariableReference) = throw(MethodError())
+candelete(m::AbstractSolverInstance, ref::AnyReference) = throw(MethodError())
 
 """
-    delete!(m::AbstractSolverInstance, ref::VariableReference)
+    isvalid(m::AbstractSolverInstance, ref::AnyReference)::Bool
 
-Delete the referenced variable from the solver instance.
-
-    delete!(m::AbstractSolverInstance, refs::Vector{VariableReference})
-
-Delete the referenced variables in the vector `refs` from the solver instance.
+Return a `Bool` indicating whether this reference refers to a valid object in the solver instance `m`.
 """
-Base.delete!(m::AbstractSolverInstance, ref::VariableReference) = throw(MethodError())
-Base.delete!(m::AbstractSolverInstance, refs::Vector{VariableReference}) = throw(MethodError())
+isvalid(m::AbstractSolverInstance, ref::AnyReference) = throw(MethodError())
+
+"""
+    delete!(m::AbstractSolverInstance, ref::AnyReference)
+
+Delete the referenced object from the solver instance.
+
+    delete!(m::AbstractSolverInstance, refs::Vector{<:AnyReference})
+
+Delete the referenced objects in the vector `refs` from the solver instance.
+It may be assumed that `R` is a concrete type.
+"""
+Base.delete!(m::AbstractSolverInstance, ref::AnyReference) = throw(MethodError())
+Base.delete!(m::AbstractSolverInstance, refs::Vector{<:AnyReference}) = throw(MethodError())

--- a/src/references.jl
+++ b/src/references.jl
@@ -1,36 +1,14 @@
 # References
 
 """
-    VariablewiseConstraintReference{T}
+    ConstraintReference{F,S}
 
-A lightweight object used to reference variablewise constraints in a solver instance.
-The parameter `T` is the type of set constraint referenced.
+A lightweight object used to reference `F`-in-`S` constraints in a solver instance.
+The parameter `F` is the type of the function in the constraint, and the parameter `S` is the type of set in the constraint.
 """
-struct VariablewiseConstraintReference{T}
+struct ConstraintReference{F,S}
     value::UInt64
 end
-
-"""
-    AffineConstraintReference{T}
-
-A lightweight object used to reference affine-in-set constraints in a solver instance.
-The parameter `T` is the type of set constraint referenced.
-"""
-struct AffineConstraintReference{T}
-    value::UInt64
-end
-
-"""
-    QuadraticConstraintReference{T}
-
-A lightweight object used to reference quadratic-in-set constraints in a solver instance.
-The parameter `T` is the type of set constraint referenced.
-"""
-struct QuadraticConstraintReference{T}
-    value::UInt64
-end
-
-const ConstraintReference = Union{VariablewiseConstraintReference, AffineConstraintReference, QuadraticConstraintReference}
 
 """
     candelete(m::AbstractSolverInstance, ref::ConstraintReference)::Bool


### PR DESCRIPTION
@blegat's comment [here](https://github.com/JuliaOpt/MathOptInterface.jl/issues/9#issuecomment-312516818) exposes the fact that we currently have 6 types of functions with different representations, between the combinations of variablewise, affine, quadratic, and scalar-valued, and vector-valued. Instead of enumerating all of these combinations in ``addconstraint!``, I think it makes sense to encode these with function objects. 

With this, the signatures of ``addconstraint!`` and ``setobjective!`` become:
```julia
addconstraint!(m::AbstractSolverInstance, func::F, set::S)::ConstraintReference{F,S}
setobjective!(m::AbstractSolverInstance, func::F, N::Int=1)
```
where `func` is a simple `struct` with the corresponding data.

``func`` could be, e.g.:
```julia
"""
    ScalarVariablewiseFunction(variable)

The function that extracts the scalar variable referenced by `variable`, a `VariableReference`.
This function would naturally be used for single variable bounds or integrality constraints.
"""
struct ScalarVariablewiseFunction <: AbstractFunction
    variable::VariableReference
end

"""
    VectorQuadraticFunction{T}(affine_variables, affine_coefficients, quadratic_rowvariables, quadratic_colvariables, quadratic_coefficients, constant)

The vector-valued quadratic function with i`th` component ("output index") defined as ``\\frac{1}{2}x^TQ_ix + a_i^T x + b_i``, where:
* ``a_i`` is a sparse vector specified in tuple form by the subset of `affine_variables, affine_coefficients` for the indices `k` where `affine_outputindex[k] == i`.
* ``b_i`` is a scalar specified by `constant[i]`
* ``Q_i`` is a symmetric matrix is specified in triplet form by the subset of `quadratic_rowvariables, quadratic_colvariables, quadratic_coefficients` for the indices `k` where `quadratic_outputindex[k] == i`

Duplicate indices in ``a_i`` or ``Q_i`` are accepted, and the corresponding coefficients are summed together. "Mirrored" indices `(q,r)` and `(r,q)` (where `r` and `q` are `VariableReferences`) are considered duplicates; only one need be specified.
"""
struct VectorQuadraticFunction{T} <: AbstractFunction
    affine_outputindex::Vector{Int}
    affine_variables::Vector{VariableReference}
    affine_coefficients::Vector{T}
    quadratic_outputindex::Vector{Int}
    quadratic_rowvariables::Vector{VariableReference}
    quadratic_colvariables::Vector{VariableReference}
    quadratic_coefficients::Vector{T}
    constant::Vector{T}
end
```

It's still a TODO to rethink the modification and query routines under this function concept, but I believe we'll be able to unify querying and modification across constraints and objectives.

I think this change is already justified as a simplification of the current interface as it is, but in addition to that it also makes everything more extensible for other kinds of functions as requested by @chriscoey.

@joehuchette @ccoffrin @odow @joaquimg 