### PR TITLE
Fix dual for SOC1

### DIFF
--- a/test/contconic.jl
+++ b/test/contconic.jl
@@ -352,7 +352,7 @@ function soc1test(solver::MOI.AbstractSolver, ε=Base.rtoldefault(Float64))
             @test MOI.getattribute(m, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=ε
 
             @test MOI.cangetattribute(m, MOI.ConstraintDual(), ceq)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), ceq) ≈ [sqrt(2)] atol=ε
+            @test MOI.getattribute(m, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=ε
             @test MOI.cangetattribute(m, MOI.ConstraintDual(), csoc)
             @test MOI.getattribute(m, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=ε
 


### PR DESCRIPTION
Since x does not appear in the objective the sum of the duals * coefficients of x should be 0.