### PR TITLE
[RFC] Add dual for convex problem with quadratic

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -842,9 +842,9 @@ twice the value of the `coefficients` field in the `VectorAffineFunction` for
 the corresponding rows. See [`PositiveSemidefiniteConeTriangle`](@ref) for
 details.
 
-#### Dual for problem with quadratic functions
+#### Dual for problems with quadratic functions
 
-Given a program with quadratic functions:
+Given a problem with quadratic functions:
 ```math
 \begin{align*}
 & \min_{x \in \mathbb{R}^n} & \frac{1}{2}x^TQ_0x + a_0^T x + b_0
@@ -875,6 +875,9 @@ A pair of primal-dual variables $(x^\star, y^\star)$ is optimal if
   if ``\frac{1}{2}x^TQ_ix + a_i^T x + b_i`` is nonzero then ``\lambda_i = 0``,
   this is the classical complementary slackness condition.
 
+If ``\mathcal{C}_i`` is a vector set, the discussion remains valid with
+``y_i(\frac{1}{2}x^TQ_ix + a_i^T x + b_i)`` replaced with the scalar product
+between `y_i` and the vector of scalar-valued quadratic functions.
 
 ### Constraint bridges
 

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -831,9 +831,6 @@ and similarly, the dual is:
 
 An important note for the LP case is that the signs of the feasible duals depend only on the sense of the inequality and not on the objective sense.
 
-
-Currently, a convention for duals is not defined for problems with non-conic sets ``\mathcal{S}_i`` or quadratic functions ``f_0, f_i``.
-
 #### Duality and scalar product
 
 The scalar product is different from the canonical one for the sets
@@ -845,6 +842,20 @@ twice the value of the `coefficients` field in the `VectorAffineFunction` for
 the corresponding rows. See [`PositiveSemidefiniteConeTriangle`](@ref) for
 details.
 
+#### Dual for convex problem with quadratic functions
+
+If ``Q`` is positive semidefinite, then the constraint ``x^TQx + a^Tx + b \le 0`` can be rewritten as an equivalent SOS constraint ``\lVert Ax + b\rVert_2 \le c^Tx + d`` which has a dual variable ``(s, y)`` constrained to satisfy ``\lVert y \rVert_2 \leq s``.
+We define the constraint value as ``x^TQx + a^Tx + b`` and the constraint dual as ``\lVert y \rVert_2 - s``.
+Note that these scalar values are always nonpositive for feasible solutions and that complementary slackness holds, i.e. their product is always zero for an optimal primal-dual pair (indeed if two vectors in the second order cone are orthogonal then they are either both on the boundary or one of them is zero).
+
+Similarly, if ``Q`` is negative semidefinite, then the constraint ``x^TQx + a^Tx + b \ge 0`` can be rewritten as an equivalent SOS constraint ``\lVert Ax + b\rVert_2 \le c^Tx + d`` which has a dual variable ``(s, y)`` constrained to satisfy ``\lVert y \rVert_2 \leq s``.
+In this case, we define the constraint value as ``x^TQx + a^Tx + b`` and the constraint dual as ``s - \lVert y \rVert_2``.
+Note that these scalar values are always nonnegative for feasible solutions and that complementary slackness holds.
+
+If the objective is a minimization of a convex quadratic function or the maximization of a concave quadratic function then it can be transformed into a linear objective and a second order cone constraint.
+Therefore if the constraints are convex, their dual can be queried as usual.
+
+However, currently, a convention for duals is not defined for problems with non-conic sets ``\mathcal{S}_i`` or quadratic functions ``f_0, f_i`` that do not enter into one of the cases discussed in this question.
 
 ### Constraint bridges
 

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -842,7 +842,7 @@ twice the value of the `coefficients` field in the `VectorAffineFunction` for
 the corresponding rows. See [`PositiveSemidefiniteConeTriangle`](@ref) for
 details.
 
-#### Dual for convex problem with quadratic functions
+#### Dual for problem with quadratic functions
 
 Given a program with quadratic functions:
 ```math
@@ -856,7 +856,7 @@ Consider the Lagrangian function
 ```math
 L(x, y) = \frac{1}{2}x^TQ_0x + a_0^T x + b_0 - \sum_{i = 1}^m y_i (\frac{1}{2}x^TQ_ix + a_i^T x + b_i)
 ```
