### PR TITLE
Update abstraction to make room for standalone instances

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -54,15 +54,17 @@ In a future version, MOI could be extended to cover functions defined by evaluat
 MOI defines some commonly used sets, but the interface is extensible to other sets recognized by the solver.
 [Describe currently supported sets.]
 
-## Solvers and solver instances, and standalone instances
+## Instances and solvers
 
-MOI defines three high-level objects that most users will interact with.
+An **Instance** ([`AbstractInstance`](@ref MathOptInterface.AbstractInstance)) is a representation of a concrete instance of an optimization problem, i.e., with all data specified.  Instances are either **standalone instances** or **solver instances**:
 
-- A **Solver Instance** should be understood as the representation of an instance of an optimization problem *loaded in the solver's API*. That is, the instance data is often (i.e., whenever possible) stored exclusively in the external API, not duplicated in the MOI translation layer (called the *MOI wrapper*). Hence, the ability to modify data in a solver instance depends on whether the solver's own API supports such modifications. [`AbstractSolverInstance`](@ref MathOptInterface.AbstractSolverInstance) is the abstract type for solver instances.
+- A **Standalone Instance** ([`AbstractStandaloneInstance`](@ref MathOptInterface.AbstractSolverInstance)) is unattached to any particular solver. It is simply a type that stores the data for an instance, which may be used for reading or writing optimization problems to files or manipulating a problem before providing it to a solver. The [MathOptInterfaceUtilities](https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl) package provides an implementation of a standalone instance.
 
-- A **Solver** is a "factory" used to specify solver-specific parameters (e.g., algorithmic parameters, license keys, etc.) and create new solver instances. These are typically very lightweight objects. [`AbstractSolver`](@ref MathOptInterface.AbstractSolver) is the abstract type for solvers.
+- A **Solver Instance** ([`AbstractSolverInstance`](@ref MathOptInterface.AbstractSolverInstance)) should be understood as the representation of an instance of an optimization problem *loaded in the solver's API*. That is, the instance data is often (i.e., whenever possible) stored exclusively in the external API, not duplicated in the MOI translation layer (called the *MOI wrapper*). Hence, the ability to modify data in a solver instance depends on whether the solver's own API supports such modifications.
 
-- A **Standalone Instance** is an explicit representation of an instance of an optimization problem unattached to any particular solver. The [MathOptInterfaceUtilities](https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl) package provides an implementation of a standalone instance type which implements the MOI interface for setting up a problem and adding variables and constraints, but does not implement any methods related to solving it or querying the solution. There is no abstract base type for standalone instances.
+Instances share a common API for constructing the problem and querying its data. Solver instances, additionally, provide methods to solve the attached instance and query the results.
+
+A **Solver** ([`AbstractSolver`](@ref MathOptInterface.AbstractSolver)) is a "factory" used to specify solver-specific parameters (e.g., algorithmic parameters, license keys, etc.) and create new solver instances. These are typically very lightweight objects.
 
 Through the rest of the manual, `m` is used as a generic solver instance.
 
@@ -79,7 +81,7 @@ v2 = addvariables!(m, 3)
 setattribute!(m, VariablePrimalStart(), v2, [1.3,6.8,-4.6])
 ```
 
-A variable can be deleted from a model with [`delete!(::AbstractSolverInstance, ::VariableReference)`](@ref MathOptInterface.delete!(::MathOptInterface.AbstractSolverInstance, ::MathOptInterface.AnyReference)), if this functionality is supported by the solver.
+A variable can be deleted from an instance with [`delete!(::AbstractInstance, ::VariableReference)`](@ref MathOptInterface.delete!(::MathOptInterface.AbstractInstance, ::MathOptInterface.AnyReference)), if this functionality is supported.
 
 ## Functions
 

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -12,6 +12,7 @@ List of attribute categories.
 
 ```@docs
 AbstractSolverAttribute
+AbstractInstanceAttribute
 AbstractSolverInstanceAttribute
 AbstractVariableAttribute
 AbstractConstraintAttribute
@@ -45,11 +46,28 @@ SupportsAddVariableAfterSolve
 SupportsConicThroughQuadratic
 ```
 
-## Solver Instance
+## Instance
 
 ```@docs
