### PR TITLE
[RFC] Add coefficienttype function

### DIFF
--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -113,6 +113,13 @@ should be `true` for a second-order cone solver `s`.
 """
 function supportsproblem end
 
+"""
+    coefficienttype(m::AbstractInstance)
+
+Returns the coefficient type used by the solver instance. Defaults to Float64.
+"""
+function coefficienttype(s::AbstractInstance); Float64; end
+
 include("references.jl")
 include("attributes.jl")
 include("functions.jl")

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -114,11 +114,19 @@ should be `true` for a second-order cone solver `s`.
 function supportsproblem end
 
 """
+    coefficienttype(m::AbstractSolver)
+
+Returns the coefficient type used by the solver. Defaults to Float64.
+"""
+function coefficienttype(::AbstractSolver); Float64; end
+
+"""
     coefficienttype(m::AbstractInstance)
 
-Returns the coefficient type used by the solver instance. Defaults to Float64.
+Returns the coefficient type used by the instance. Defaults to Float64.
 """
-function coefficienttype(s::AbstractInstance); Float64; end
+function coefficienttype(::AbstractInstance); Float64; end
+
 
 include("references.jl")
 include("attributes.jl")


### PR DESCRIPTION
This adds a coefficient type function that defaults to `Float64`. (This is used in the pull request https://github.com/JuliaOpt/SemidefiniteOptInterface.jl/pull/3). I hope this is an idiomatic way to add this function. Comments welcome.