### PR TITLE
rename variablewise functions

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -163,8 +163,8 @@ ConstraintSet
 List of recognized functions.
 ```@docs
 AbstractFunction
-ScalarVariablewiseFunction
-VectorVariablewiseFunction
+SingleVariable
+VectorOfVariables
 ScalarAffineFunction
 VectorAffineFunction
 ScalarQuadraticFunction

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -76,7 +76,7 @@ supportsproblem(s, ScalarAffineFunction{Float64},
     [(ScalarAffineFunction{Float64},Zeros),
     (ScalarAffineFunction{Float64},LessThan),
     (ScalarAffineFunction{Float64},GreaterThan),
-    (ScalarVariablewiseFunction{Float64},ZeroOne)])
+    (SingleVariable,ZeroOne)])
 ```
 should be `true` for a mixed-integer linear programming solver `s`.
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -23,7 +23,7 @@ If `c` is a `ConstraintReference{ScalarAffineFunction,S}` and `v1` and `v2` are 
 
 ```julia
 modifyconstraint!(m, c, ScalarAffineFunction([v1,v2],[1.0,2.0],5.0))
-modifyconstraint!(m, c, ScalarVariablewiseFunction(v1)) # Error
+modifyconstraint!(m, c, SingleVariable(v1)) # Error
 ```
 
 ## Modify Set

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -23,22 +23,22 @@ abstract type AbstractVectorFunction <: AbstractFunction end
 
 
 """
-    ScalarVariablewiseFunction(variable)
+    SingleVariable(variable)
 
 The function that extracts the scalar variable referenced by `variable`, a `VariableReference`.
-This function would naturally be used for single variable bounds or integrality constraints.
+This function is naturally be used for single variable bounds or integrality constraints.
 """
-struct ScalarVariablewiseFunction <: AbstractScalarFunction
+struct SingleVariable <: AbstractScalarFunction
     variable::VariableReference
 end
 
 """
-    VectorVariablewiseFunction(variables)
+    VectorOfVariables(variables)
 
 The function that extracts the vector of variables referenced by `variables`, a `Vector{VariableReference}`.
-This function would naturally be used for constraints that apply to groups of variables, such as an "all different" constraint, an indicator constraint, or a complementarity constraint.
+This function is naturally be used for constraints that apply to groups of variables, such as an "all different" constraint, an indicator constraint, or a complementarity constraint.
 """
-struct VectorVariablewiseFunction <: AbstractVectorFunction
+struct VectorOfVariables <: AbstractVectorFunction
     variables::Vector{VariableReference}
 end
 

--- a/test/contconic.jl
+++ b/test/contconic.jl
@@ -5,7 +5,7 @@ MOI = MathOptInterface
 
 function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
 
-    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorVariablewiseFunction,MOI.Nonnegatives),(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives)])
+    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorOfVariables,MOI.Nonnegatives),(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives)])
         @testset "LIN1" begin
             # linear conic problem
             # min -3x - 2y - 4z
@@ -19,13 +19,13 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
             v = MOI.addvariables!(m, 3)
             @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
 
-            vc = MOI.addconstraint!(m, MOI.VectorVariablewiseFunction(v), MOI.Nonnegatives(3))
+            vc = MOI.addconstraint!(m, MOI.VectorOfVariables(v), MOI.Nonnegatives(3))
             c = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,1,1,2,2], [v;v[2];v[3]], ones(5), [-3.0,-2.0]), MOI.Zeros(2))
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorVariablewiseFunction,MOI.Nonnegatives}()) == 1
+            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
             @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
             loc = MOI.getattribute(m, MOI.ListOfConstraints())
             @test length(loc) == 2
-            @test (MOI.VectorVariablewiseFunction,MOI.Nonnegatives) in loc
+            @test (MOI.VectorOfVariables,MOI.Nonnegatives) in loc
             @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
 
             MOI.setobjective!(m, MOI.MinSense, MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
@@ -92,7 +92,7 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
         end
     end
 
-    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorVariablewiseFunction,MOI.Nonnegatives),(MOI.VectorVariablewiseFunction,MOI.Nonpositives)])
+    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.Nonnegatives),(MOI.VectorOfVariables,MOI.Nonpositives)])
         @testset "LIN2" begin
             # mixed cones
             # min  3x + 2y - 4z + 0s