-An pair of primal-dual variables $(x^\star, y^\star)$ is optimal if
+A pair of primal-dual variables $(x^\star, y^\star)$ is optimal if
 * ``x^\star`` is a minimizer of
   ```math
   \min_{x \in \mathbb{R}^n} L(x, y^\star).
@@ -871,7 +871,7 @@ An pair of primal-dual variables $(x^\star, y^\star)$ is optimal if
   ```
   That is, for all ``i = 1, \ldots, m``, ``\frac{1}{2}x^TQ_ix + a_i^T x + b_i`` is
   either zero or in the normal cone of ``\mathcal{C}_i^*`` at ``y^\star``.
-  For instance, if ``\mathcal{C}_i`` is ``MOI.LessThan(0.0)``, it means that
+  For instance, if ``\mathcal{C}_i`` is ``\{ x \in \mathbb{R} : x \le 0 \}``, it means that
   if ``\frac{1}{2}x^TQ_ix + a_i^T x + b_i`` is nonzero then ``\lambda_i = 0``,
   this is the classical complementary slackness condition.
 

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -844,18 +844,37 @@ details.
 
 #### Dual for convex problem with quadratic functions
 
-If ``Q`` is positive semidefinite, then the constraint ``x^TQx + a^Tx + b \le 0`` can be rewritten as an equivalent SOC constraint ``\lVert Ax + b\rVert_2 \le c^Tx + d`` which has a dual variable ``(s, y)`` constrained to satisfy ``\lVert y \rVert_2 \leq s``.
-We define the constraint value as ``x^TQx + a^Tx + b`` and the constraint dual as ``\lVert y \rVert_2 - s``.
-Note that these scalar values are always nonpositive for feasible solutions and that complementary slackness holds, i.e. their product is always zero for an optimal primal-dual pair (indeed if two vectors in the second order cone are orthogonal then they are either both on the boundary or one of them is zero).
+Given a program with quadratic functions:
+```math
+\begin{align*}
+& \min_{x \in \mathbb{R}^n} & \frac{1}{2}x^TQ_0x + a_0^T x + b_0
+\\
+& \;\;\text{s.t.} & \frac{1}{2}x^TQ_ix + a_i^T x + b_i & \in \mathcal{C}_i & i = 1 \ldots m
+\end{align*}
+```
+Consider the Lagrangian function
+```math
+L(x, y) = \frac{1}{2}x^TQ_0x + a_0^T x + b_0 - \sum_{i = 1}^m y_i (\frac{1}{2}x^TQ_ix + a_i^T x + b_i)
+```
+An pair of primal-dual variables $(x^\star, y^\star)$ is optimal if
+* ``x^\star`` is a minimizer of
+  ```math
+  \min_{x \in \mathbb{R}^n} L(x, y^\star).
+  ```
+  That is,
+  ```math
+  0 = \nabla_x L(x, y^\star) = Q_0x + a_0 - \sum_{i = 1}^m y_i^\star (Q_ix + a_i).
+  ```
+* and ``y^\star`` is a maximizer of
+  ```math
+  \max_{y_i \in \mathcal{C}_i^*} L(x^\star, y).
+  ```
+  That is, for all ``i = 1, \ldots, m``, ``\frac{1}{2}x^TQ_ix + a_i^T x + b_i`` is
+  either zero or in the normal cone of ``\mathcal{C}_i^*`` at ``y^\star``.
+  For instance, if ``\mathcal{C}_i`` is ``MOI.LessThan(0.0)``, it means that
+  if ``\frac{1}{2}x^TQ_ix + a_i^T x + b_i`` is nonzero then ``\lambda_i = 0``,
+  this is the classical complementary slackness condition.
 
-Similarly, if ``Q`` is negative semidefinite, then the constraint ``x^TQx + a^Tx + b \ge 0`` can be rewritten as an equivalent SOC constraint ``\lVert Ax + b\rVert_2 \le c^Tx + d`` which has a dual variable ``(s, y)`` constrained to satisfy ``\lVert y \rVert_2 \leq s``.
-In this case, we define the constraint value as ``x^TQx + a^Tx + b`` and the constraint dual as ``s - \lVert y \rVert_2``.
-Note that these scalar values are always nonnegative for feasible solutions and that complementary slackness holds.
-
-If the objective is a minimization of a convex quadratic function or the maximization of a concave quadratic function then it can be transformed into a linear objective and a second order cone constraint.
-Therefore if the constraints are convex, their dual can be queried as usual.
-
-However, currently, a convention for duals is not defined for problems with non-conic sets ``\mathcal{S}_i`` or quadratic functions ``f_0, f_i`` that do not enter into one of the cases discussed in this question.
 
 ### Constraint bridges
 

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -844,11 +844,11 @@ details.
 
 #### Dual for convex problem with quadratic functions
 
