### PR TITLE
attributes to access list of references present in an instance

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -63,8 +63,10 @@ List of solver instance attributes
 RawSolver
 Sense
 NumberOfVariables
-NumberOfConstraints
+ListOfVariableReferences
 ListOfConstraints
+NumberOfConstraints
+ListOfConstraintReferences
 ResultCount
 ObjectiveFunction
 ObjectiveValue

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -289,6 +289,22 @@ The number of variables in the solver instance.
 struct NumberOfVariables <: AbstractSolverInstanceAttribute end
 
 """
+    ListOfVariableReferences()
+
+A `Vector{VariableReference}` with references to all variables present
+in the solver instance (i.e., of length equal to the value of `NumberOfVariables()`).
+"""
+struct ListOfVariableReferences <: AbstractSolverInstanceAttribute end
+
+"""
+    ListOfConstraintReferences{F,S}()
+
+A `Vector{ConstraintReferences{F,S}}` with references to all constraints of
+type `F`-in`S` in the solver instance (i.e., of length equal to the value of `NumberOfConstraints{F,S}()`).
+"""
+struct ListOfConstraintReferences{F,S} <: AbstractSolverInstanceAttribute end
+
+"""
     NumberOfConstraints{F,S}()
 
 The number of constraints of the type `F`-in-`S` present in the solver instance.


### PR DESCRIPTION
This is particularly useful if you only have an instance object and want to extract data from it (e.g., in JuMP). Right now you're forced to keep track of the variable and constraint references separately. 