@@ -118,13 +118,13 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
 
             c = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,1,2,3,3], [x,s,y,x,z], [1.0,-1.0,1.0,1.0,1.0], [4.0,3.0,-12.0]), MOI.Zeros(3))
 
-            vy = MOI.addconstraint!(m, MOI.VectorVariablewiseFunction([y]), MOI.Nonpositives(1))
-            vz = MOI.addconstraint!(m, MOI.VectorVariablewiseFunction([z]), MOI.Nonnegatives(1))
-            vz = MOI.addconstraint!(m, MOI.VectorVariablewiseFunction([s]), MOI.Zeros(1))
+            vy = MOI.addconstraint!(m, MOI.VectorOfVariables([y]), MOI.Nonpositives(1))
+            vz = MOI.addconstraint!(m, MOI.VectorOfVariables([z]), MOI.Nonnegatives(1))
+            vz = MOI.addconstraint!(m, MOI.VectorOfVariables([s]), MOI.Zeros(1))
 
             @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorVariablewiseFunction,MOI.Nonpositives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorVariablewiseFunction,MOI.Nonnegatives}()) == 1
+            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
+            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
 
             MOI.optimize!(m)
 
@@ -249,7 +249,7 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
         end
     end
 
-    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorVariablewiseFunction,MOI.Nonpositives)])
+    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorOfVariables,MOI.Nonpositives)])
         @testset "LIN4 - infeasible" begin
             # Problem LIN4 - Infeasible LP
             # min  0
@@ -265,10 +265,10 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
             x = MOI.addvariable!(m)
 
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Nonnegatives(1))
-            MOI.addconstraint!(m, MOI.VectorVariablewiseFunction([x]), MOI.Nonpositives(1))
+            MOI.addconstraint!(m, MOI.VectorOfVariables([x]), MOI.Nonpositives(1))
 
             @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorVariablewiseFunction,MOI.Nonpositives}()) == 1
+            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
 
             MOI.optimize!(m)
 
@@ -283,7 +283,7 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
         end
     end
 
-    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorVariablewiseFunction,MOI.SecondOrderCone)])
+    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.SecondOrderCone)])
         @testset "SOC1" begin
             # Problem SOC1
             # max 0x + 1y + 1z
@@ -297,14 +297,14 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
             MOI.setobjective!(m, MOI.MaxSense, MOI.ScalarAffineFunction([y,z],[-1.0,-1.0],0.0))
 
             ceq = MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Zeros(1))
-            csoc = MOI.addconstraint!(m, MOI.VectorVariablewiseFunction([x,y,z]), MOI.SecondOrderCone(3))
+            csoc = MOI.addconstraint!(m, MOI.VectorOfVariables([x,y,z]), MOI.SecondOrderCone(3))
 
             @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorVariablewiseFunction,MOI.SecondOrderCone}()) == 1
+            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
             loc = MOI.getattribute(m, MOI.ListOfConstraints())
             @test length(loc) == 2
             @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
-            @test (MOI.VectorVariablewiseFunction,MOI.SecondOrderCone) in loc
+            @test (MOI.VectorOfVariables,MOI.SecondOrderCone) in loc
 
             MOI.optimize!(m)
 
@@ -507,7 +507,7 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
         end
     end
 
-    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.Zeros),(MOI.VectorVariablewiseFunction,MOI.SecondOrderCone)])
+    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.SecondOrderCone)])
         @testset "SOC4" begin
             # Problem SOC4
             # min 0x[1] - 2x[2] - 1x[3]
@@ -537,10 +537,10 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
             A_vals = [1.0,1.0,1.0,-1.0,-1.0]
 
             c1 = MOI.addconstraint!(m, MOI.VectorAffineFunction(A_rows,A_cols,A_vals,b), MOI.Zeros(3))
-            c2 = MOI.addconstraint!(m, MOI.VectorVariablewiseFunction([x[1],x[4],x[5]]), MOI.SecondOrderCone(3))
+            c2 = MOI.addconstraint!(m, MOI.VectorOfVariables([x[1],x[4],x[5]]), MOI.SecondOrderCone(3))
 
             @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorVariablewiseFunction,MOI.SecondOrderCone}()) == 1
+            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
 
             MOI.setobjective!(m, MOI.MinSense, MOI.ScalarAffineFunction(x,c,0.0))
             MOI.optimize!(m)
@@ -571,7 +571,7 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
         end
     end
 