-If ``Q`` is positive semidefinite, then the constraint ``x^TQx + a^Tx + b \le 0`` can be rewritten as an equivalent SOS constraint ``\lVert Ax + b\rVert_2 \le c^Tx + d`` which has a dual variable ``(s, y)`` constrained to satisfy ``\lVert y \rVert_2 \leq s``.
+If ``Q`` is positive semidefinite, then the constraint ``x^TQx + a^Tx + b \le 0`` can be rewritten as an equivalent SOC constraint ``\lVert Ax + b\rVert_2 \le c^Tx + d`` which has a dual variable ``(s, y)`` constrained to satisfy ``\lVert y \rVert_2 \leq s``.
 We define the constraint value as ``x^TQx + a^Tx + b`` and the constraint dual as ``\lVert y \rVert_2 - s``.
 Note that these scalar values are always nonpositive for feasible solutions and that complementary slackness holds, i.e. their product is always zero for an optimal primal-dual pair (indeed if two vectors in the second order cone are orthogonal then they are either both on the boundary or one of them is zero).
 
-Similarly, if ``Q`` is negative semidefinite, then the constraint ``x^TQx + a^Tx + b \ge 0`` can be rewritten as an equivalent SOS constraint ``\lVert Ax + b\rVert_2 \le c^Tx + d`` which has a dual variable ``(s, y)`` constrained to satisfy ``\lVert y \rVert_2 \leq s``.
+Similarly, if ``Q`` is negative semidefinite, then the constraint ``x^TQx + a^Tx + b \ge 0`` can be rewritten as an equivalent SOC constraint ``\lVert Ax + b\rVert_2 \le c^Tx + d`` which has a dual variable ``(s, y)`` constrained to satisfy ``\lVert y \rVert_2 \leq s``.
 In this case, we define the constraint value as ``x^TQx + a^Tx + b`` and the constraint dual as ``s - \lVert y \rVert_2``.
 Note that these scalar values are always nonnegative for feasible solutions and that complementary slackness holds.
 

--- a/src/Bridges/Constraint/quad_to_soc.jl
+++ b/src/Bridges/Constraint/quad_to_soc.jl
@@ -195,8 +195,8 @@ function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal,
 end
 
 # Lemma: If (1, s, x), (v, u, y) in RotatedSecondOrderCone and
-#        (1, s, x) ⋅ (v, u, y) = 0, then ∃σ ≥ 0 that,
-#        y = -σ*x, u = σ, v = σ*||x||_2^2/2.
+#        (1, s, x) ⋅ (v, u, y) = 0, then we have
+#        y = -u*x, v = u*||x||_2^2/2.
 # Proof: We have
 #        (1, s, x) ⋅ (v, u, y) = v + s * u + x ⋅ y
 #        (Cauchy-Schwarz)      ≥ v + s * u - ||x||_2 * ||y||_2
@@ -212,21 +212,21 @@ end
 #        2) `||x||_2^2 < 2 * s` and `||y||_2^2 = 2 * u * v = 0`: we have either:
 #           a) `u = 0`: hence `v = s * u = 0` or
 #           b) `v = 0`: since `s > 0`, `u = v / s = 0`.
-#           In any case, `x = 0` and `u = v = 0` hence we can take `σ = 0`.
+#           In any case, `y = 0` and `u = v = 0` hence the statement holds.
 #        3) `||x||_2^2 = 2 * s` and `||y||_2^2 = 2 * u * v`: we have
 #           `σ^2 * ||x||_2^2 = ||y||_2^2 = 2 * u * v = 2 * u^2 * s` hence
-#           `u = σ`. It follows that at `v = s * u = σ * ||x||_2^2/2`.
+#           `u = σ`. It follows that at `v = s * u = σ * ||x||_2^2/2`.         □
 #
 # It follows from the Lemma that
-# (1, s, x) ⋅ (v, u, y) = σ * (1, s, x) ⋅ (||x||_2^2/2, 1, -x)
-#                       = σ * (||x||_2^2/2 + s - ||x||_2^2)
-#                       = σ * (-||x||_2^2/2 + s)
+# (1, s, x) ⋅ (v, u, y) = u * (1, s, x) ⋅ (||x||_2^2/2, 1, -x)
+#                       = u * (||x||_2^2/2 + s - ||x||_2^2)
+#                       = u * (-||x||_2^2/2 + s)
 # Given a constraint `z^T Q z/2 + a^T z + b ≤ 0` that was transformed,
 # where Q = U^T * U$, we have `x = U * z` and `s = -a^T z - b` hence, we have
