### PR TITLE
fix comparisons of variablewise and affine functions

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -318,6 +318,7 @@ struct ListOfPresentConstraints <: AbstractSolverInstanceAttribute end
     ObjectiveFunction()
 
 An `AbstractFunction` instance which represents the objective function.
+It is guaranteed to be equivalent but not necessarily identical to the function provided by the user.
 """
 struct ObjectiveFunction <: AbstractSolverInstanceAttribute end
 ## Variable attributes
@@ -413,6 +414,7 @@ struct ConstraintBasisStatus <: AbstractConstraintAttribute end
     ConstraintFunction()
 
 Return the `AbstractFunction` object used to define the constraint.
+It is guaranteed to be equivalent but not necessarily identical to the function provided by the user.
 """
 struct ConstraintFunction <: AbstractConstraintAttribute end
 

--- a/test/function_utilities.jl
+++ b/test/function_utilities.jl
@@ -1,0 +1,34 @@
+# Utilities for comparing functions
+# Define isapprox so that we can use ≈ in tests
+
+import Base: ==
+function (==)(f1::MOI.VectorVariablewiseFunction, f2::MOI.VectorVariablewiseFunction)
+    function canonicalize(f)
+        s = Set{MOI.VariableReference}()
+        for v in f.variables
+            if v in s
+                error("Repeated variable references in variablewise function")
+            end
+            push!(s,v)
+        end
+        return s
+    end
+    return canonicalize(d1) == canonicalize(d2)
+end
+
+function Base.isapprox(f1::MOI.ScalarAffineFunction{T}, f2::MOI.ScalarAffineFunction{T}; rtol = sqrt(eps), atol = 0, nans = false) where {T}
+    function canonicalize(f)
+        d = Dict{MOI.VariableReference,T}()
+        @assert length(f.variables) == length(f.coefficients)
+        for k in 1:length(f.variables)
+            d[f.variables[k]] = f.coefficients[k] + get(d, f.variables[k], zero(T))
+        end
+        return (d,f.constant)
+    end
+    d1, c1 = canonicalize(f1)
+    d2, c2 = canonicalize(f2)
+    for (var,coef) in d2
+        d1[var] = get(d1,var,zero(T)) - coef
+    end
+    return isapprox([c2-c1;collect(values(d1))], zeros(T,length(d1)), rtol=rtol, atol=atol, nans=nans)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using MathOptInterface, Base.Test
 
 const MOI = MathOptInterface
 
+include("function_utilities.jl")
+
 include("contlinear.jl")
 @testset "Continuous linear problems" begin
     # contlineartest(GLPKSolverLP())


### PR DESCRIPTION
@joaquimg, what do you think of this? For comparisons we canonicalize using a dictionary, so no order is required. Quadratic would look very similar.