-    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorVariablewiseFunction, MOI.PositiveSemidefiniteConeTriangle), (MOI.VectorVariablewiseFunction, MOI.SecondOrderCone)])
+    if MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle), (MOI.VectorOfVariables, MOI.SecondOrderCone)])
         @testset "SDP1" begin
             # Problem SDP1 - sdo1 from MOSEK docs
             # From Mosek.jl/test/mathprogtestextra.jl, under license:
@@ -607,8 +607,8 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
             x = MOI.addvariables!(m, 3)
             @test MOI.getattribute(m, MOI.NumberOfVariables()) == 9
 
-            cX = MOI.addconstraint!(m, MOI.VectorVariablewiseFunction(x), MOI.PositiveSemidefiniteConeTriangle(3))
-            cx = MOI.addconstraint!(m, MOI.VectorVariablewiseFunction(X), MOI.SecondOrderCone(3))
+            cX = MOI.addconstraint!(m, MOI.VectorOfVariables(x), MOI.PositiveSemidefiniteConeTriangle(3))
+            cx = MOI.addconstraint!(m, MOI.VectorOfVariables(X), MOI.SecondOrderCone(3))
 
             c1 = MOI.addconstraint!(m, MOI.ScalarAffineFunction([X[1], X[4], X[6], x[1]], [1., 1, 1, 1], 0.), MOI.EqualTo(1.))
             c2 = MOI.addconstraint!(m, MOI.ScalarAffineFunction([X; x[2]; x[3]], [1., 2, 2, 1, 2, 1, 1, 1], 0.), MOI.EqualTo(1/2))
@@ -618,8 +618,8 @@ function contconictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
 
 
             @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 2
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorVariablewiseFunction, MOI.PositiveSemidefiniteConeTriangle}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorVariablewiseFunction, MOI.SecondOrderCone}()) == 1
+            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle}()) == 1
+            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables, MOI.SecondOrderCone}()) == 1
 
             MOI.optimize!(m)
 

--- a/test/contlinear.jl
+++ b/test/contlinear.jl
@@ -10,7 +10,7 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
         # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
         #       x, y >= 0   (x, y ∈ Nonnegatives)
 
-        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64})])
+        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
         m = MOI.SolverInstance(solver)
 
@@ -21,9 +21,9 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
         c = MOI.addconstraint!(m, cf, MOI.LessThan(1.0))
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
-        vc1 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(v[1]), MOI.GreaterThan(0.0))
-        vc2 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(v[2]), MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64}}()) == 2
+        vc1 = MOI.addconstraint!(m, MOI.SingleVariable(v[1]), MOI.GreaterThan(0.0))
+        vc2 = MOI.addconstraint!(m, MOI.SingleVariable(v[2]), MOI.GreaterThan(0.0))
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
         objf = MOI.ScalarAffineFunction(v, [-1.0,0.0], 0.0)
         MOI.setobjective!(m, MOI.MinSense, objf)
@@ -128,14 +128,14 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
         push!(v, z)
         @test v[3] == z
 
-        vc3 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(v[3]), MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64}}()) == 3
+        vc3 = MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.GreaterThan(0.0))
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
         MOI.modifyconstraint!(m, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
         MOI.modifyobjective!(m, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
 
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64}}()) == 3
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
         MOI.optimize!(m)
 
@@ -194,8 +194,8 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
 
         MOI.modifyconstraint!(m, vc1, MOI.GreaterThan(0.0))
         MOI.delete!(m, vc3)
-        vc3 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(v[3]), MOI.EqualTo(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64}}()) == 3
+        vc3 = MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
         MOI.optimize!(m)
 
@@ -300,7 +300,7 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
         # s.t. x + y <= 1
         # x, y >= 0
 
-        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64})])
+        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
         m = MOI.SolverInstance(solver)
 
@@ -313,9 +313,9 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
         c = MOI.addconstraint!(m, cf, MOI.LessThan(1.0))
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
-        vc1 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(x), MOI.GreaterThan(0.0))
-        vc2 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(y), MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64}}()) == 2
+        vc1 = MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        vc2 = MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
         objf = MOI.ScalarAffineFunction([x, y], [-1.0,0.0], 0.0)
         MOI.setobjective!(m, MOI.MinSense, objf)
@@ -366,11 +366,11 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
         x = MOI.addvariable!(m)
         @test MOI.getattribute(m, MOI.NumberOfVariables()) == 1
 
-        MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(x), MOI.GreaterThan(0.0))
+        MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         cf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
         MOI.addconstraint!(m, cf, MOI.GreaterThan(3.0))
 
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64}}()) == 1
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
 
         objf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
