### PR TITLE
more work on the manual

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -179,15 +179,18 @@ If `x` is a `VariableRefrence` then the function call returns a scalar, and if `
 
 See also the attributes [`ConstraintPrimal`](@ref MathOptInterface.ConstraintPrimal), and [`ConstraintDual`](@ref MathOptInterface.ConstraintDual).
 
-## A complete example: `mixintopt`
+## A complete example: `solveknapsack`
+
+## A more complex example: `solveintegerlinear`
+
 
 [this needs formatting help]
 
 ```julia
 """
-    MixintoptSolution
+    IntegerLinearResult
 
-A `struct` returned by `mixintopt` containing solution information.
+A `struct` returned by `solverintegerlinear` containing solution information.
 The fields are as follows:
 
   - `termination_status`: the `TerminationStatusCode` returned by the solver
@@ -196,7 +199,7 @@ The fields are as follows:
   - `objective_value`: the objective value of the result vector as reported by the solver
   - `objective_bound`: the best known bound on the optimal objective value
 """
-struct MixtintoptSolution
+struct IntegerLinearResult
     termination_status::TerminationStatusCode
     result_status::ResultStatusCode
     primal_variable_result::Vector{Float64}
@@ -205,11 +208,11 @@ struct MixtintoptSolution
 end
 
 """
-    mixintopt(c, Ale, ble, Aeq, beq, lb, ub, integerindices, solver)
+    solveintegerlinear(c, Ale, ble, Aeq, beq, lb, ub, integerindices, solver)
 
-Solve the optimization problem: min c'x s.t. `Ale*x` <= `ble`, `Aeq*x` = `beq`, `lb` <= `x` <= `ub`, and`x[i]` is integer for `i` in `integerindices` using the solver specified by `solver`. Returns a `MixintprogSolution`.
+Solve the mixed-integer linear optimization problem: min c'x s.t. `Ale*x` <= `ble`, `Aeq*x` = `beq`, `lb` <= `x` <= `ub`, and`x[i]` is integer for `i` in `integerindices` using the solver specified by `solver`. Returns a `MixintprogSolution`.
 """
