### PR TITLE
clear out runtests.jl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ git:
 
 ## uncomment the following lines to override the default test script
 script:
-  - julia -e 'Pkg.clone(pwd()); Pkg.clone("https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl.git"); Pkg.build("MathOptInterface"); Pkg.test("MathOptInterface"; coverage=true)'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("MathOptInterface"); Pkg.test("MathOptInterface"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
   #- julia -e 'cd(Pkg.dir("MathOptInterface")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,6 @@ build_script:
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
       Pkg.clone(pwd(), \"MathOptInterface\");
-      Pkg.clone(\"https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl.git\");
       Pkg.build(\"MathOptInterface\")"
 
 test_script:

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-MathOptInterfaceUtilities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,24 +1,5 @@
 using MathOptInterface, Base.Test
-# TODO using solvers?
 
 const MOI = MathOptInterface
 
-include("contlinear.jl")
-@testset "Continuous linear problems" begin
-    # contlineartest(GLPKSolverLP())
-end
-
-include("contquadratic.jl")
-@testset "Continuous quadratic problems" begin
-    # contquadratictest(GurobiSolver())
-end
-
-include("contconic.jl")
-@testset "Continuous conic problems" begin
-    # contconictest(SCSSolver(verbose=0))
-end
-
-include("intlinear.jl")
-@testset "Mixed-integer linear problems" begin
-    # intlineartest(GLPKSolverMIP())
-end
+# TODO: Any tests here should be self-contained. We should have a toy reference implementation of a solver that we can test. Until then, the interface is tested when solvers run the separate test files.


### PR DESCRIPTION
There's no reason to have MOI failing on travis when we don't even test anything at all.
This closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/102 as far as I'm concerned. When solvers run the MOI tests they need to call MOIU, but that's less of an issue because many solvers will depend on MOIU anyway.

Ref https://github.com/JuliaOpt/MathOptInterface.jl/pull/96