-#                       = -σ * (z^T Q z/2 + a^T z + b)
-# So the dual of the quadratic constraint is `-σ`, so that the contribution
+#                       = -u * (z^T Q z/2 + a^T z + b)
+# So the dual of the quadratic constraint is `-u`, so that the contribution
 # to the lagrangian function of both the quadratic and RotatedSOC formulation
-# is exactly the same.
+# is exactly the same. Q.E.D.
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintDual,
                  bridge::QuadtoSOCBridge)
     λ = MOI.get(model, attr, bridge.soc)[2]

--- a/src/Bridges/Constraint/quad_to_soc.jl
+++ b/src/Bridges/Constraint/quad_to_soc.jl
@@ -194,10 +194,44 @@ function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal,
     return output
 end
 
-# TODO
-#function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintFunction,
-#                 b::QuadtoSOCBridge)
-#end
+# Lemma: If (1, s, x), (v, u, y) in RotatedSecondOrderCone and
+#        (1, s, x) ⋅ (v, u, y) = 0, then ∃σ ≥ 0 that,
+#        y = -σ*x, u = σ, v = σ*||x||_2^2/2.
+# Proof: We have
+#        (1, s, x) ⋅ (v, u, y) = v + s * u + x ⋅ y
+#        (Cauchy-Schwarz)      ≥ v + s * u - ||x||_2 * ||y||_2
+#        (RotatedSOC)          ≥ v + s * u - 2 * √(s * u * v)
+#        (AM-GM)               ≥ v + s * u - 2 * (v + s * u) / 2
+#                              = 0
+#        By assumption, the left-hand side is zero, hence all inequalities
+#        are equalities. By Cauchy-Schwarz, this means that ∃σ ≥ 0 such
+#        that `y = -σ*x`. By AM-GM, we have `v = s * u`.
+#        By RotatedSOC, we have either:
+#        1) `||y||_2^2 < 2 * u * v` and `||x||_2^2 = 2 * s = 0`: That implies
+#           that `v = 0 * u = 0` hence `||y||_2^2 < 0` which is impossible.
+#        2) `||x||_2^2 < 2 * s` and `||y||_2^2 = 2 * u * v = 0`: we have either:
+#           a) `u = 0`: hence `v = s * u = 0` or
+#           b) `v = 0`: since `s > 0`, `u = v / s = 0`.
+#           In any case, `x = 0` and `u = v = 0` hence we can take `σ = 0`.
+#        3) `||x||_2^2 = 2 * s` and `||y||_2^2 = 2 * u * v`: we have
+#           `σ^2 * ||x||_2^2 = ||y||_2^2 = 2 * u * v = 2 * u^2 * s` hence
+#           `u = σ`. It follows that at `v = s * u = σ * ||x||_2^2/2`.
+#
+# It follows from the Lemma that
+# (1, s, x) ⋅ (v, u, y) = σ * (1, s, x) ⋅ (||x||_2^2/2, 1, -x)
+#                       = σ * (||x||_2^2/2 + s - ||x||_2^2)
+#                       = σ * (-||x||_2^2/2 + s)
+# Given a constraint `z^T Q z/2 + a^T z + b ≤ 0` that was transformed,
+# where Q = U^T * U$, we have `x = U * z` and `s = -a^T z - b` hence, we have
+#                       = -σ * (z^T Q z/2 + a^T z + b)
+# So the dual of the quadratic constraint is `-σ`, so that the contribution
+# to the lagrangian function of both the quadratic and RotatedSOC formulation
+# is exactly the same.
+function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintDual,
+                 bridge::QuadtoSOCBridge)
+    λ = MOI.get(model, attr, bridge.soc)[2]
+    return bridge.less_than ? -λ : λ
+end
 
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintSet,
                  b::QuadtoSOCBridge{T}) where T

