### PR TITLE
Add tests for candelete and canmodify

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -118,6 +118,7 @@ ConstraintReference
 candelete
 isvalid
 delete!(::AbstractSolverInstance,::AnyReference)
+candelete
 ```
 
 ### Variables
@@ -148,6 +149,8 @@ addconstraint!
 addconstraints!
 modifyconstraint!
 canmodifyconstraint
+transformconstraint!
+cantransformconstraint
 ```
 
 List of attributes associated with constraints. [category AbstractConstraintAttribute]
@@ -227,4 +230,5 @@ Functions for adding and modifying objectives.
 ```@docs
 setobjective!
 modifyobjective!
+canmodifyobjective
 ```

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -145,3 +145,22 @@ transformconstraint!(m, c, LessThan(0.0)) # errors
 ```
 """
 function transformconstraint! end
+
+"""
+## Transform Constraint Set
+
+    cantransformconstraint(m::AbstractSolverInstance, c::ConstraintReference{F,S1}, newset::S2)::Bool
+
+Return a `Bool` is the set in constraint `c` can be replaced with `newset`.
+
+### Examples
+
+If `c` is a `ConstraintReference{ScalarAffineFunction{Float64},LessThan{Float64}}`,
+
+```julia
+cantransformconstraint(m, c, GreaterThan(0.0)) # true
+cantransformconstraint(m, c, ZeroOne())        # false
+```
+"""
+function cantransformconstraint end
+cantransformconstraint(m::AbstractSolverInstance, c::ConstraintReference, newset) = false

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -20,3 +20,18 @@ modifyobjective!(m, ScalarConstantChange(10.0))
 ```
 """
 function modifyobjective! end
+
+"""
+    canmodifyobjective(m::AbstractSolverInstance, change::AbstractFunctionModification)::Bool
+
+Return a `Bool` indicating whether it is possible to apply the modification
+specified by `change` to the objective function of `m`.
+
+### Examples
+
+```julia
+canmodifyobjective!(m, ScalarConstantChange(10.0))
+```
+"""
+function canmodifyobjective! end
+canmodifyobjective(m::AbstractSolverInstance, change) = false

--- a/src/references.jl
+++ b/src/references.jl
@@ -26,14 +26,14 @@ const AnyReference = Union{ConstraintReference,VariableReference}
 
 Return a `Bool` indicating whether the object referred to by `ref` can be removed from the solver instance `m`.
 """
-candelete(m::AbstractSolverInstance, ref::AnyReference) = throw(MethodError(candelete, (m, ref)))
+candelete(m::AbstractSolverInstance, ref::AnyReference) = false
 
 """
     isvalid(m::AbstractSolverInstance, ref::AnyReference)::Bool
 
 Return a `Bool` indicating whether this reference refers to a valid object in the solver instance `m`.
 """
