### PR TITLE
Fix test args, test for SOS-constraint suppoort

### DIFF
--- a/test/contconic.jl
+++ b/test/contconic.jl
@@ -432,8 +432,8 @@ function soc1atest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), r
 end
 
 function soc1tests(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
-    soc1test(solver, ɛ)
-    soc1atest(solver, ɛ)
+    soc1test(solver, atol=atol, rtol=rtol)
+    soc1atest(solver, atol=atol, rtol=rtol)
 end
 
 function soc2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
@@ -532,8 +532,8 @@ function soc2atest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), r
 end
 
 function soc2tests(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
-    soc2test(solver, atol)
-    soc2atest(solver, atol)
+    soc2test(solver, atol=atol,rtol=rtol)
+    soc2atest(solver, atol=atol,rtol=rtol)
 end
 
 function soc3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))

--- a/test/contlinear.jl
+++ b/test/contlinear.jl
@@ -832,7 +832,7 @@ function linear8test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         MOI.optimize!(m)
 
         @test MOI.cangetattribute(m, MOI.ResultCount())
-        if MOI.getattribute(m, MOI.ResultCount()) == 1
+        if MOI.getattribute(m, MOI.ResultCount()) > 0
             # solver returned an unbounded ray
             @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
             @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate


### PR DESCRIPTION
Disable SOS tests for non-SOS solvers. Absense of SOS support should not produce a test fail.
I have added `NearlyFeasible` as an acceptable result for some tests. 