--- a/src/Utilities/results.jl
+++ b/src/Utilities/results.jl
@@ -200,6 +200,46 @@ function variable_coefficient(func::MOI.VectorAffineFunction{T},
     end
     return coef
 end
+function variable_coefficient(func::MOI.ScalarQuadraticFunction{T},
+                              vi::MOI.VariableIndex, value::Function) where T
+    coef = zero(T)
+    # `vi`'th row of `Qx + a` where `func` is `x'Qx/2 + a'x + b`.
+    for term in func.affine_terms
+        if term.variable_index == vi
+            coef += term.coefficient
+        end
+    end
+    for term in func.quadratic_terms
+        if term.variable_index_1 == vi
+            coef += term.coefficient * value(term.variable_index_2)
+        elseif term.variable_index_2 == vi
+            coef += term.coefficient * value(term.variable_index_1)
+        end
+    end
+    return coef
+end
+function variable_coefficient(func::MOI.VectorQuadraticFunction{T},
+                              vi::MOI.VariableIndex, value::Function) where T
+    coef = zeros(T, MOI.output_dimension(func))
+    # `vi`'th row of `Qx + a` where `func` is `x'Qx/2 + a'x + b`.
+    for vector_term in func.affine_terms
+        term = vector_term.scalar_term
+        if term.variable_index == vi
+            coef[vector_term.output_index] += term.coefficient
+        end
+    end
+    for vector_term in func.quadratic_terms
+        term = vector_term.scalar_term
+        oi = vector_term.output_index
+        if term.variable_index_1 == vi
+            coef[oi] += term.coefficient * value(term.variable_index_2)
+        elseif term.variable_index_2 == vi
+            coef[oi] += term.coefficient * value(term.variable_index_1)
+        end
+    end
+    return coef
+end
+
 
 """
     variable_dual(model::MOI.ModelLike,
@@ -224,9 +264,30 @@ end
 function variable_dual(model::MOI.ModelLike,
                        attr::MOI.ConstraintDual,
                        vi::MOI.VariableIndex,
+                       ci::MOI.ConstraintIndex{<:MOI.VectorQuadraticFunction})
+    func = MOI.get(model, MOI.ConstraintFunction(), ci)
+    set = MOI.get(model, MOI.ConstraintSet(), ci)
+    primal_attr = MOI.VariablePrimal(attr.N)
+    coef = variable_coefficient(func, vi, vi -> MOI.get(model, primal_attr, vi))
+    dual = MOI.get(model, attr, ci)
+    return set_dot(coef, dual, set)
+end
+function variable_dual(model::MOI.ModelLike,
+                       attr::MOI.ConstraintDual,
+                       vi::MOI.VariableIndex,
                        ci::MOI.ConstraintIndex{<:MOI.ScalarAffineFunction})
     func = MOI.get(model, MOI.ConstraintFunction(), ci)
     coef = variable_coefficient(func, vi)
+    dual = MOI.get(model, attr, ci)
+    return coef * dual
+end
+function variable_dual(model::MOI.ModelLike,
+                       attr::MOI.ConstraintDual,
+                       vi::MOI.VariableIndex,
+                       ci::MOI.ConstraintIndex{<:MOI.ScalarQuadraticFunction})
+    func = MOI.get(model, MOI.ConstraintFunction(), ci)
+    primal_attr = MOI.VariablePrimal(attr.N)
+    coef = variable_coefficient(func, vi, vi -> MOI.get(model, primal_attr, vi))
     dual = MOI.get(model, attr, ci)
     return coef * dual
 end
@@ -268,23 +329,12 @@ function variable_dual(model::MOI.ModelLike,
             if (F == MOI.SingleVariable && func.variable == vi) ||
                (F == MOI.VectorOfVariables && vi in func.variables)
                error("Fallback getter for variable constraint dual does not",
-                     "support other variable-wise constraints on the variable.",
-                     "Please report this issue to the solver wrapper package.")
+                     " support other variable-wise constraints on the variable.",
+                     " Please report this issue to the solver wrapper package.")
             end
         end
     end
     return 0.0
-end
-function variable_dual(::MOI.ModelLike,
-                       ::MOI.ConstraintDual,
-                       ::MOI.ConstraintIndex,
-                       ::MOI.VariableIndex,
-                       ::Type{<:Union{MOI.ScalarQuadraticFunction,
-                                      MOI.VectorQuadraticFunction}},
-                       ::Type{<:MOI.AbstractSet})
-    error("Fallback getter for variable constraint dual only supports affine",
-          "constraint functions.",
-          "Please report this issue to the solver wrapper package.")
 end
 
 """
@@ -317,10 +367,14 @@ function variable_dual(model::MOI.ModelLike,
         elseif F <: MOI.ScalarAffineFunction
             f = MOI.get(model, obj_attr)
             dual += sign * variable_coefficient(f, vi)
+        elseif F <: MOI.ScalarQuadraticFunction
+            f = MOI.get(model, obj_attr)
+            primal_attr = MOI.VariablePrimal(attr.N)
+            dual += sign * variable_coefficient(f, vi, vi -> MOI.get(model, primal_attr, vi))
         else
-            error("Fallback getter for variable constraint dual only supports",
-                  "affine objective function.",
-                  "Please report this issue to the solver wrapper package.")
+            error("Fallback getter for variable constraint dual does not",
+                  " support objective function of type $F.",
+                  " Please report this issue to the solver wrapper package.")
         end
     end
     for FS in MOI.get(model, MOI.ListOfConstraints())

--- a/test/Bridges/Constraint/quad_to_soc.jl
+++ b/test/Bridges/Constraint/quad_to_soc.jl
@@ -62,13 +62,14 @@ config = MOIT.TestConfig()
     end
     @testset "QCP tests" begin
         MOIU.set_mock_optimize!(mock,
-            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 7/4], MOI.FEASIBLE_POINT))
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 7/4],
+                (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)  => [zeros(2)],
+                (MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)  => [[0.25, 1.0, -1/√2]]))
         MOIT.qcp1test(bridged_mock, config)
         MOIU.set_mock_optimize!(mock,
-            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2],
+                (MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)  => [[1/√2, 1/(2 * √2), -1/√2]]))
         MOIT.qcp2test(bridged_mock, config)