-function mixintopt(c, Ale::SparseMatrixCSC, ble, Aeq::SparseMatrixCSC, beq, lb, ub, integerindices, solver)
+function solverintegerlinear(c, Ale::SparseMatrixCSC, ble, Aeq::SparseMatrixCSC, beq, lb, ub, integerindices, solver)
     if !supportsproblem(solver, ScalarAffineFunction,
             [(ScalarAffineFunction,LessThan),
              (ScalarAffineFunction,Zero),
@@ -281,14 +284,14 @@ function mixintopt(c, Ale::SparseMatrixCSC, ble, Aeq::SparseMatrixCSC, beq, lb, 
 
      termination_status = getattribute(m, TerminationStatus())
      objbound = cangetattribute(m, ObjectiveBound()) ? getattribute(m, ObjectiveBound()) : NaN
-     objvalue = cangtattribute(m, ObjectiveValue()) ? getattribute(m, ObjectiveValue()) : NaN
+     objvalue = cangetattribute(m, ObjectiveValue()) ? getattribute(m, ObjectiveValue()) : NaN
 
      if getattribute(m, ResultCount()) > 0
         result_status = getattribute(m, PrimalStatus())
         primal_variable_result = getattribute(m, VariableResult(), x)
-        return MixintoptSolution(termination_status, result_status, primal_variable_result, objvalue, objbound)
+        return IntegerLinearResult(termination_status, result_status, primal_variable_result, objvalue, objbound)
      else
-        return MixintoptSolution(termination_status, UnknownResultStatus, Float64[], objvalue, objbound)
+        return IntegerLinearResult(termination_status, UnknownResultStatus, Float64[], objvalue, objbound)
      end
 end
 ```

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -91,7 +91,7 @@ If `v` is a `VariableReference` object, then `ScalarVariablewiseFunction(v)` is 
 A more interesting function is [`ScalarAffineFunction`](@ref MathOptInterface.ScalarAffineFunction), defined as
 ```julia
 struct ScalarAffineFunction{T} <: AbstractFunction
-    varables::Vector{VariableReference}
+    variables::Vector{VariableReference}
     coefficients::Vector{T}
     constant::T
 end
@@ -143,7 +143,45 @@ addconstraint!(m, ScalarVariablewiseFunction(x[2]), GreaterThan(-1.0))
 
 [Example with vector-valued set.]
 
-[Table of common constraints and which pair of function/set they correspond to. Linear constraints, bounds, nonnegativity, second-order cone, PSD, quadratic, bilinear matrix inequality, indicator, SOS, ...]
+### Table of constraints
+
+[This needs formatting help.]
+
+#### Linear
+- ``a^Tx \le u``: `ScalarAffineFunction`, `LessThan`
+- ``a^Tx \ge l``: `ScalarAffineFunction`, `GreaterThan`
+- ``a^Tx = b``: `ScalarAffineFunction`, `EqualTo`
+- ``l \le a^Tx \le u``: `ScalarAffineFunction`, `Interval`
+- ``x_i \le u``: `ScalarVariablewiseFunction`, `LessThan`
+- ``x_i \ge l``: `ScalarVariablewiseFunction`, `GreaterThan`
+- ``x_i = b``: `ScalarVariablewiseFunction`, `EqualTo`
+- ``l \le x_i \le u``: `ScalarVariablewiseFunction`, `Interval`
+- ``Ax + b \in \mathbb{R}_+^n``: `VectorAffineFunction`, `Nonnegative`
+- ``Ax + b \in \mathbb{R}_-^n``: `VectorAffineFunction`, `Nonpositive`
+- ``Ax + b = 0``: `VectorAffineFunction`, `Zero`
+
+[Define ``\mathbb{R}_+, \mathbb{R}_-``]
+
+#### Conic
+- ``||Ax + b|| \le c^Tx + b``: `VectorAffineFunction`, `SecondOrderCone`
+- ``(a_1^Tx + b_1,a_2^Tx + b_2,a_3^Tx + b_3) \in \mathcal{E}``: `VectorAffineFunction`, `ExponentialCone`
+- ``A(x) \in \mathbb{S}_+``: `VectorAffineFunction`, `PositiveSemidefiniteConeTriangle` or `PositiveSemidefiniteConeScaled`
+
+[Define ``\mathcal{E}`` (exponential cone), ``\mathbb{S}_+``. ``A(x)`` is an affine function of ``x`` that outputs a matrix.]
+
+#### Quadratic
+- ``x^TQx + a^Tx + b \ge 0``: `ScalarQuadraticFunction`, `GreaterThan`
+- ``x^TQx + a^Tx + b \le 0``: `ScalarQuadraticFunction`, `LessThan`
+- ``x^TQx + a^Tx + b = 0``: `ScalarQuadraticFunction`, `EqualTo`
+- Bilinear matrix inequality: `VectorQuadraticFunction`, `PositiveSemidefiniteConeTriangle` or `PositiveSemidefiniteConeScaled`
+
+#### Discrete/logical
+- ``x_i \in \mathbb{Z}``: `ScalarVariablewiseFunction`, `Integers`
+- ``x_i \in \{0,1\}``: `ScalarVariablewiseFunction`, `Binaries`
+- ``x_i \in \{0\} \cup [l,u]``: `ScalarVariablewiseFunction`, `Semicontinous`
+- ``x_i \in \{0\} \cup \{l,l+1,\ldots,u-1,u\}``: `ScalarVariablewiseFunction`, `SemiInteger`
+- At most one component of ``x`` can be nonzero: `VectorVariablewiseFunction`, `SOS1`
+- At most two components of ``x`` can be nonzero, and if two are nonzero they must be adjacent components: `VectorVariablewiseFuncion`, `SOS2`
 
 ## Solving and retrieving the results
 
@@ -269,7 +307,7 @@ end
 """
     solveintegerlinear(c, Ale, ble, Aeq, beq, lb, ub, integerindices, solver)
 
-Solve the mixed-integer linear optimization problem: min c'x s.t. `Ale*x` <= `ble`, `Aeq*x` = `beq`, `lb` <= `x` <= `ub`, and`x[i]` is integer for `i` in `integerindices` using the solver specified by `solver`. Returns a `MixintprogSolution`.
+Solve the mixed-integer linear optimization problem: min c'x s.t. `Ale*x` <= `ble`, `Aeq*x` = `beq`, `lb` <= `x` <= `ub`, and`x[i]` is integer for `i` in `integerindices` using the solver specified by `solver`. Returns an `IntegerLinearResult`.
 """
 function solverintegerlinear(c, Ale::SparseMatrixCSC, ble, Aeq::SparseMatrixCSC, beq, lb, ub, integerindices, solver)
     if !supportsproblem(solver, ScalarAffineFunction,

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -273,10 +273,7 @@ function solverintegerlinear(c, Ale::SparseMatrixCSC, ble, Aeq::SparseMatrixCSC,
      # add equality constraints
      Aeq_affine = csc_to_affine(Aeq)
      for k in 1:length(Aeq_affine)
-        affine = Aeq_affine[k]
-        # subtract constant so that we can impose "== 0" constraint
-        affine = ScalarAffineFunction(Aeq_affine[k].variables, Aeq_affine[k].coefficients, -beq[k])
-        addconstraint!(m, affine, Zeros(1))
+        addconstraint!(m, Aeq_affine[k], EqualTo(beq[k]))
      end
 
      # all set

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -110,16 +110,188 @@ See [Functions and function modifications](@ref) for the complete list of functi
 
 ## Sets
 
-[Examples of sets and how to use them. How to add constraints.]
+All constraints are specified with [`addconstraint!`](@ref MathOptInterface.addconstraint!)
+by restricting the output of some function to a set.
+The interface allows an arbitrary combination of functions at sets, but of course
+solvers may decide to support only a small number of combinations (see [`supportsproblem`](@ref MathOptInterface.supportsproblem)).
+
+For example, linear programming solvers should support, at least, combinations of affine functions with
+the [`LessThan`](@ref MathOptInterface.LessThan) and [`GreaterThan`](@ref MathOptInterface.GreaterThan)
+sets. These are simply linear constraints.
+Scalar variablewise functions combined with these same sets are used to specify upper and lower bounds on variables.
+
+The code example below encodes the linear optimization problem:
+```math
+\begin{align}
+& \max_{x \in \mathbb{R}^2} & 3x_1 + 2x_2 &
+\\
+& \;\;\text{s.t.} & x_1 + x_2 &\le 5
+\\
+&& x_1 & \ge 0
+\\
+&&x_2 & \ge -1
+\end{align}
+```
+
+```julia
+x = addvariables!(m, 2)
+setobjective!(m, MaxSense, ScalarAffineFunction(x, [3.0,2.0], 0.0))
+addconstraint!(m, ScalarAffineFunction(x, [1.0,1.0], 0.0), LessThan(5.0))
+addconstraint!(m, ScalarVariablewiseFunction(x[1]), GreaterThan(0.0))
+addconstraint!(m, ScalarVariablewiseFunction(x[2]), GreaterThan(-1.0))
+```
+
+[Example with vector-valued set.]
+
+[Table of common constraints and which pair of function/set they correspond to. Linear constraints, bounds, nonnegativity, second-order cone, PSD, quadratic, bilinear matrix inequality, indicator, SOS, ...]
 
 ## Solving and retrieving the results
 
-[Example of calling `optimize!` and getting the status and results back.]
+Once a solver instance is loaded with the objective function and all of the constraints, we can ask the solver to solve the instance by calling [`optimize!`](@ref MathOptInterface.optimize!).
+```julia
+optimize!(m)
+```
+
+The optimization procedure may terminate for a number of reasons. The [`TerminationStatus`](@ref MathOptInterface.TerminationStatus) attribute of the solver instance returns a [`TerminationStatusCode`](@ref MathOptInterface.TerminationStatusCode) object which explains why the solver stopped. Some statuses indicate generally successful termination, some termination because of limit, and some termination because of something unexpected like invalid problem data or failure to converge. A typical usage of the `TerminationStatus` attribute is as follows:
+```julia
+status = getattribute(m, TerminationStatus())
+if status == Success
+    # Ok, the solver has a result to return
+else
+    # Handle other cases
+    # The solver may or may not have a result
+end
+```
+
+The `Success` status code specifically implies that the solver has a "result" to return. In the case that the solver converged to an optimal solution, this result will just be the optimal solution vector. The [`PrimalStatus`](@ref MathOptInterface.PrimalStatus) attribute returns a [`ResultStatusCode`](@ref MathOptInterface.ResultStatusCode) that explains how to interpret the result. In the case that the solver is known to return globally optimal solutions (up to numerical tolerances), the combination of `Success` termination status and `FeasiblePoint` primal result status implies that the primal result vector should be interpreted as a globally optimal solution. A result may be available even if the status is not `Success`, for example, if the solver stopped because of a time limit and has a feasible but nonoptimal solution. Use the [`ResultCount`](@ref MathOptInterface.ResultCount) attribute to check if one or more results are available.
+
+In addition to the primal status, the [`DualStatus`](@ref MathOptInterface.DualStatus) provides important information for primal-dual solvers. The following table lists common situations and the corresponding termination and result statuses.
+
+[Table of common situations and termination/primal/dual status]
+
+See [Duals](@ref) for a discussion of the MOI conventions for primal-dual pairs and certificates.
+
+Finally, to retrieve the values of each variable in the result, use the [`VariablePrimal`](@ref MathOptInterface.VariablePrimal) attribute:
+```julia
+getattribute(m, VariablePrimal(), x)
+```
+If `x` is a `VariableRefrence` then the function call returns a scalar, and if `x` is a `Vector{VariableReference}` then the call returns a vector of scalars. `VariablePrimal()` is equivalent to `VariablePrimal(1)`, i.e., the variable primal vector of the first result. Use `VariablePrimal(N)` to access the `N`th result.
+
+See also the attributes [`ConstraintPrimal`](@ref MathOptInterface.ConstraintPrimal), and [`ConstraintDual`](@ref MathOptInterface.ConstraintDual).
+
+## A complete example: `mixintopt`
+
+[this needs formatting help]
+
+```julia
+"""
+    MixintoptSolution
+
+A `struct` returned by `mixintopt` containing solution information.
+The fields are as follows:
+
+  - `termination_status`: the `TerminationStatusCode` returned by the solver
+  - `result_status`: the `ResultStatusCode` returned by the solver (if any results are available)
+  - `primal_variable_result`: the primal result vector returned by the solver; if no result is returned then this vector has length zero
+  - `objective_value`: the objective value of the result vector as reported by the solver
+  - `objective_bound`: the best known bound on the optimal objective value
+"""
+struct MixtintoptSolution
+    termination_status::TerminationStatusCode
+    result_status::ResultStatusCode
+    primal_variable_result::Vector{Float64}
+    objective_value::Float64
+    objective_bound::Float64
+end
+
+"""
+    mixintopt(c, Ale, ble, Aeq, beq, lb, ub, integerindices, solver)
+
+Solve the optimization problem: min c'x s.t. `Ale*x` <= `ble`, `Aeq*x` = `beq`, `lb` <= `x` <= `ub`, and`x[i]` is integer for `i` in `integerindices` using the solver specified by `solver`. Returns a `MixintprogSolution`.
+"""
+function mixintopt(c, Ale::SparseMatrixCSC, ble, Aeq::SparseMatrixCSC, beq, lb, ub, integerindices, solver)
+    if !supportsproblem(solver, ScalarAffineFunction,
+            [(ScalarAffineFunction,LessThan),
+             (ScalarAffineFunction,Zero),
+             (ScalarVariablewiseFunction,LessThan),
+             (ScalarVariablewiseFunction,GreaterThan),
+             (ScalarVariablewiseFunction,Integers)])
+        error("Provided solver does not support mixed-integer linear optimization")
+    end
+    numvar = size(Ale,2)
+    @assert numvar == size(Aeq,2) == length(lb) == length(ub)
 
 
-## A complete example: `mixintprog`
+    m = SolverInstance(solver)
 
-[Showcase of how to go from data to MOI instance to `optimize!` to results, by implementing the `mixintprog` function]
+    # create the variables in the problem
+    x = addvariables!(m, numvar)
+
+    # set the objective function
+    setobjective!(m, MinSense, ScalarAffineFunction(x, c, 0.0))
+
+    # add variable bound constraints
+    for i in 1:numvar
+        if isfinite(lb[i])
+            addconstraint!(m, ScalarVariablewiseFunction(x[i]), GreaterThan(lb[i]))
+        end
+        if isfinite(ub[i])
+            addconstraint!(m, ScalarVariablewiseFunction(x[i]), LessThan(ub[i]))
+        end
+    end
+
+    # add integrality constraints
+    for i in integerindices
+        @assert 1 <= i <= numvar
+        addconstraint!(m, ScalarVariablewiseFunction(x[i]), Integers())
+    end
+
+    # convert a SparseMatrixCSC into a vector of scalar affine functions
+    # meant to be illustrative, not the fastest possible
+    function csc_to_affine(A::SparseMatrixCSC)
+        nrow = size(A,1)
+        variables_by_row = [Vector{VariableReference}(0) for k in 1:nrow]
+        coefficients_by_row = [Vector{Float64}(0) for k in 1:nrow]
+
+        I,J,V = findnz(A) # convert the sparse matrix to triplet form
+        for p in 1:length(I)
+            push!(variables_by_row[I[p]], x[J[p]])
+            push!(coefficients_by_row[I[p]], V[p])
+        end
+        return [ScalarAffineFunction(variables_by_row[k], coefficients_by_row[k], 0.0) for k in 1:nrow]
+     end
+
+     # add inequality constraints
+     Ale_affine = csc_to_affine(Ale)
+     for k in 1:length(Ale_affine)
+        addconstraint!(m, Ale_affine[k], LessThan(ble[k]))
+     end
+
+     # add equality constraints
+     Aeq_affine = csc_to_affine(Aeq)
+     for k in 1:length(Aeq_affine)
+        affine = Aeq_affine[k]
+        # subtract constant so that we can impose "== 0" constraint
+        affine = ScalarAffineFunction(Aeq_affine[k].variables, Aeq_affine[k].coefficients, -beq[k])
+        addconstraint!(m, affine, Zeros(1))
+     end
+
+     # all set
+     optimize!(m)
+
+     termination_status = getattribute(m, TerminationStatus())
+     objbound = cangetattribute(m, ObjectiveBound()) ? getattribute(m, ObjectiveBound()) : NaN
+     objvalue = cangtattribute(m, ObjectiveValue()) ? getattribute(m, ObjectiveValue()) : NaN
+
+     if getattribute(m, ResultCount()) > 0
+        result_status = getattribute(m, PrimalStatus())
+        primal_variable_result = getattribute(m, VariableResult(), x)
+        return MixintoptSolution(termination_status, result_status, primal_variable_result, objvalue, objbound)
+     else
+        return MixintoptSolution(termination_status, UnknownResultStatus, Float64[], objvalue, objbound)
+     end
+end
+```
 
 ## Advanced
 
@@ -165,4 +337,8 @@ Note:
 
 ### Implementing a solver interface
 
-[Discussion for potential authors of solver interfaces]
+[The interface is designed for multiple dispatch, e.g., attributes, combinations of sets and functions.]
+
+[Avoid storing extra copies of the problem when possible.]
+
+[It would be nice if solvers supported the multiple different ways to write the same constraint, e.g., `GreaterThan` and `Nonnegative`, second-order cone and rotated second-order cone.]

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -199,6 +199,8 @@ PositiveSemidefiniteConeTriangle
 PositiveSemidefiniteConeScaled
 Integers
 ZeroOne
+Semicontinuous
+SemiInteger
 SOS1
 SOS2
 ```

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -184,8 +184,8 @@ List of recognized sets.
 AbstractSet
 Reals
 Zeros
-NonNegatives
-NonPositives
+Nonnegatives
+Nonpositives
 GreaterThan
 LessThan
 Interval

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -188,6 +188,7 @@ Nonnegatives
 Nonpositives
 GreaterThan
 LessThan
+EqualTo
 Interval
 SecondOrderCone
 ExponentialCone

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -442,7 +442,6 @@ This attribute is meant to explain the reason why the solver stopped executing.
 These are generally OK statuses.
 
 * `Success`: the algorithm ran successfully and has a result; this includes cases where the algorithm converges to an infeasible point (NLP) or converges to a solution of a homogeneous self-dual problem and has a certificate of primal/dual infeasibility
-* `AlmostSuccess`: the algorithm *almost* ran successfully (e.g., to relaxed convergence tolerances) and has a result
 * `InfeasibleNoResult`: the algorithm stopped because it decided that the problem is infeasible but does not have a result to return
 * `UnboundedNoResult`: the algorithm stopped because it decided that the problem is unbounded but does not have a result to return
 * `InfeasibleOrUnbounded`: the algorithm stopped because it decided that the problem is infeasible or unbounded (no result is available); this occasionally happens during MIP presolve
@@ -459,7 +458,7 @@ This group of statuses means that something unexpected or problematic happened.
 * `SlowProgress`: the algorithm stopped because it was unable to continue making progress towards the solution
 * `AlmostSuccess` should be used if there is additional information that relaxed convergence tolerances are satisfied
 
-To be documented: `NumericalError`, `InvalidSolverInstance`, `InvalidOption`, `Interrupted`, `OtherError`.
+To be documented: `NumericalError`, `InvalidInstance`, `InvalidOption`, `Interrupted`, `OtherError`.
 
 """
 @enum TerminationStatusCode Success AlmostSuccess InfeasibleNoResult UnboundedNoResult InfeasibleOrUnbounded IterationLimit TimeLimit NodeLimit SolutionLimit MemoryLimit ObjectiveLimit NormLimit OtherLimit SlowProgress NumericalError InvalidSolverInstance InvalidOption Interrupted OtherError
@@ -479,10 +478,10 @@ The values indicate how to interpret the result vector.
 * `NearlyInfeasibilityCertificate`
 * `ReductionCertificate`
 * `NearlyReductionCertificate`
-* `Unknown`
-* `Other`
+* `UnknownResultStatus`
+* `OtherResultStatus`
 """
-@enum ResultStatusCode FeasiblePoint NearlyFeasiblePoint InfeasiblePoint InfeasibilityCertificate NearlyInfeasibilityCertificate ReductionCertificate NearlyReductionCertificate Unknown Other
+@enum ResultStatusCode FeasiblePoint NearlyFeasiblePoint InfeasiblePoint InfeasibilityCertificate NearlyInfeasibilityCertificate ReductionCertificate NearlyReductionCertificate UnknownResultStatus OtherResultStatus
 
 """
     PrimalStatus(N)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -37,7 +37,7 @@ The scalar-valued affine function ``a^T x + b``, where:
 Duplicate variable references in `variables` are accepted, and the corresponding coefficients are summed together.
 """
 struct ScalarAffineFunction{T} <: AbstractFunction
-    varables::Vector{VariableReference}
+    variables::Vector{VariableReference}
     coefficients::Vector{T}
     constant::T
 end

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -69,6 +69,15 @@ struct LessThan{T <: Real} <: AbstractSet
 end
 
 """
+    EqualTo(value)
+
+The set containing the single point ``x \\in \\mathbb{R}`` where ``x`` is given by `value`.
+"""
+struct EqualTo{T <: Real} <: AbstractSet
+    value::T
+end
+
+"""
     Interval(lower,upper)
 
 The interval ``[lower, upper] \\subseteq \\mathbb{R}``.
@@ -79,7 +88,7 @@ struct Interval{T <: Real} <: AbstractSet
     upper::T
 end
 
-dimension(s::Union{Interval,GreaterThan,LessThan}) = 1
+dimension(s::Union{Interval,GreaterThan,LessThan,EqualTo}) = 1
 
 """
     SecondOrderCone(dim)

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -200,6 +200,26 @@ struct ZeroOne <: AbstractSet end
 dimension(s::Union{Integers,ZeroOne}) = 1
 
 """
+    Semicontinuous(l,u)
+
+The set ``\\{0\\} \\cup [l,u]``.
+"""
+struct Semicontinuous{T <: Real} <: AbstractSet
+    l::T
+    u::T
+end
+
+"""
+    SemiInteger(l,u)
+
+The set ``\\{0\\} \\cup \\{l,l+1,\\ldots,u-1,u\\}``.
+"""
+struct SemiInteger{T <: Real} <: AbstractSet
+    l::T
+    u::T
+end
+
+"""
     SOS1(weights)
 
 The set corresponding to the special ordered set (SOS) constraint of type 1.

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -33,20 +33,20 @@ struct Zeros <: AbstractSet
 end
 
 """
-    NonNegatives(dim)
+    Nonnegatives(dim)
 
 The nonnegative orthant ``\\{ x \\in \\mathbb{R}^{dim} : x \\ge 0 \\}`` of dimension `dim`.
 """
-struct NonNegatives <: AbstractSet
+struct Nonnegatives <: AbstractSet
     dim::Int
 end
 
 """
-    NonPositives(dim)
+    Nonpositives(dim)
 
 The nonpositive orthant ``\\{ x \\in \\mathbb{R}^{dim} : x \\le 0 \\}`` of dimension `dim`.
 """
-struct NonPositives <: AbstractSet
+struct Nonpositives <: AbstractSet
     dim::Int
 end
 


### PR DESCRIPTION
Worth looking at the ~`mixintopt`~ `solveintegerlinear` code example to see if we're happy with the final result. ~There's a small awkwardness in that we have the ``LessThan`` and ``GreatThan`` sets but no set representing equality with a constant, so for equality constraints we have to move the right-hand side into the constant of the affine expression.~ I added the ``EqualTo`` set for consistency.