+AbstractInstance
+AbstractStandaloneInstance
 AbstractSolverInstance
 ```
+
+List of instance attributes
+
+```@docs
+ObjectiveSense
+NumberOfVariables
+ListOfVariableReferences
+ListOfConstraints
+NumberOfConstraints
+ListOfConstraintReferences
+```
+
+There are no attributes specific to a standalone instance.
+
+## Solver instance
 
 ```@docs
 SolverInstance
@@ -59,14 +77,9 @@ free!
 
 List of solver instance attributes
 
+
 ```@docs
 RawSolver
-ObjectiveSense
-NumberOfVariables
-ListOfVariableReferences
-ListOfConstraints
-NumberOfConstraints
-ListOfConstraintReferences
 ResultCount
 ObjectiveFunction
 ObjectiveValue

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -11,11 +11,31 @@ It does not store any solver instance data.
 abstract type AbstractSolver end
 
 """
+    AbstractInstance
+
+Abstract supertype for objects representing an instance of an optimization problem.
+"""
+abstract type AbstractInstance end
+
+"""
+    AbstractStandaloneInstance
+
+Abstract supertype for objects representing an instance of an optimization problem
+unattached to any particular solver. Does not have methods for solving
+or querying results.
+"""
+abstract type AbstractStandaloneInstance <: AbstractInstance end
+
+
+"""
     AbstractSolverInstance
 
-Abstract supertype which represents a solver's in-memory representation of an optimization problem.
+Abstract supertype for objects representing an instance of an optimization problem
+tied to a particular solver. This is typically a solver's in-memory representation.
+In addition to `AbstractInstance`, `AbstractSolverInstance` objects let you
+solve the instance and query the solution.
 """
-abstract type AbstractSolverInstance end
+abstract type AbstractSolverInstance <: AbstractInstance end
 
 """
     SolverInstance(solver::AbstractSolver)
@@ -42,10 +62,10 @@ Users must discard the solver instance object after this method is invoked.
 function free! end
 
 """
-    writeproblem(m::AbstractSolverInstance, filename::String)
+    writeproblem(m::AbstractInstance, filename::String)
 
 Writes the current problem data to the given file.
-Supported file types are solver-dependent.
+Supported file types depend on the solver or standalone instance type.
 """
 function writeproblem end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -262,7 +262,7 @@ struct ListOfVariableReferences <: AbstractInstanceAttribute end
 A `Vector{ConstraintReferences{F,S}}` with references to all constraints of
 type `F`-in`S` in the instance (i.e., of length equal to the value of `NumberOfConstraints{F,S}()`).
 """
-struct ListOfConstraintReferences{F,S} <: AbstractSolverInstanceAttribute end
+struct ListOfConstraintReferences{F,S} <: AbstractInstanceAttribute end
 
 """
     NumberOfConstraints{F,S}()

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -8,23 +8,31 @@ Abstract supertype for attribute objects that can be used to set or get attribut
 abstract type AbstractSolverAttribute end
 
 """
+    AbstractInstanceAttribute
+
+Abstract supertype for attribute objects that can be used to set or get attributes (properties) of the instance.
+"""
+abstract type AbstractInstanceAttribute end
+
+"""
     AbstractSolverInstanceAttribute
 
 Abstract supertype for attribute objects that can be used to set or get attributes (properties) of the solver instance.
+These attributes do not apply to standalone instances.
 """
-abstract type AbstractSolverInstanceAttribute end
+abstract type AbstractSolverInstanceAttribute <: AbstractInstanceAttribute end
 
 """
     AbstractVariableAttribute
 
-Abstract supertype for attribute objects that can be used to set or get attributes (properties) of variables in the solver instance.
+Abstract supertype for attribute objects that can be used to set or get attributes (properties) of variables in the instance.
 """
 abstract type AbstractVariableAttribute end
 
 """
     AbstractConstraintAttribute
 
-Abstract supertype for attribute objects that can be used to set or get attributes (properties) of constraints in the solver instance.
+Abstract supertype for attribute objects that can be used to set or get attributes (properties) of constraints in the instance.
 """
 abstract type AbstractConstraintAttribute end
 
@@ -35,25 +43,29 @@ const AnyAttribute = Union{AbstractSolverAttribute, AbstractSolverInstanceAttrib
 
 Return an attribute `attr` of the solver `s`.
 
+    getattribute(m::AbstractInstance, attr::AbstractInstanceAttribute)
+
+Return an attribute `attr` of the instance `m`.
+
     getattribute(m::AbstractSolverInstance, attr::AbstractSolverInstanceAttribute)
 
 Return an attribute `attr` of the solver instance `m`.
 
-    getattribute(m::AbstractSolverInstance, attr::AbstractVariableAttribute, v::VariableReference)
+    getattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference)
 
-Return an attribute `attr` of the variable `v` in solver instance `m`.
+Return an attribute `attr` of the variable `v` in instance `m`.
 
-    getattribute(m::AbstractSolverInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})
+    getattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})
 
-Return a vector of attributes corresponding to each variable in the collection `v` in the solver instance `m`.
+Return a vector of attributes corresponding to each variable in the collection `v` in the instance `m`.
 
-    getattribute(m::AbstractSolverInstance, attr::AbstractConstraintAttribute, c::ConstraintReference)
+    getattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference)
 
-Return an attribute `attr` of the constraint `c` in solver instance `m`.
+Return an attribute `attr` of the constraint `c` in instance `m`.
 
-    getattribute(m::AbstractSolverInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})
+    getattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})
 
-Return a vector of attributes corresponding to each constraint in the collection `c` in the solver instance `m`.
+Return a vector of attributes corresponding to each constraint in the collection `c` in the instance `m`.
 
 ### Examples
 
@@ -71,7 +83,7 @@ function getattribute(m, attr::AnyAttribute, args...)
 end
 
 """
-    getattribute!(output, m::AbstractSolverInstance, args...)
+    getattribute!(output, m::AbstractInstance, args...)
 
 An in-place version of `getattribute`.
 The signature matches that of `getattribute` except that the the result is placed in the vector `output`.
@@ -86,15 +98,15 @@ end
 
 Return a `Bool` indicating whether it is possible to query attribute `attr` from the solver `s`.
 
-    cangetattribute(m::AbstractSolverInstance, attr::AbstractVariableAttribute, v::VariableReference)::Bool
-    cangetattribute(m::AbstractSolverInstance, attr::AbstractConstraintAttribute, c::ConstraintReference{F,S})::Bool
+    cangetattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference)::Bool
+    cangetattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference{F,S})::Bool
 
-Return a `Bool` indicating whether the solver instance `m` currently has a value for the attributed specified by attribute type `attr` applied to the variable reference `v` or constraint reference `c`.
+Return a `Bool` indicating whether the instance `m` currently has a value for the attributed specified by attribute type `attr` applied to the variable reference `v` or constraint reference `c`.
 
-    cangetattribute(m::AbstractSolverInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})::Bool
-    cangetattribute(m::AbstractSolverInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})::Bool
+    cangetattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})::Bool
+    cangetattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})::Bool
 
-Return a `Bool` indicating whether the solver instance `m` currently has a value for the attributed specified by attribute type `attr` applied to *every* variable references in `v` or constraint reference in `c`.
+Return a `Bool` indicating whether the instance `m` currently has a value for the attributed specified by attribute type `attr` applied to *every* variable references in `v` or constraint reference in `c`.
 
 ### Examples
 
@@ -106,24 +118,24 @@ cangetattribute(m, VariablePrimal(), [ref1, ref2])
 ```
 """
 function cangetattribute end
-cangetattribute(m::AbstractSolverInstance, attr::AnyAttribute) = false
-cangetattribute(m::AbstractSolverInstance, attr::AnyAttribute, ref::AnyReference) = false
-cangetattribute(m::AbstractSolverInstance, attr::AnyAttribute, refs::Vector{<:AnyReference}) = false
+cangetattribute(m::AbstractInstance, attr::AnyAttribute) = false
+cangetattribute(m::AbstractInstance, attr::AnyAttribute, ref::AnyReference) = false
+cangetattribute(m::AbstractInstance, attr::AnyAttribute, refs::Vector{<:AnyReference}) = false
 
 """
     cansetattribute(s::AbstractSolver, attr::AbstractSolverAttribute)::Bool
 
 Return a `Bool` indicating whether it is possible to set attribute `attr` in the solver `s`.
 
