### PR TITLE
Proposal: tolerances for constraints

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -179,6 +179,7 @@ ConstraintDual
 ConstraintBasisStatus
 ConstraintFunction
 ConstraintSet
+ConstraintPrimalTolerance
 ```
 
 ## Functions and function modifications

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -476,7 +476,7 @@ Return the `AbstractSet` object used to define the constraint.
 struct ConstraintSet <: AbstractConstraintAttribute end
 
 """
-    PrimalFeasibilityTolerance()
+    ConstraintPrimalTolerance()
 
 For scalar functions `f ∈ S`, this tolerance corresponds to the amount by which
 primal constraint solution can lie outside the set and still be considered
@@ -491,7 +491,7 @@ feasible.
 For sets `SOS1` and `SOS2`, this corresponds to the maximum value that a zero
 element can take and still be considered feasible.
 """
-struct PrimalFeasibilityTolerance  <: AbstractConstraintAttribute end
+struct ConstraintPrimalTolerance  <: AbstractConstraintAttribute end
 
 ## Termination status
 """

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -475,6 +475,24 @@ Return the `AbstractSet` object used to define the constraint.
 """
 struct ConstraintSet <: AbstractConstraintAttribute end
 
+"""
+    PrimalFeasibilityTolerance()
+
+For scalar functions `f ∈ S`, this tolerance corresponds to the amount by which
+primal constraint solution can lie outside the set and still be considered
+feasible.For vector functions, this is applied row-wise.
+
+#### Special Cases
+
+For sets `ZeroOne`, `Integer`, and `Semiinteger`: specify the amount by which an
+integer variable can differ from an integer value and still be considered
+feasible.
+
+For sets `SOS1` and `SOS2`, this corresponds to the maximum value that a zero
+element can take and still be considered feasible.
+"""
+struct PrimalFeasibilityTolerance  <: AbstractConstraintAttribute end
+
 ## Termination status
 """
     TerminationStatus()


### PR DESCRIPTION
The other day @mlubin and I discussed the idea that tolerances and other options should be a component of any model instance with floating point arithmetic. (The discussion was based around what features to include in https://github.com/odow/MathOptFormat.jl)

For example, integrality tolerances
```julia
struct ConstraintPrimalTolerance <: AbstractConstraintAttribute end
c = addconstraint!(m, x, Integer())
setattribute!(m, ConstraintPrimalTolerance(), c, 1e-2)
# would permit
#     x = 1.01
# as feasible
```
and primal feasibility
```julia
c = addconstraint!(m, ScalarAffineFunction([x], [1.0], 1.0), LessThan(1.0))
setattribute!(m, ConstraintPrimalTolerance(), c, 1e-2)
# would permit
#     x =0.01
# as feasible: x + 1 <= 1 ... => ... 1.01 <= 1
```

For things like SOS
```julia
c = addconstraint!(m, VectorOfVariables([x,y,z]), SOS1([1.0, 2.0, 3.0]))
setattribute!(m, ConstraintPrimalTolerance(), c, 1e-2)
# would permit
#     (x, y, z) = (1.0, 0.0, 0.01)
# as feasible
```