-        MOIU.set_mock_optimize!(mock,
-            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
         MOIT.qcp3test(bridged_mock, config)
         @testset "Bridge deletion" begin
             ci = first(MOI.get(bridged_mock,
@@ -77,7 +78,8 @@ config = MOIT.TestConfig()
             test_delete_bridge(bridged_mock, ci, 1, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),))
         end
         MOIU.set_mock_optimize!(mock,
-            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 1.0], MOI.FEASIBLE_POINT))
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 1.0],
+                (MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)  => [[1.0, 1/3, -1/√2, -1/√6]]))
         MOIT.qcp4test(bridged_mock, config)
         MOIT.qcp5test(bridged_mock, config)
     end

--- a/test/Test/contquadratic.jl
+++ b/test/Test/contquadratic.jl
@@ -11,27 +11,41 @@ config = MOIT.TestConfig()
 
 @testset "QP" begin
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [4/7, 3/7, 6/7]))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [4/7, 3/7, 6/7],
+            (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})  => [5/7, 6/7]))
     MOIT.qp1test(mock, config)
+    MOIU.set_mock_optimize!(mock,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [4/7, 3/7, 6/7],
+            (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})  => [5/7, 6/7]),
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [4/7, 3/7, 6/7],
+            (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})  => [10/7, 12/7]))
     MOIT.qp2test(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/4, 3/4]),
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 0.0]))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/4, 3/4],
+            (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})  => [11/4]),
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 0.0],
+            (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})  => [-2.0]))
     MOIT.qp3test(mock, config)
 end
 @testset "QCP" begin
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 7/4], MOI.FEASIBLE_POINT))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 7/4],
+            (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)  => [zeros(2)],
+            (MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})  => [-1.0]))
     MOIT.qcp1test(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2],
+            (MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})  => [-1/(2*√2)]))
     MOIT.qcp2test(mock, config)
-    MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
     MOIT.qcp3test(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 1.0], MOI.FEASIBLE_POINT))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 1.0],
+            (MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})  => [-1/3]))
     MOIT.qcp4test(mock, config)
+    MOIU.set_mock_optimize!(mock,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 1.0],
+            (MOI.ScalarQuadraticFunction{Float64}, MOI.GreaterThan{Float64})  => [1/3]))
+    MOIT.qcp5test(mock, config)
 end
 @testset "Non-convex QCP" begin
     MOIU.set_mock_optimize!(mock,
@@ -43,6 +57,8 @@ end
 end
 @testset "SOCP" begin
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 1/2, 1/√2]))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 1/2, 1/√2],
+            (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})  => [1/√2],
+            (MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})  => [-1/√2]))
     MOIT.socp1test(mock, config)
 end


### PR DESCRIPTION
I have attempted a convention for the dual and constraint values for convex programs with quadratic functions.
It seems to me that it would be inconsistent to say that the dual is the dual of the equivalent SOC formulation since the dimension depends on the choice of `A` and the constraint value has scalar dimension.