-    cansetattribute(m::AbstractSolverInstance, attr::AbstractVariableAttribute, R::Type{VariableReference})::Bool
-    cangetattribute(m::AbstractSolverInstance, attr::AbstractConstraintAttribute, R::Type{ConstraintReference{F,S})::Bool
+    cansetattribute(m::AbstractInstance, attr::AbstractVariableAttribute, R::Type{VariableReference})::Bool
+    cangetattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, R::Type{ConstraintReference{F,S})::Bool
 
-Return a `Bool` indicating whether it is possible to set attribute `attr` applied to the reference type `R` in the solver instance `m`.
+Return a `Bool` indicating whether it is possible to set attribute `attr` applied to the reference type `R` in the instance `m`.
 
-    cansetattribute(m::AbstractSolverInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})::Bool
-    cansetattribute(m::AbstractSolverInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})::Bool
+    cansetattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})::Bool
+    cansetattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})::Bool
 
-Return a `Bool` indicating whether it is possible to set attribute `attr`applied to *every* variable reference in `v` or constraint reference in `c` in the solver instance `m`.
+Return a `Bool` indicating whether it is possible to set attribute `attr`applied to *every* variable reference in `v` or constraint reference in `c` in the instance `m`.
 
 ### Examples
 
@@ -134,34 +146,34 @@ cansetattribute(m, ConstraintPrimal(), ConstraintReference{VectorAffineFunction{
 ```
 """
 function cansetattribute end
-cansetattribute(m::AbstractSolverInstance, attr::AnyAttribute) = false
-cansetattribute(m::AbstractSolverInstance, attr::AnyAttribute, ref::AnyReference) = false
-cansetattribute(m::AbstractSolverInstance, attr::AnyAttribute, refs::Vector{<:AnyReference}) = false
+cansetattribute(m::AbstractInstance, attr::AnyAttribute) = false
+cansetattribute(m::AbstractInstance, attr::AnyAttribute, ref::AnyReference) = false
+cansetattribute(m::AbstractInstance, attr::AnyAttribute, refs::Vector{<:AnyReference}) = false
 
 """
     setattribute!(s::AbstractSolver, attr::AbstractSolverAttribute, value)
 
 Assign `value` to the attribute `attr` of the solver `s`.
 
-    setattribute!(m::AbstractSolverInstance, attr::AbstractSolverInstanceAttribute, value)
+    setattribute!(m::AbstractInstance, attr::AbstractInstanceAttribute, value)
 
-Assign `value` to the attribute `attr` of the solver instance `m`.
+Assign `value` to the attribute `attr` of the instance `m`.
 
-    setattribute!(m::AbstractSolverInstance, attr::AbstractVariableAttribute, v::VariableReference, value)
+    setattribute!(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference, value)
 
-Assign `value` to the attribute `attr` of variable `v` in solver instance `m`.
+Assign `value` to the attribute `attr` of variable `v` in instance `m`.
 
-    setattribute!(m::AbstractSolverInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference}, vector_of_values)
+    setattribute!(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference}, vector_of_values)
 
-Assign a value respectively to the attribute `attr` of each variable in the collection `v` in solver instance `m`.
+Assign a value respectively to the attribute `attr` of each variable in the collection `v` in instance `m`.
 
-    setattribute!(m::AbstractSolverInstance, attr::AbstractConstraintAttribute, c::ConstraintReference, value)
+    setattribute!(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference, value)
 
-Assign a value to the attribute `attr` of constraint `c` in solver instance `m`.
+Assign a value to the attribute `attr` of constraint `c` in instance `m`.
 
-    setattribute!(m::AbstractSolverInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})
+    setattribute!(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})
 
-Assign a value respectively to the attribute `attr` of each constraint in the collection `c` in solver instance `m`.
+Assign a value respectively to the attribute `attr` of each constraint in the collection `c` in instance `m`.
 """
 function setattribute! end
 function setattribute!(m, attr::AnyAttribute, args...)
@@ -218,6 +230,64 @@ A `Bool` indicating if the solver interprets certain quadratic constraints as se
 """
 struct SupportsConicThroughQuadratic <: AbstractSolverAttribute end
 
+## Instance attributes
+
+"""
+    ObjectiveSense()
+
+The sense of the objective function, an `OptimizationSense` with value `MinSense`, `MaxSense`, or `FeasiblitySense`.
+"""
+struct ObjectiveSense <: AbstractInstanceAttribute end
+
+@enum OptimizationSense MinSense MaxSense FeasibilitySense
+
+"""
+    NumberOfVariables()
+
+The number of variables in the instance.
+"""
+struct NumberOfVariables <: AbstractInstanceAttribute end
+
+"""
+    ListOfVariableReferences()
+
+A `Vector{VariableReference}` with references to all variables present
+in the instance (i.e., of length equal to the value of `NumberOfVariables()`).
+"""
+struct ListOfVariableReferences <: AbstractInstanceAttribute end
+
+"""
+    ListOfConstraintReferences{F,S}()
+
+A `Vector{ConstraintReferences{F,S}}` with references to all constraints of
+type `F`-in`S` in the instance (i.e., of length equal to the value of `NumberOfConstraints{F,S}()`).
+"""
+struct ListOfConstraintReferences{F,S} <: AbstractSolverInstanceAttribute end
+
+"""
+    NumberOfConstraints{F,S}()
+
+The number of constraints of the type `F`-in-`S` present in the instance.
+"""
+struct NumberOfConstraints{F,S} <: AbstractInstanceAttribute end
+
+"""
+    ListOfConstraints()
+
+A list of tuples of the form `(F,S)`, where `F` is a function type
+and `S` is a set type indicating that the attribute `NumberOfConstraints{F,S}()`
+has value greater than zero.
+"""
+struct ListOfConstraints <: AbstractInstanceAttribute end
+
+"""
+    ObjectiveFunction()
+
+An `AbstractFunction` instance which represents the objective function.
+It is guaranteed to be equivalent but not necessarily identical to the function provided by the user.
+"""
+struct ObjectiveFunction <: AbstractInstanceAttribute end
+
 ## Solver instance attributes
 
 """
@@ -250,15 +320,6 @@ struct RelativeGap <: AbstractSolverInstanceAttribute  end
 The total elapsed solution time (in seconds) as reported by the solver.
 """
 struct SolveTime <: AbstractSolverInstanceAttribute end
-
-"""
-    ObjectiveSense()
-
-The sense of the objective function, an `OptimizationSense` with value `MinSense`, `MaxSense`, or `FeasiblitySense`.
-"""
-struct ObjectiveSense <: AbstractSolverInstanceAttribute end
-
-@enum OptimizationSense MinSense MaxSense FeasibilitySense
 
 """
     SimplexIterations()
@@ -296,52 +357,6 @@ The number of results available.
 """
 struct ResultCount <: AbstractSolverInstanceAttribute end
 
-"""
-    NumberOfVariables()
-
-The number of variables in the solver instance.
-"""
-struct NumberOfVariables <: AbstractSolverInstanceAttribute end
-
-"""
-    ListOfVariableReferences()
-
-A `Vector{VariableReference}` with references to all variables present
-in the solver instance (i.e., of length equal to the value of `NumberOfVariables()`).
-"""
-struct ListOfVariableReferences <: AbstractSolverInstanceAttribute end
-
-"""
-    ListOfConstraintReferences{F,S}()
-
-A `Vector{ConstraintReferences{F,S}}` with references to all constraints of
-type `F`-in`S` in the solver instance (i.e., of length equal to the value of `NumberOfConstraints{F,S}()`).
-"""
-struct ListOfConstraintReferences{F,S} <: AbstractSolverInstanceAttribute end
-
-"""
-    NumberOfConstraints{F,S}()
-
-The number of constraints of the type `F`-in-`S` present in the solver instance.
-"""
-struct NumberOfConstraints{F,S} <: AbstractSolverInstanceAttribute end
-
-"""
-    ListOfConstraints()
-
-A list of tuples of the form `(F,S)`, where `F` is a function type
-and `S` is a set type indicating that the attribute `NumberOfConstraints{F,S}()`
-has value greater than zero.
-"""
-struct ListOfConstraints <: AbstractSolverInstanceAttribute end
-
-"""
-    ObjectiveFunction()
-
-An `AbstractFunction` instance which represents the objective function.
-It is guaranteed to be equivalent but not necessarily identical to the function provided by the user.
-"""
-struct ObjectiveFunction <: AbstractSolverInstanceAttribute end
 ## Variable attributes
 
 """

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,23 +1,23 @@
 # Constraints
 
 """
-    addconstraint!(m::AbstractSolverInstance, func::F, set::S)::ConstraintReference{F,S} where {F,S}
+    addconstraint!(m::AbstractInstance, func::F, set::S)::ConstraintReference{F,S} where {F,S}
 
 Add the constraint ``f(x) \\in \\mathcal{S}`` where ``f`` is defined by `func`, and ``\\mathcal{S}`` is defined by `set`.
 
-    addconstraint!(m::AbstractSolverInstance, v::VariableReference, set::S)::ConstraintReference{SingleVariable,S} where {S}
-    addconstraint!(m::AbstractSolverInstance, vec::Vector{VariableReference}, set::S)::ConstraintReference{VectorOfVariables,S} where {S}
+    addconstraint!(m::AbstractInstance, v::VariableReference, set::S)::ConstraintReference{SingleVariable,S} where {S}
+    addconstraint!(m::AbstractInstance, vec::Vector{VariableReference}, set::S)::ConstraintReference{VectorOfVariables,S} where {S}
 
 Add the constraint ``v \\in \\mathcal{S}`` where ``v`` is the variable (or vector of variables) referenced by `v` and ``\\mathcal{S}`` is defined by `set`.
 """
 function addconstraint! end
 
-# fallbacks
-addconstraint!(m::AbstractSolverInstance, v::VariableReference, set) = addconstraint!(m, SingleVariable(v), set)
-addconstraint!(m::AbstractSolverInstance, v::Vector{VariableReference}, set) = addconstraint!(m, VectorOfVariables(v), set)
+# convenient shorthands TODO: document
+addconstraint!(m::AbstractInstance, v::VariableReference, set) = addconstraint!(m, SingleVariable(v), set)
+addconstraint!(m::AbstractInstance, v::Vector{VariableReference}, set) = addconstraint!(m, VectorOfVariables(v), set)
 
 """
-    addconstraints!(m::AbstractSolverInstance, funcs::Vector{F}, sets::Vector{S})::Vector{ConstraintReference{F,S}} where {F,S}
+    addconstraints!(m::AbstractInstance, funcs::Vector{F}, sets::Vector{S})::Vector{ConstraintReference{F,S}} where {F,S}
 
 Add the set of constraints specified by each function-set pair in `funcs` and `sets`. `F` and `S` should be concrete types.
 This call is equivalent to `addconstraint!.(m, funcs, sets)` but may be more efficient.
@@ -25,12 +25,12 @@ This call is equivalent to `addconstraint!.(m, funcs, sets)` but may be more eff
 function addconstraints! end
 
 # default fallback
-addconstraints!(m::AbstractSolverInstance, funcs, sets) = addconstraint!.(m, funcs, sets)
+addconstraints!(m::AbstractInstance, funcs, sets) = addconstraint!.(m, funcs, sets)
 
 """
 ## Modify Function
 
-    canmodifyconstraint(m::AbstractSolverInstance, c::ConstraintReference{F,S}, func::F)::Bool
+    canmodifyconstraint(m::AbstractInstance, c::ConstraintReference{F,S}, func::F)::Bool
 
 Return a `Bool` indicating whether it is possible to replace the function in constraint `c` with `func`. `F` must match the original function type used to define the constraint.
 
@@ -45,7 +45,7 @@ canmodifyconstraint(m, c, SingleVariable(v1)) # false
 
 ## Modify Set
 
-    canmodifyconstraint(m::AbstractSolverInstance, c::ConstraintReference{F,S}, set::S)::Bool
+    canmodifyconstraint(m::AbstractInstance, c::ConstraintReference{F,S}, set::S)::Bool
 
 Return a `Bool` indicating whether it is possible to change the set of constraint `c` to the new set `set` which should be of the same type as the original set.
 
@@ -60,7 +60,7 @@ canmodifyconstraint(m, c, NonPositives) # false
 
 ## Partial Modifications
 
-    canmodifyconstraint(m::AbstractSolverInstance, c::ConstraintReference, change::AbstractFunctionModification)::Bool
+    canmodifyconstraint(m::AbstractInstance, c::ConstraintReference, change::AbstractFunctionModification)::Bool
 
 Return a `Bool` indicating whether it is possible to apply the modification specified by `change` to the function of constraint `c`.
 
@@ -71,12 +71,12 @@ canmodifyconstraint(m, c, ScalarConstantChange(10.0))
 ```
 """
 function canmodifyconstraint end
-canmodifyconstraint(m::AbstractSolverInstance, c::ConstraintReference, change) = false
+canmodifyconstraint(m::AbstractInstance, c::ConstraintReference, change) = false
 
 """
 ## Modify Function
 
-    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference{F,S}, func::F)
+    modifyconstraint!(m::AbstractInstance, c::ConstraintReference{F,S}, func::F)
 
 Replace the function in constraint `c` with `func`. `F` must match the original function type used to define the constraint.
 
@@ -91,7 +91,7 @@ modifyconstraint!(m, c, SingleVariable(v1)) # Error
 
 ## Modify Set
 
-    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference{F,S}, set::S)
+    modifyconstraint!(m::AbstractInstance, c::ConstraintReference{F,S}, set::S)
 
 Change the set of constraint `c` to the new set `set` which should be of the same type as the original set.
 
@@ -106,7 +106,7 @@ modifyconstraint!(m, c, NonPositives) # Error
 
 ## Partial Modifications
 
-    modifyconstraint!(m::AbstractSolverInstance, c::ConstraintReference, change::AbstractFunctionModification)
+    modifyconstraint!(m::AbstractInstance, c::ConstraintReference, change::AbstractFunctionModification)
 
 Apply the modification specified by `change` to the function of constraint `c`.
 
@@ -122,7 +122,7 @@ function modifyconstraint! end
 """
 ## Transform Constraint Set
 
-    transformconstraint!(m::AbstractSolverInstance, c::ConstraintReference{F,S1}, newset::S2)::ConstraintReference{F,S2}
+    transformconstraint!(m::AbstractInstance, c::ConstraintReference{F,S1}, newset::S2)::ConstraintReference{F,S2}
 
 Replace the set in constraint `c` with `newset`. The constraint reference `c`
 will no longer be valid, and the function returns a new constraint reference.
@@ -147,7 +147,7 @@ transformconstraint!(m, c, LessThan(0.0)) # errors
 function transformconstraint! end
 
 # default fallback
-function transformconstraint!(m::AbstractSolverInstance, c::ConstraintReference, newset)
+function transformconstraint!(m::AbstractInstance, c::ConstraintReference, newset)
     f = getattribute(m, ConstraintFunction(), c)
     delete!(m, c)
     addconstraint!(m, f, newset)
@@ -156,7 +156,7 @@ end
 """
 ## Transform Constraint Set
 
-    cantransformconstraint(m::AbstractSolverInstance, c::ConstraintReference{F,S1}, newset::S2)::Bool
+    cantransformconstraint(m::AbstractInstance, c::ConstraintReference{F,S1}, newset::S2)::Bool
 
 Return a `Bool` is the set in constraint `c` can be replaced with `newset`.
 
@@ -172,7 +172,7 @@ cantransformconstraint(m, c, ZeroOne())        # false
 function cantransformconstraint end
 
 # default fallback
-function cantransformconstraint(m::AbstractSolverInstance, c::ConstraintReference, newset)
+function cantransformconstraint(m::AbstractInstance, c::ConstraintReference, newset)
     # TODO: add "&& canaddconstraint(m, getattribute(m, ConstraintFunction(), c), newset)"
     #       when candaddconstraint is defined
     cangetattribute(m, ConstraintFunction(), c) && candelete(m, c)

--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -1,14 +1,14 @@
 # Objectives
 
 """
-    setobjective!(m::AbstractSolverInstance, sense::OptimizationSense, func::F)
+    setobjective!(m::AbstractInstance, sense::OptimizationSense, func::F)
 
-Set the objective function in the solver instance `m` to be ``f(x)`` where ``f`` is a function specified by `func` with the objective sense (`MinSense` or `MaxSense`) specified by `sense`.
+Set the objective function in the instance `m` to be ``f(x)`` where ``f`` is a function specified by `func` with the objective sense (`MinSense` or `MaxSense`) specified by `sense`.
 """
 function setobjective! end
 
 """
-    modifyobjective!(m::AbstractSolverInstance, change::AbstractFunctionModification)
+    modifyobjective!(m::AbstractInstance, change::AbstractFunctionModification)
 
 Apply the modification specified by `change` to the objective function of `m`.
 To change the function completely, call `setobjective!` instead.
@@ -22,7 +22,7 @@ modifyobjective!(m, ScalarConstantChange(10.0))
 function modifyobjective! end
 
 """
-    canmodifyobjective(m::AbstractSolverInstance, change::AbstractFunctionModification)::Bool
+    canmodifyobjective(m::AbstractInstance, change::AbstractFunctionModification)::Bool
 
 Return a `Bool` indicating whether it is possible to apply the modification
 specified by `change` to the objective function of `m`.

--- a/src/references.jl
+++ b/src/references.jl
@@ -3,7 +3,7 @@
 """
     ConstraintReference{F,S}
 
-A lightweight object used to reference `F`-in-`S` constraints in a solver instance.
+A lightweight object used to reference `F`-in-`S` constraints in an instance.
 The parameter `F` is the type of the function in the constraint, and the parameter `S` is the type of set in the constraint.
 """
 struct ConstraintReference{F,S}
@@ -13,7 +13,7 @@ end
 """
     VariableReference
 
-A lightweight object used to reference variables in a solver instance.
+A lightweight object used to reference variables in an instance.
 """
 struct VariableReference
     value::UInt64
@@ -22,28 +22,28 @@ end
 const AnyReference = Union{ConstraintReference,VariableReference}
 
 """
-    candelete(m::AbstractSolverInstance, ref::AnyReference)::Bool
+    candelete(m::AbstractInstance, ref::AnyReference)::Bool
 
-Return a `Bool` indicating whether the object referred to by `ref` can be removed from the solver instance `m`.
+Return a `Bool` indicating whether the object referred to by `ref` can be removed from the instance `m`.
 """
-candelete(m::AbstractSolverInstance, ref::AnyReference) = false
-
-"""
-    isvalid(m::AbstractSolverInstance, ref::AnyReference)::Bool
-
-Return a `Bool` indicating whether this reference refers to a valid object in the solver instance `m`.
-"""
-isvalid(m::AbstractSolverInstance, ref::AnyReference) = false
+candelete(m::AbstractInstance, ref::AnyReference) = false
 
 """
-    delete!(m::AbstractSolverInstance, ref::AnyReference)
+    isvalid(m::AbstractInstance, ref::AnyReference)::Bool
 
-Delete the referenced object from the solver instance.
+Return a `Bool` indicating whether this reference refers to a valid object in the instance `m`.
+"""
+isvalid(m::AbstractInstance, ref::AnyReference) = false
 
-    delete!{R}(m::AbstractSolverInstance, refs::Vector{R<:AnyReference})
+"""
+    delete!(m::AbstractInstance, ref::AnyReference)
 
-Delete the referenced objects in the vector `refs` from the solver instance.
+Delete the referenced object from the instance.
+
+    delete!{R}(m::AbstractInstance, refs::Vector{R<:AnyReference})
+
+Delete the referenced objects in the vector `refs` from the instance.
 It may be assumed that `R` is a concrete type.
 """
-Base.delete!(m::AbstractSolverInstance, ref::AnyReference) = throw(MethodError(Base.delete!, (m, ref)))
-Base.delete!(m::AbstractSolverInstance, refs::Vector{<:AnyReference}) = throw(MethodError(Base.delete!, (m, refs)))
+Base.delete!(m::AbstractInstance, ref::AnyReference) = throw(MethodError(Base.delete!, (m, ref)))
+Base.delete!(m::AbstractInstance, refs::Vector{<:AnyReference}) = throw(MethodError(Base.delete!, (m, refs)))

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,15 +1,15 @@
 # Variables
 
 """
-    addvariables!(m::AbstractSolverInstance, n::Int)::Vector{VariableReference}
+    addvariables!(m::AbstractInstance, n::Int)::Vector{VariableReference}
 
-Add `n` scalar variables to the solver instance, returning a vector of variable references.
+Add `n` scalar variables to the instance, returning a vector of variable references.
 """
 function addvariables! end
 
 """
-    addvariable!(m::AbstractSolverInstance)::VariableReference
+    addvariable!(m::AbstractInstance)::VariableReference
 
-Add a scalar variable to the solver instance, returning a variable reference.
+Add a scalar variable to the instance, returning a variable reference.
 """
 function addvariable! end


### PR DESCRIPTION
Following up on https://github.com/JuliaOpt/MathOptInterface.jl/pull/131, this PR updates the type hierarchy to allow for a standalone instance that's not attached to a solver.
- `AbstractSolverInstance` and `AbstractStandaloneInstance` inherit from `AbstractInstance`.
- Attributes are split into `AbstractSolverInstanceAttribute` and `AbstractInstanceAttribute`. There are no attributes specific to a standalone instance.
- No change to variable and constraint attributes, standalone instances can just implement `cangetattribute` appropriately.

I'm heading in the direction of making a simple reader/writer for MOI instances that we can use in JuMP's unit tests to check if JuMP generates the problem correctly. After this PR we can just call these objects standalone instances, as a first-class MOI concept.

Closes #9