-isvalid(m::AbstractSolverInstance, ref::AnyReference) = throw(MethodError(isvalid, (m, ref)))
+isvalid(m::AbstractSolverInstance, ref::AnyReference) = false
 
 """
     delete!(m::AbstractSolverInstance, ref::AnyReference)

--- a/test/contlinear.jl
+++ b/test/contlinear.jl
@@ -141,6 +141,7 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test MOI.canmodifyconstraint(m, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
         MOI.modifyconstraint!(m, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
 
+        @test MOI.canmodifyobjective(m, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
         MOI.modifyobjective!(m, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
 
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
@@ -636,7 +637,7 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         #   solution: y = 2, objv = 2
         @test MOI.candelete(m, x)
         MOI.delete!(m, x)
-        
+
         MOI.optimize!(m)
 
         @test MOI.cangetattribute(m, MOI.TerminationStatus())

--- a/test/contlinear.jl
+++ b/test/contlinear.jl
@@ -1032,6 +1032,7 @@ function linear11test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64)
         @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
 
+        @test MOI.cantransformconstraint(m, c2, MOI.LessThan(2.0))
         c3 = MOI.transformconstraint!(m, c2, MOI.LessThan(2.0))
 
         @test isa(c3, MOI.ConstraintReference{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}})

--- a/test/contlinear.jl
+++ b/test/contlinear.jl
@@ -138,7 +138,9 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         vc3 = MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.GreaterThan(0.0))
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
+        @test MOI.canmodifyconstraint(m, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
         MOI.modifyconstraint!(m, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
+
         MOI.modifyobjective!(m, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
 
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
@@ -183,7 +185,7 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # s.t. x + y + z <= 1
         # x >= -1
         # y,z >= 0
-
+        @test MOI.canmodifyconstraint(m, vc1, MOI.GreaterThan(-1.0))
         MOI.modifyconstraint!(m, vc1, MOI.GreaterThan(-1.0))
 
         MOI.optimize!(m)
@@ -204,9 +206,12 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # max x + 2z
         # s.t. x + y + z <= 1
         # x, y >= 0, z = 0
-
+        @test MOI.canmodifyconstraint(m, vc1, MOI.GreaterThan(0.0))
         MOI.modifyconstraint!(m, vc1, MOI.GreaterThan(0.0))
+
+        @test MOI.candelete(m, vc3)
         MOI.delete!(m, vc3)
+
         vc3 = MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
         @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
@@ -228,7 +233,7 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # max x + 2z
         # s.t. x + y + z == 2
         # x,y >= 0, z = 0
-
+        @test MOI.candelete(m, c)
         MOI.delete!(m, c)
         cf = MOI.ScalarAffineFunction(v, [1.0,1.0,1.0], 0.0)
         c = MOI.addconstraint!(m, cf, MOI.EqualTo(2.0))
@@ -488,6 +493,7 @@ function linear4test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # Min  x - y
         # s.t. 100.0 <= x
         #               y <= 0.0
+        @test MOI.canmodifyconstraint(m, c1, MOI.GreaterThan(100.0))
         MOI.modifyconstraint!(m, c1, MOI.GreaterThan(100.0))
         MOI.optimize!(m)
         @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
@@ -500,6 +506,7 @@ function linear4test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # Min  x - y
         # s.t. 100.0 <= x
         #               y <= -100.0
+        @test MOI.canmodifyconstraint(m, c2, MOI.LessThan(-100.0))
         MOI.modifyconstraint!(m, c2, MOI.LessThan(-100.0))
         MOI.optimize!(m)
         @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
@@ -580,7 +587,7 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         #
         #   solution: x = 2, y = 0, objv = 2
 
-
+        @test MOI.canmodifyconstraint(m, c1, MOI.ScalarCoefficientChange(y, 3.0))
         MOI.modifyconstraint!(m, c1, MOI.ScalarCoefficientChange(y, 3.0))
         MOI.optimize!(m)
 
@@ -603,8 +610,9 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         #        x >= 0, y >= 0
         #
         #   solution: x = 4, y = 0, objv = 4
-
+        @test MOI.candelete(m, c1)
         MOI.delete!(m, c1)
+
         MOI.optimize!(m)
 
         @test MOI.cangetattribute(m, MOI.TerminationStatus())
@@ -626,8 +634,9 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         #           y >= 0
         #
         #   solution: y = 2, objv = 2
-
+        @test MOI.candelete(m, x)
         MOI.delete!(m, x)
+        
         MOI.optimize!(m)
 
         @test MOI.cangetattribute(m, MOI.TerminationStatus())
@@ -676,6 +685,7 @@ function linear6test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # Min  x - y
         # s.t. 100.0 <= x
         #               y <= 0.0
+        @test MOI.canmodifyconstraint(m, c1, MOI.GreaterThan(100.0))
         MOI.modifyconstraint!(m, c1, MOI.GreaterThan(100.0))
         MOI.optimize!(m)
         @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
@@ -688,6 +698,7 @@ function linear6test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # Min  x - y
         # s.t. 100.0 <= x
         #               y <= -100.0
+        @test MOI.canmodifyconstraint(m, c2, MOI.LessThan(-100.0))
         MOI.modifyconstraint!(m, c2, MOI.LessThan(-100.0))
         MOI.optimize!(m)
         @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
@@ -731,6 +742,7 @@ function linear7test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # Min  x - y
         # s.t. 100.0 <= x
         #               y <= 0.0
+        @test MOI.canmodifyconstraint(m, c1, MOI.VectorConstantChange([-100.0]))
         MOI.modifyconstraint!(m, c1, MOI.VectorConstantChange([-100.0]))
         MOI.optimize!(m)
         @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
@@ -743,6 +755,7 @@ function linear7test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # Min  x - y
         # s.t. 100.0 <= x
         #               y <= -100.0
+        @test MOI.canmodifyconstraint(m, c2, MOI.VectorConstantChange([100.0]))
         MOI.modifyconstraint!(m, c2, MOI.VectorConstantChange([100.0]))
         MOI.optimize!(m)
         @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
@@ -970,6 +983,7 @@ function linear10test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64)
             @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
         end
 
+        @test MOI.canmodifyconstraint(m, c, MOI.Interval(2.0, 12.0))
         MOI.modifyconstraint!(m, c, MOI.Interval(2.0, 12.0))
         MOI.optimize!(m)
 

--- a/test/intlinear.jl
+++ b/test/intlinear.jl
@@ -153,7 +153,9 @@ function int2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
 
                 @test MOI.cangetattribute(m, MOI.DualStatus()) == false
 
+                @test MOI.candelete(m, c1)
                 MOI.delete!(m, c1)
+                @test MOI.candelete(m, c2)
                 MOI.delete!(m, c2)
 
                 MOI.optimize!(m)
@@ -250,6 +252,7 @@ function int2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
                 @test MOI.cangetattribute(m, MOI.DualStatus()) == false
 
                 for cref in bin_constraints
+                    @test MOI.candelete(m, cref)
                     MOI.delete!(m, cref)
                 end
 


### PR DESCRIPTION
So far only added to contlinear and intlinear. There should be more modification tests in conic and quadratic...

I also reverted https://github.com/JuliaOpt/MathOptInterface.jl/pull/121 to default to the boolean `false` rather than throw an error which seems like the better thing to do.