@@ -396,11 +396,11 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
         x = MOI.addvariable!(m)
         @test MOI.getattribute(m, MOI.NumberOfVariables()) == 1
 
-        MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(x), MOI.LessThan(0.0))
+        MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.LessThan(0.0))
         cf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
         MOI.addconstraint!(m, cf, MOI.LessThan(3.0))
 
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.LessThan{Float64}}()) == 1
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
         objf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
@@ -420,7 +420,7 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
 
     @testset "Modify GreaterThan and LessThan sets as bounds" begin
 
-        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64}),(MOI.ScalarVariablewiseFunction,MOI.LessThan{Float64})])
+        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.LessThan{Float64})])
 
         m = MOI.SolverInstance(solver)
 
@@ -433,8 +433,8 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
 
         MOI.setobjective!(m, MOI.MinSense, MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
 
-        c1 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(x), MOI.GreaterThan(0.0))
-        c2 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(y), MOI.LessThan(0.0))
+        c1 = MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        c2 = MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.LessThan(0.0))
 
         MOI.optimize!(m)
 
@@ -503,10 +503,10 @@ function contlineartest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64)
 
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
 
-        vc1 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(x), MOI.GreaterThan(0.0))
-        vc2 = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(y), MOI.GreaterThan(0.0))
+        vc1 = MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        vc2 = MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.GreaterThan{Float64}}()) == 2
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
         objf = MOI.ScalarAffineFunction([x, y], [1.0,1.0], 0.0)
         MOI.setobjective!(m, MOI.MaxSense, objf)

--- a/test/contquadratic.jl
+++ b/test/contquadratic.jl
@@ -273,7 +273,7 @@ function contquadratictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float
         #      x^2 + y^2 <= t^2 (c2)
         #      t >= 0 (bound)
 
-        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuaFunction{Float64},MOI.LessThan), (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan), (MOI.ScalarVariablewiseFunction,MOI.GreaterThan)])dratic
+        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuaFunction{Float64},MOI.LessThan), (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan), (MOI.SingleVariable,MOI.GreaterThan)])dratic
 
         m = MOI.SolverInstance(solver)
 
@@ -290,8 +290,8 @@ function contquadratictest(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float
         c2 = MOI.addconstraint!(m, c2f, MOI.LessThan(0.0))
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan}()) == 1
 
-        bound = MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(t), MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction, MOI.GreaterThan}()) == 1
+        bound = MOI.addconstraint!(m, MOI.SingleVariable(t), MOI.GreaterThan(0.0))
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable, MOI.GreaterThan}()) == 1
 
         MOI.setobjective!(m, MOI.MinSense, MOI.ScalarAffineFunction([t], [1.0], 0.0))
         @test MOI.getattribute(m, MOI.Sense()) == MOI.MinSense

--- a/test/intlinear.jl
+++ b/test/intlinear.jl
@@ -12,15 +12,15 @@ function intlineartest(solver::MOI.AbstractSolver, eps=Base.rtoldefault(Float64)
 
         m = MOI.SolverInstance(solver)
 
-        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarVariablewiseFunction,MOI.ZeroOne),(MOI.ScalarAffineFunction{Float64},MOI.LessThan)])
+        @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.ZeroOne),(MOI.ScalarAffineFunction{Float64},MOI.LessThan)])
 
         v = MOI.addvariables!(m, 5)
         @test MOI.getattribute(m, MOI.NumberOfVariables()) == 5
 
         for vi in v
-            MOI.addconstraint!(m, MOI.ScalarVariablewiseFunction(vi), MOI.ZeroOne())
+            MOI.addconstraint!(m, MOI.SingleVariable(vi), MOI.ZeroOne())
         end
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarVariablewiseFunction,MOI.ZeroOne}()) == 5
+        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 5
         c = MOI.addconstraint!(m, MOI.ScalarAffineFunction(v, [2.0, 8.0, 4.0, 2.0, 5.0], 0.0), MOI.LessThan(10))
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.ZeroOne}()) == 1
 


### PR DESCRIPTION
`ScalarVariablewiseFunction` is renamed to `SingleVariable`, `VectorVariablewiseFunction` is renamed to `VectorOfVariables`. In a second PR I'll add the shorthand proposed [here](https://github.com/JuliaOpt/MathOptInterface.jl/issues/60#issuecomment-316474508).

Closes #60