### PR TITLE
Copy vector of variable before giving it to ScalarAffineFunction

### DIFF
--- a/test/contlinear.jl
+++ b/test/contlinear.jl
@@ -125,7 +125,7 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
         # x,y,z >= 0
 
         z = MOI.addvariable!(m)
-        push!(v, z)
+        v = [v; z]
         @test v[3] == z
 
         vc3 = MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.GreaterThan(0.0))


### PR DESCRIPTION
We do `push!(v, z)` later so if we consider that `v` is owned by the function (since it does not copy), we need to copy before giving it