### PR TITLE
rename getattribute to get and setattribute! to set!

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -30,7 +30,7 @@ MOI does not export functions, but for brevity we often omit qualifying names wi
 using MathOptInterface
 const MOI = MathOptInterface
 ```
-and prefix all MOI methods with `MOI.` in user code. If a name is also available in base Julia, we always use explicitly use the module prefix, for example, with `MOI.get`.
+and prefix all MOI methods with `MOI.` in user code. If a name is also available in base Julia, we always explicitly use the module prefix, for example, with `MOI.get`.
 
 ## Standard form problem
 

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -25,6 +25,13 @@ MOI is designed to:
 This manual introduces the concepts needed to understand MOI and give a high-level picture of how all of the pieces fit together. The primary focus is on MOI from the perspective of a user of the interface. At the end of the manual we have a section on [Implementing a solver interface](@ref).
 The [API Reference](@ref) page lists the complete API.
 
+MOI does not export functions, but for brevity we often omit qualifying names with the MOI module. Best practice is to have
+```julia
+using MathOptInterface
+const MOI = MathOptInterface
+```
+and prefix all MOI methods with `MOI.` in user code. If a name is also available in base Julia, we always use explicitly use the module prefix, for example, with `MOI.get`.
+
 ## Standard form problem
 
 The standard form problem is:
@@ -76,9 +83,9 @@ New scalar variables are created with [`addvariable!`](@ref MathOptInterface.add
 One uses `VariableReference` objects to set and get variable attributes. For example, the [`VariablePrimalStart`](@ref MathOptInterface.VariablePrimalStart) attribute is used to provide an initial starting point for a variable or collection of variables:
 ```julia
 v = addvariable!(m)
-setattribute!(m, VariablePrimalStart(), v, 10.5)
+set!(m, VariablePrimalStart(), v, 10.5)
 v2 = addvariables!(m, 3)
-setattribute!(m, VariablePrimalStart(), v2, [1.3,6.8,-4.6])
+set!(m, VariablePrimalStart(), v2, [1.3,6.8,-4.6])
 ```
 
 A variable can be deleted from an instance with [`delete!(::AbstractInstance, ::VariableReference)`](@ref MathOptInterface.delete!(::MathOptInterface.AbstractInstance, ::MathOptInterface.AnyReference)), if this functionality is supported.
@@ -111,8 +118,8 @@ The [`ObjectiveSense`](@ref MathOptInterface.ObjectiveSense) attribute is used f
 For example,
 ```julia
 x = addvariables!(m, 2)
-setattribute!(m, ObjectiveFunction(), ScalarAffineFunction([x[1],x[2]],[5.0,-2.3],1.0))
-setattribute!(m, ObjectiveSense(), MinSense)
+set!(m, ObjectiveFunction(), ScalarAffineFunction([x[1],x[2]],[5.0,-2.3],1.0))
+set!(m, ObjectiveSense(), MinSense)
 ```
 sets the objective to the function just discussed in the minimization sense.
 
@@ -145,8 +152,8 @@ The code example below encodes the linear optimization problem:
 
 ```julia
 x = addvariables!(m, 2)
-setattribute!(m, ObjectiveFunction(), ScalarAffineFunction(x, [3.0,2.0], 0.0))
-setattribute!(m, ObjectiveSense(), MaxSense)
+set!(m, ObjectiveFunction(), ScalarAffineFunction(x, [3.0,2.0], 0.0))
+set!(m, ObjectiveSense(), MaxSense)
 addconstraint!(m, ScalarAffineFunction(x, [1.0,1.0], 0.0), LessThan(5.0))
 addconstraint!(m, SingleVariable(x[1]), GreaterThan(0.0))
 addconstraint!(m, SingleVariable(x[2]), GreaterThan(-1.0))
@@ -233,7 +240,7 @@ optimize!(m)
 
 The optimization procedure may terminate for a number of reasons. The [`TerminationStatus`](@ref MathOptInterface.TerminationStatus) attribute of the solver instance returns a [`TerminationStatusCode`](@ref MathOptInterface.TerminationStatusCode) object which explains why the solver stopped. Some statuses indicate generally successful termination, some termination because of limit, and some termination because of something unexpected like invalid problem data or failure to converge. A typical usage of the `TerminationStatus` attribute is as follows:
 ```julia
-status = getattribute(m, TerminationStatus())
+status = MOI.get(m, TerminationStatus())
 if status == Success
     # Ok, the solver has a result to return
 else
@@ -248,7 +255,7 @@ In addition to the primal status, the [`DualStatus`](@ref MathOptInterface.DualS
 
 If a result is available, it may be retrieved with the [`VariablePrimal`](@ref MathOptInterface.VariablePrimal) attribute:
 ```julia
-getattribute(m, VariablePrimal(), x)
+MOI.get(m, VariablePrimal(), x)
 ```
 If `x` is a `VariableRefrence` then the function call returns a scalar, and if `x` is a `Vector{VariableReference}` then the call returns a vector of scalars. `VariablePrimal()` is equivalent to `VariablePrimal(1)`, i.e., the variable primal vector of the first result. Use `VariablePrimal(N)` to access the `N`th result.
 
@@ -304,8 +311,8 @@ function solveknapsack(c::Vector{Float64}, w::Vector{Float64}, C::Float64, solve
     x = addvariables!(m, numvar)
 
     # set the objective function
-    setattribute!(m, ObjectiveFunction(), ScalarAffineFunction(x, c, 0.0))
-    setattribute!(m, ObjectiveSense(), MaxSense)
+    set!(m, ObjectiveFunction(), ScalarAffineFunction(x, c, 0.0))
+    set!(m, ObjectiveSense(), MaxSense)
 
     # add the knapsack constraint
     addconstraint!(m, ScalarAffineFunction(x, w, 0.0), LessThan(C))
@@ -318,19 +325,19 @@ function solveknapsack(c::Vector{Float64}, w::Vector{Float64}, C::Float64, solve
     # all set
     optimize!(m)
 
-    termination_status = getattribute(m, TerminationStatus())
-    objvalue = cangetattribute(m, ObjectiveValue()) ? getattribute(m, ObjectiveValue()) : NaN
+    termination_status = MOI.get(m, TerminationStatus())
+    objvalue = canget(m, ObjectiveValue()) ? MOI.get(m, ObjectiveValue()) : NaN
     if termination_status != Success
         error("Solver terminated with status $termination_status")
     end
 
-    @assert getattribute(m, ResultCount()) > 0
+    @assert MOI.get(m, ResultCount()) > 0
 
-    result_status = getattribute(m, PrimalStatus())
+    result_status = MOI.get(m, PrimalStatus())
     if result_status != FeasiblePoint
         error("Solver ran successfully did not return a feasible point. The problem may be infeasible.")
     end
-    primal_variable_result = getattribute(m, VariablePrimal(), x)
+    primal_variable_result = MOI.get(m, VariablePrimal(), x)
 
     return (objvalue, primal_variable_result)
 end
@@ -386,8 +393,8 @@ function solveintegerlinear(c, Ale::SparseMatrixCSC, ble, Aeq::SparseMatrixCSC, 
     x = addvariables!(m, numvar)
 
     # set the objective function
-    setattribute!(m, ObjectiveFunction(), ScalarAffineFunction(x, c, 0.0))
-    setattribute!(m, ObjectiveSense(), MinSense)
+    set!(m, ObjectiveFunction(), ScalarAffineFunction(x, c, 0.0))
+    set!(m, ObjectiveSense(), MinSense)
 
     # add variable bound constraints
     for i in 1:numvar
@@ -435,13 +442,13 @@ function solveintegerlinear(c, Ale::SparseMatrixCSC, ble, Aeq::SparseMatrixCSC, 
     # all set
     optimize!(m)
 
-    termination_status = getattribute(m, TerminationStatus())
-    objbound = cangetattribute(m, ObjectiveBound()) ? getattribute(m, ObjectiveBound()) : NaN
-    objvalue = cangetattribute(m, ObjectiveValue()) ? getattribute(m, ObjectiveValue()) : NaN
+    termination_status = MOI.get(m, TerminationStatus())
+    objbound = canget(m, ObjectiveBound()) ? MOI.get(m, ObjectiveBound()) : NaN
+    objvalue = canget(m, ObjectiveValue()) ? MOI.get(m, ObjectiveValue()) : NaN
 
-    if getattribute(m, ResultCount()) > 0
-        result_status = getattribute(m, PrimalStatus())
-        primal_variable_result = getattribute(m, VariablePrimal(), x)
+    if MOI.get(m, ResultCount()) > 0
+        result_status = MOI.get(m, PrimalStatus())
+        primal_variable_result = MOI.get(m, VariablePrimal(), x)
         return IntegerLinearResult(termination_status, result_status, primal_variable_result, objvalue, objbound)
     else
         return IntegerLinearResult(termination_status, UnknownResultStatus, Float64[], objvalue, objbound)
@@ -583,7 +590,7 @@ coefficients in existing constraints when adding a new variable, it is possible
 to queue modifications and new variables and then call the solver's API once all of the
 new coefficients are known.
 
-All data passed to the solver should be copied immediately to internal data structures. Solvers may not modify any input vectors and should not assume that input vectors will not be modified by users in the future. This applies, for example, to the coefficient vector in `ScalarAffineFunction`. Vectors returned to the user, e.g., via `ObjectiveFunction` or `ConstraintFunction` attributes should not be modified by the solver afterwards. The in-place version of `getattribute!` can be used by users to avoid extra copies in this case.
+All data passed to the solver should be copied immediately to internal data structures. Solvers may not modify any input vectors and should not assume that input vectors will not be modified by users in the future. This applies, for example, to the coefficient vector in `ScalarAffineFunction`. Vectors returned to the user, e.g., via `ObjectiveFunction` or `ConstraintFunction` attributes should not be modified by the solver afterwards. The in-place version of `get!` can be used by users to avoid extra copies in this case.
 
 Solver wrappers should document how the low-level solver statuses map to the MOI statuses. In particular, the characterization of a result with status `FeasiblePoint` and termination status `Success` is entirely solver defined. It may or may not be a globally optimal solution. Solver wrappers are not responsible for verifying the feasibility of results. Statuses like `NearlyFeasiblePoint`, `InfeasiblePoint`, `NearlyInfeasiblePoint`, and `NearlyReductionCertificate` are designed to be used when the solver explicitly indicates as much.
 

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -21,11 +21,11 @@ AbstractConstraintAttribute
 Functions for getting and setting attributes.
 
 ```@docs
-cangetattribute
-getattribute
-getattribute!
-cansetattribute
-setattribute!
+canget
+get
+get!
+canset
+set!
 ```
 
 ## Solver
@@ -145,7 +145,7 @@ addvariable!
 ```
 
 List of attributes associated with variables. [category AbstractVariableAttribute]
-Calls to `getattribute` and `setattribute!` should include as an argument a single `VariableReference` or a vector of `VariableReference` objects.
+Calls to `get` and `set!` should include as an argument a single `VariableReference` or a vector of `VariableReference` objects.
 
 ```@docs
 VariableName
@@ -170,7 +170,7 @@ cantransformconstraint
 ```
 
 List of attributes associated with constraints. [category AbstractConstraintAttribute]
-Calls to `getattribute` and `setattribute!` should include as an argument a single `ConstraintReference` or a vector of `ConstraintReference{F,S}` objects.
+Calls to `get` and `set!` should include as an argument a single `ConstraintReference` or a vector of `ConstraintReference{F,S}` objects.
 
 ```@docs
 ConstraintName

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -39,144 +39,144 @@ abstract type AbstractConstraintAttribute end
 const AnyAttribute = Union{AbstractSolverAttribute, AbstractSolverInstanceAttribute, AbstractVariableAttribute, AbstractConstraintAttribute}
 
 """
-    getattribute(s::AbstractSolver, attr::AbstractSolverAttribute)
+    get(s::AbstractSolver, attr::AbstractSolverAttribute)
 
 Return an attribute `attr` of the solver `s`.
 
-    getattribute(m::AbstractInstance, attr::AbstractInstanceAttribute)
+    get(m::AbstractInstance, attr::AbstractInstanceAttribute)
 
 Return an attribute `attr` of the instance `m`.
 
-    getattribute(m::AbstractSolverInstance, attr::AbstractSolverInstanceAttribute)
+    get(m::AbstractSolverInstance, attr::AbstractSolverInstanceAttribute)
 
 Return an attribute `attr` of the solver instance `m`.
 
-    getattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference)
+    get(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference)
 
 Return an attribute `attr` of the variable `v` in instance `m`.
 
-    getattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})
+    get(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})
 
 Return a vector of attributes corresponding to each variable in the collection `v` in the instance `m`.
 
-    getattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference)
+    get(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference)
 
 Return an attribute `attr` of the constraint `c` in instance `m`.
 
-    getattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})
+    get(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})
 
 Return a vector of attributes corresponding to each constraint in the collection `c` in the instance `m`.
 
 ### Examples
 
 ```julia
-getattribute(m, ObjectiveValue())
-getattribute(m, VariablePrimal(), ref)
-getattribute(m, VariablePrimal(5), [ref1, ref2])
-getattribute(m, OtherAttribute("something specific to cplex"))
+get(m, ObjectiveValue())
+get(m, VariablePrimal(), ref)
+get(m, VariablePrimal(5), [ref1, ref2])
+get(m, OtherAttribute("something specific to cplex"))
 ```
 """
-function getattribute end
+function get end
 
-function getattribute(m, attr::AnyAttribute, args...)
+function get(m, attr::AnyAttribute, args...)
     throw(ArgumentError("SolverInstance of type $(typeof(m)) does not support accessing the attribute $attr"))
 end
 
 """
-    getattribute!(output, m::AbstractInstance, args...)
+    get!(output, m::AbstractInstance, args...)
 
-An in-place version of `getattribute`.
-The signature matches that of `getattribute` except that the the result is placed in the vector `output`.
+An in-place version of `get`.
+The signature matches that of `get` except that the the result is placed in the vector `output`.
 """
-function getattribute! end
-function getattribute!(output, m, attr::AnyAttribute, args...)
+function get! end
+function get!(output, m, attr::AnyAttribute, args...)
     throw(ArgumentError("SolverInstance of type $(typeof(m)) does not support accessing the attribute $attr"))
 end
 
 """
-    cangetattribute(s::AbstractSolver, attr::AbstractSolverAttribute)::Bool
+    canget(s::AbstractSolver, attr::AbstractSolverAttribute)::Bool
 
 Return a `Bool` indicating whether it is possible to query attribute `attr` from the solver `s`.
 
-    cangetattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference)::Bool
-    cangetattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference{F,S})::Bool
+    canget(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference)::Bool
+    canget(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference{F,S})::Bool
 
 Return a `Bool` indicating whether the instance `m` currently has a value for the attributed specified by attribute type `attr` applied to the variable reference `v` or constraint reference `c`.
 
-    cangetattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})::Bool
-    cangetattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})::Bool
+    canget(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})::Bool
+    canget(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})::Bool
 
 Return a `Bool` indicating whether the instance `m` currently has a value for the attributed specified by attribute type `attr` applied to *every* variable references in `v` or constraint reference in `c`.
 
 ### Examples
 
 ```julia
-cangetattribute(m, ObjectiveValue())
-cangetattribute(m, VariablePrimalStart(), varref)
-cangetattribute(m, ConstraintPrimal(), conref)
-cangetattribute(m, VariablePrimal(), [ref1, ref2])
+canget(m, ObjectiveValue())
+canget(m, VariablePrimalStart(), varref)
+canget(m, ConstraintPrimal(), conref)
+canget(m, VariablePrimal(), [ref1, ref2])
 ```
 """
-function cangetattribute end
-cangetattribute(m::AbstractInstance, attr::AnyAttribute) = false
-cangetattribute(m::AbstractInstance, attr::AnyAttribute, ref::AnyReference) = false
-cangetattribute(m::AbstractInstance, attr::AnyAttribute, refs::Vector{<:AnyReference}) = false
+function canget end
+canget(m::AbstractInstance, attr::AnyAttribute) = false
+canget(m::AbstractInstance, attr::AnyAttribute, ref::AnyReference) = false
+canget(m::AbstractInstance, attr::AnyAttribute, refs::Vector{<:AnyReference}) = false
 
 """
-    cansetattribute(s::AbstractSolver, attr::AbstractSolverAttribute)::Bool
+    canset(s::AbstractSolver, attr::AbstractSolverAttribute)::Bool
 
 Return a `Bool` indicating whether it is possible to set attribute `attr` in the solver `s`.
 
-    cansetattribute(m::AbstractInstance, attr::AbstractVariableAttribute, R::Type{VariableReference})::Bool
-    cangetattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, R::Type{ConstraintReference{F,S})::Bool
+    canset(m::AbstractInstance, attr::AbstractVariableAttribute, R::Type{VariableReference})::Bool
+    canget(m::AbstractInstance, attr::AbstractConstraintAttribute, R::Type{ConstraintReference{F,S})::Bool
 
 Return a `Bool` indicating whether it is possible to set attribute `attr` applied to the reference type `R` in the instance `m`.
 
-    cansetattribute(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})::Bool
-    cansetattribute(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})::Bool
+    canset(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference})::Bool
+    canset(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})::Bool
 
 Return a `Bool` indicating whether it is possible to set attribute `attr`applied to *every* variable reference in `v` or constraint reference in `c` in the instance `m`.
 
 ### Examples
 
 ```julia
-cansetattribute(m, ObjectiveValue())
-cansetattribute(m, VariablePrimalStart(), VariableReference)
-cansetattribute(m, ConstraintPrimal(), ConstraintReference{VectorAffineFunction{Float64},Nonnegatives})
+canset(m, ObjectiveValue())
+canset(m, VariablePrimalStart(), VariableReference)
+canset(m, ConstraintPrimal(), ConstraintReference{VectorAffineFunction{Float64},Nonnegatives})
 ```
 """
-function cansetattribute end
-cansetattribute(m::AbstractInstance, attr::AnyAttribute) = false
-cansetattribute(m::AbstractInstance, attr::AnyAttribute, ref::AnyReference) = false
-cansetattribute(m::AbstractInstance, attr::AnyAttribute, refs::Vector{<:AnyReference}) = false
+function canset end
+canset(m::AbstractInstance, attr::AnyAttribute) = false
+canset(m::AbstractInstance, attr::AnyAttribute, ref::AnyReference) = false
+canset(m::AbstractInstance, attr::AnyAttribute, refs::Vector{<:AnyReference}) = false
 
 """
-    setattribute!(s::AbstractSolver, attr::AbstractSolverAttribute, value)
+    set!(s::AbstractSolver, attr::AbstractSolverAttribute, value)
 
 Assign `value` to the attribute `attr` of the solver `s`.
 
-    setattribute!(m::AbstractInstance, attr::AbstractInstanceAttribute, value)
+    set!(m::AbstractInstance, attr::AbstractInstanceAttribute, value)
 
 Assign `value` to the attribute `attr` of the instance `m`.
 
-    setattribute!(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference, value)
+    set!(m::AbstractInstance, attr::AbstractVariableAttribute, v::VariableReference, value)
 
 Assign `value` to the attribute `attr` of variable `v` in instance `m`.
 
-    setattribute!(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference}, vector_of_values)
+    set!(m::AbstractInstance, attr::AbstractVariableAttribute, v::Vector{VariableReference}, vector_of_values)
 
 Assign a value respectively to the attribute `attr` of each variable in the collection `v` in instance `m`.
 
-    setattribute!(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference, value)
+    set!(m::AbstractInstance, attr::AbstractConstraintAttribute, c::ConstraintReference, value)
 
 Assign a value to the attribute `attr` of constraint `c` in instance `m`.
 
-    setattribute!(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})
+    set!(m::AbstractInstance, attr::AbstractConstraintAttribute, c::Vector{ConstraintReference{F,S}})
 
 Assign a value respectively to the attribute `attr` of each constraint in the collection `c` in instance `m`.
 """
-function setattribute! end
-function setattribute!(m, attr::AnyAttribute, args...)
+function set! end
+function set!(m, attr::AnyAttribute, args...)
     throw(ArgumentError("SolverInstance of type $(typeof(m)) does not support setting the attribute $attr"))
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -155,7 +155,7 @@ function transformconstraint! end
 
 # default fallback
 function transformconstraint!(m::AbstractInstance, c::ConstraintReference, newset)
-    f = getattribute(m, ConstraintFunction(), c)
+    f = get(m, ConstraintFunction(), c)
     delete!(m, c)
     addconstraint!(m, f, newset)
 end
@@ -180,7 +180,7 @@ function cantransformconstraint end
 
 # default fallback
 function cantransformconstraint(m::AbstractInstance, c::ConstraintReference, newset)
-    # TODO: add "&& canaddconstraint(m, getattribute(m, ConstraintFunction(), c), newset)"
+    # TODO: add "&& canaddconstraint(m, get(m, ConstraintFunction(), c), newset)"
     #       when candaddconstraint is defined
-    cangetattribute(m, ConstraintFunction(), c) && candelete(m, c)
+    canget(m, ConstraintFunction(), c) && candelete(m, c)
 end

--- a/test/contconic.jl
+++ b/test/contconic.jl
@@ -25,38 +25,38 @@ function lin1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             m = MOI.SolverInstance(solver)
 
             v = MOI.addvariables!(m, 3)
-            @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
+            @test MOI.get(m, MOI.NumberOfVariables()) == 3
 
             vc = MOI.addconstraint!(m, MOI.VectorOfVariables(v), MOI.Nonnegatives(3))
             c = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,1,1,2,2], [v;v[2];v[3]], ones(5), [-3.0,-2.0]), MOI.Zeros(2))
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            loc = MOI.getattribute(m, MOI.ListOfConstraints())
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            loc = MOI.get(m, MOI.ListOfConstraints())
             @test length(loc) == 2
             @test (MOI.VectorOfVariables,MOI.Nonnegatives) in loc
             @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), v)
+            @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
 
             # TODO var dual and con primal
         end
@@ -76,34 +76,34 @@ function lin1atest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), r
             m = MOI.SolverInstance(solver)
 
             v = MOI.addvariables!(m, 3)
-            @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
+            @test MOI.get(m, MOI.NumberOfVariables()) == 3
 
             vc = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,2,3], v, ones(3), zeros(3)), MOI.Nonnegatives(3))
             c = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,1,1,2,2], [v;v[2];v[3]], ones(5), [-3.0,-2.0]), MOI.Zeros(2))
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), v)
+            @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
 
             # TODO var dual and con primal
         end
@@ -139,10 +139,10 @@ function lin2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             m = MOI.SolverInstance(solver)
 
             x,y,z,s = MOI.addvariables!(m, 4)
-            @test MOI.getattribute(m, MOI.NumberOfVariables()) == 4
+            @test MOI.get(m, MOI.NumberOfVariables()) == 4
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y,z], [3.0, 2.0, -4.0], 0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y,z], [3.0, 2.0, -4.0], 0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
             c = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,1,2,3,3], [x,s,y,x,z], [1.0,-1.0,1.0,1.0,1.0], [4.0,3.0,-12.0]), MOI.Zeros(3))
 
@@ -151,31 +151,31 @@ function lin2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             vz = MOI.addconstraint!(m, [z], MOI.Nonnegatives(1))
             vz = MOI.addconstraint!(m, MOI.VectorOfVariables([s]), MOI.Zeros(1))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
 
             # TODO var dual and con primal
         end
@@ -201,11 +201,11 @@ function lin2atest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), r
             m = MOI.SolverInstance(solver)
 
             x,y,z,s = MOI.addvariables!(m, 4)
-            @test MOI.getattribute(m, MOI.NumberOfVariables()) == 4
+            @test MOI.get(m, MOI.NumberOfVariables()) == 4
 
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y,z], [3.0, 2.0, -4.0], 0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y,z], [3.0, 2.0, -4.0], 0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
 
             c = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,1,2,3,3], [x,s,y,x,z], [1.0,-1.0,1.0,1.0,1.0], [4.0,3.0,-12.0]), MOI.Zeros(3))
@@ -214,32 +214,32 @@ function lin2atest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), r
             vz = MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[z],[1.0],[0.0]), MOI.Nonnegatives(1))
             vz = MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[s],[1.0],[0.0]), MOI.Zeros(1))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 2
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 2
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
 
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
 
             # TODO var dual and con primal
         end
@@ -270,19 +270,19 @@ function lin3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Nonnegatives(1))
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[1.0]), MOI.Nonpositives(1))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            if MOI.cangetattribute(m, MOI.PrimalStatus())
-                @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+            if MOI.canget(m, MOI.PrimalStatus())
+                @test MOI.get(m, MOI.PrimalStatus()) == MOI.InfeasiblePoint
             end
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.InfeasibilityCertificate
 
             # TODO test dual feasibility and objective sign
         end
@@ -308,19 +308,19 @@ function lin4test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Nonnegatives(1))
             MOI.addconstraint!(m, MOI.VectorOfVariables([x]), MOI.Nonpositives(1))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            if MOI.cangetattribute(m, MOI.PrimalStatus())
-                @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+            if MOI.canget(m, MOI.PrimalStatus())
+                @test MOI.get(m, MOI.PrimalStatus()) == MOI.InfeasiblePoint
             end
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.InfeasibilityCertificate
 
             # TODO test dual feasibility and objective sign
         end
@@ -347,41 +347,41 @@ function soc1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
 
             x,y,z = MOI.addvariables!(m, 3)
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([y,z],[1.0,1.0],0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([y,z],[1.0,1.0],0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
             ceq = MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Zeros(1))
             csoc = MOI.addconstraint!(m, MOI.VectorOfVariables([x,y,z]), MOI.SecondOrderCone(3))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
-            loc = MOI.getattribute(m, MOI.ListOfConstraints())
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
+            loc = MOI.get(m, MOI.ListOfConstraints())
             @test length(loc) == 2
             @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
             @test (MOI.VectorOfVariables,MOI.SecondOrderCone) in loc
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), ceq)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), csoc)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), ceq)
+            @test MOI.get(m, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), csoc)
+            @test MOI.get(m, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
 
             # TODO con primal
         end
@@ -401,37 +401,37 @@ function soc1atest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), r
 
             x,y,z = MOI.addvariables!(m, 3)
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([y,z],[1.0,1.0],0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([y,z],[1.0,1.0],0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
             ceq = MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Zeros(1))
             csoc = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,2,3],[x,y,z],ones(3),zeros(3)), MOI.SecondOrderCone(3))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), ceq)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), csoc)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), ceq)
+            @test MOI.get(m, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), csoc)
+            @test MOI.get(m, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
 
             # TODO con primal
         end
@@ -460,33 +460,33 @@ function soc2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
 
             x,y,t = MOI.addvariables!(m, 3)
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x],[1.0],0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x],[1.0],0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[y],[1.0],[-1/sqrt(2)]), MOI.Nonnegatives(1))
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[t],[-1.0],[1.0]), MOI.Zeros(1))
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1,2,3],[t,x,y],ones(3),zeros(3)), MOI.SecondOrderCone(3))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
 
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
 
             # TODO constraint primal and duals
         end
@@ -507,33 +507,33 @@ function soc2atest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), r
 
             x,y,t = MOI.addvariables!(m, 3)
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x],[1.0],0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x],[1.0],0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[y],[-1.0],[1/sqrt(2)]), MOI.Nonpositives(1))
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[t],[-1.0],[1.0]), MOI.Zeros(1))
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1,2,3],[t,x,y],ones(3),zeros(3)), MOI.SecondOrderCone(3))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
 
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
 
             # TODO constraint primal and duals
         end
@@ -567,18 +567,18 @@ function soc3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Nonpositives(1))
             MOI.addconstraint!(m, MOI.VectorAffineFunction([1,2],[x,y],ones(2),zeros(2)), MOI.SecondOrderCone(2))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test !MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test !MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.InfeasibilityCertificate
 
             # TODO test dual feasibility and objective sign
         end
@@ -618,31 +618,31 @@ function soc4test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             c1 = MOI.addconstraint!(m, MOI.VectorAffineFunction(A_rows,A_cols,A_vals,b), MOI.Zeros(3))
             c2 = MOI.addconstraint!(m, MOI.VectorOfVariables([x[1],x[4],x[5]]), MOI.SecondOrderCone(3))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            x_primal = MOI.getattribute(m, MOI.VariablePrimal(), x)
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            x_primal = MOI.get(m, MOI.VariablePrimal(), x)
             @test x_primal[1]^2 ≥ x_primal[4]^2 + x_primal[5]^2 - atol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c2)
-            x_dual = MOI.getattribute(m, MOI.ConstraintDual(), c2)
+            @test MOI.canget(m, MOI.ConstraintDual(), c2)
+            x_dual = MOI.get(m, MOI.ConstraintDual(), c2)
             @test x_dual[1]^2 ≥ x_dual[2]^2 + x_dual[3]^2 - atol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c1)
-            c1_dual = MOI.getattribute(m, MOI.ConstraintDual(), c1)
+            @test MOI.canget(m, MOI.ConstraintDual(), c1)
+            c1_dual = MOI.get(m, MOI.ConstraintDual(), c1)
 
             @test dot(c,x_primal) ≈ -dot(c1_dual,b) atol=atol rtol=rtol
             @test (c-A'c1_dual) ≈ [x_dual[1], 0, 0, x_dual[2], x_dual[3]] atol=atol rtol=rtol
@@ -681,35 +681,35 @@ function rotatedsoc1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float
 
             rsoc = MOI.addconstraint!(m, MOI.VectorOfVariables(x), MOI.RotatedSecondOrderCone(4))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 2
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.RotatedSecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 2
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.RotatedSecondOrderCone}()) == 1
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -sqrt(2.0) atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -sqrt(2.0) atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
 
-            if MOI.getattribute(solver, MOI.SupportsDuals())
-                @test MOI.cangetattribute(m, MOI.DualStatus(1))
-                @test MOI.getattribute(m, MOI.DualStatus(1)) == MOI.FeasiblePoint
+            if MOI.get(solver, MOI.SupportsDuals())
+                @test MOI.canget(m, MOI.DualStatus(1))
+                @test MOI.get(m, MOI.DualStatus(1)) == MOI.FeasiblePoint
 
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc1)
-                d1 = MOI.getattribute(m, MOI.ConstraintDual(), vc1)
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc2)
-                d2 = MOI.getattribute(m, MOI.ConstraintDual(), vc2)
+                @test MOI.canget(m, MOI.ConstraintDual(), vc1)
+                d1 = MOI.get(m, MOI.ConstraintDual(), vc1)
+                @test MOI.canget(m, MOI.ConstraintDual(), vc2)
+                d2 = MOI.get(m, MOI.ConstraintDual(), vc2)
 
                 d = [d1, d2]
                 dualobj = dot(b, d)
@@ -717,8 +717,8 @@ function rotatedsoc1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float
                 @test d1 <= atol
                 @test d2 <= atol
 
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), rsoc)
-                vardual = MOI.getattribute(m, MOI.ConstraintDual(), rsoc)
+                @test MOI.canget(m, MOI.ConstraintDual(), rsoc)
+                vardual = MOI.get(m, MOI.ConstraintDual(), rsoc)
 
                 @test vardual ≈ (c - A'd) atol=atol rtol=rtol
                 @test 2*vardual[1]*vardual[2] ≥ vardual[3]^2 + vardual[4]^2 - atol
@@ -744,35 +744,35 @@ function rotatedsoc1atest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Floa
             x = MOI.addvariables!(m, 2)
 
             rsoc = MOI.addconstraint!(m, MOI.VectorAffineFunction([3, 4], x, [1., 1.], b), MOI.RotatedSecondOrderCone(4))
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 1
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x, [-1.0,-1.0], 0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x, [-1.0,-1.0], 0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -sqrt(2.0) atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -sqrt(2.0) atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ [1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ [1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
 
-            if MOI.getattribute(solver, MOI.SupportsDuals())
-                @test MOI.cangetattribute(m, MOI.DualStatus(1))
-                @test MOI.getattribute(m, MOI.DualStatus(1)) == MOI.FeasiblePoint
+            if MOI.get(solver, MOI.SupportsDuals())
+                @test MOI.canget(m, MOI.DualStatus(1))
+                @test MOI.get(m, MOI.DualStatus(1)) == MOI.FeasiblePoint
 
-                @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), rsoc)
-                @test MOI.getattribute(m, MOI.ConstraintPrimal(), rsoc) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.ConstraintPrimal(), rsoc)
+                @test MOI.get(m, MOI.ConstraintPrimal(), rsoc) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
 
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), rsoc)
-                d = MOI.getattribute(m, MOI.ConstraintDual(), rsoc)
+                @test MOI.canget(m, MOI.ConstraintDual(), rsoc)
+                d = MOI.get(m, MOI.ConstraintDual(), rsoc)
                 @test 2*d[1]*d[2] ≥ d[3]^2 + d[4]^2 - atol
 
                 dualobj = -dot(b, d)
@@ -816,36 +816,36 @@ function rotatedsoc2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float
 
             rsoc = MOI.addconstraint!(m, MOI.VectorOfVariables(x), MOI.RotatedSecondOrderCone(3))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.RotatedSecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.RotatedSecondOrderCone}()) == 1
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(x,c,0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
 
-            if MOI.getattribute(m, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleOrUnbounded] && MOI.getattribute(solver, MOI.SupportsDuals())
-                @test MOI.cangetattribute(m, MOI.DualStatus())
-                @test MOI.getattribute(m, MOI.DualStatus()) in [MOI.InfeasibilityCertificate, MOI.NearlyInfeasibilityCertificate]
+            if MOI.get(m, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleOrUnbounded] && MOI.get(solver, MOI.SupportsDuals())
+                @test MOI.canget(m, MOI.DualStatus())
+                @test MOI.get(m, MOI.DualStatus()) in [MOI.InfeasibilityCertificate, MOI.NearlyInfeasibilityCertificate]
 
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc1)
-                y1 = MOI.getattribute(m, MOI.ConstraintDual(), vc1)
+                @test MOI.canget(m, MOI.ConstraintDual(), vc1)
+                y1 = MOI.get(m, MOI.ConstraintDual(), vc1)
                 @test y1 < -atol # Should be strictly negative
 
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc2)
-                y2 = MOI.getattribute(m, MOI.ConstraintDual(), vc2)
+                @test MOI.canget(m, MOI.ConstraintDual(), vc2)
+                y2 = MOI.get(m, MOI.ConstraintDual(), vc2)
 
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc3)
-                y3 = MOI.getattribute(m, MOI.ConstraintDual(), vc3)
+                @test MOI.canget(m, MOI.ConstraintDual(), vc3)
+                y3 = MOI.get(m, MOI.ConstraintDual(), vc3)
                 @test y3 > atol # Should be strictly positive
 
                 y = [y1, y2, y3]
 
-                vardual = MOI.getattribute(m, MOI.ConstraintDual(), rsoc)
+                vardual = MOI.get(m, MOI.ConstraintDual(), rsoc)
 
                 @test vardual ≈ -y atol=atol rtol=rtol
                 @test 2*vardual[1]*vardual[2] ≥ vardual[3]^2 - atol
@@ -873,7 +873,7 @@ function _sdp0test(solver::MOI.AbstractSolver, vecofvars::Bool, sdpcone; atol=Ba
             m = MOI.SolverInstance(solver)
 
             X = MOI.addvariables!(m, 3)
-            @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
+            @test MOI.get(m, MOI.NumberOfVariables()) == 3
 
             if vecofvars
                 cX = MOI.addconstraint!(m, MOI.VectorOfVariables(X), sdpcone(2))
@@ -883,32 +883,32 @@ function _sdp0test(solver::MOI.AbstractSolver, vecofvars::Bool, sdpcone; atol=Ba
 
             c = MOI.addconstraint!(m, MOI.ScalarAffineFunction([X[2]], [1/s], 0.), MOI.EqualTo(1.))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, sdpcone}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, sdpcone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([X[1], X[3]], ones(2), 0.))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([X[1], X[3]], ones(2), 0.))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), X)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), X) ≈ [1, s, 1] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), X)
+            @test MOI.get(m, MOI.VariablePrimal(), X) ≈ [1, s, 1] atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ 2 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ 2 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), cX)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), cX) ≈ [1, -s, 1] atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), cX)
+            @test MOI.get(m, MOI.ConstraintDual(), cX) ≈ [1, -s, 1] atol=atol rtol=rtol
         end
     end
 end
@@ -949,9 +949,9 @@ function _sdp1test(solver::MOI.AbstractSolver, vecofvars::Bool, sdpcone; atol=Ba
             m = MOI.SolverInstance(solver)
 
             X = MOI.addvariables!(m, 6)
-            @test MOI.getattribute(m, MOI.NumberOfVariables()) == 6
+            @test MOI.get(m, MOI.NumberOfVariables()) == 6
             x = MOI.addvariables!(m, 3)
-            @test MOI.getattribute(m, MOI.NumberOfVariables()) == 9
+            @test MOI.get(m, MOI.NumberOfVariables()) == 9
 
             if vecofvars
                 cX = MOI.addconstraint!(m, MOI.VectorOfVariables(X), sdpcone(3))
@@ -963,35 +963,35 @@ function _sdp1test(solver::MOI.AbstractSolver, vecofvars::Bool, sdpcone; atol=Ba
             c1 = MOI.addconstraint!(m, MOI.ScalarAffineFunction([X[1], X[4], X[6], x[1]], [1., 1, 1, 1], 0.), MOI.EqualTo(1.))
             c2 = MOI.addconstraint!(m, MOI.ScalarAffineFunction([X; x[2]; x[3]], [1., 2/s, 2/s, 1, 2/s, 1, 1, 1], 0.), MOI.EqualTo(1/2))
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([X[1:2]; X[4:6]; x[1]], [2., 2/s, 2, 2/s, 2, 1], 0.))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([X[1:2]; X[4:6]; x[1]], [2., 2/s, 2, 2/s, 2, 1], 0.))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, sdpcone}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 2
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables, MOI.SecondOrderCone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, sdpcone}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 2
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables, MOI.SecondOrderCone}()) == 1
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 0.705710509 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ 0.705710509 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), X)
-            Xv = MOI.getattribute(m, MOI.VariablePrimal(), X)
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            xv = MOI.getattribute(m, MOI.VariablePrimal(), x)
+            @test MOI.canget(m, MOI.VariablePrimal(), X)
+            Xv = MOI.get(m, MOI.VariablePrimal(), X)
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            xv = MOI.get(m, MOI.VariablePrimal(), x)
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c1)
-            y1 = MOI.getattribute(m, MOI.ConstraintDual(), c1)
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c2)
-            y2 = MOI.getattribute(m, MOI.ConstraintDual(), c2)
+            @test MOI.canget(m, MOI.ConstraintDual(), c1)
+            y1 = MOI.get(m, MOI.ConstraintDual(), c1)
+            @test MOI.canget(m, MOI.ConstraintDual(), c2)
+            y2 = MOI.get(m, MOI.ConstraintDual(), c2)
 
             #     X11  X21  X31  X22  X32  X33  x1  x2  x3
             c = [   2, 2/s,   0,   2, 2/s,   2,  1,  0,  0]
@@ -1002,8 +1002,8 @@ function _sdp1test(solver::MOI.AbstractSolver, vecofvars::Bool, sdpcone; atol=Ba
             comp_dobj = dot([y1, y2], b)
             @test comp_pobj ≈ comp_dobj atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), cX)
-            Xdv = MOI.getattribute(m, MOI.ConstraintDual(), cX)
+            @test MOI.canget(m, MOI.ConstraintDual(), cX)
+            Xdv = MOI.get(m, MOI.ConstraintDual(), cX)
             Xd = [Xdv[1]   Xdv[2]/s Xdv[3]/s;
                   Xdv[2]/s Xdv[4]   Xdv[5]/s;
                   Xdv[3]/s Xdv[5]/s Xdv[6]]
@@ -1041,7 +1041,7 @@ function sdp2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             m = MOI.SolverInstance(solver)
 
             x = MOI.addvariables!(m, 7)
-            @test MOI.getattribute(m, MOI.NumberOfVariables()) == 7
+            @test MOI.get(m, MOI.NumberOfVariables()) == 7
 
             c = [0.0,0.0,0.0,0.0,0.0,0.0,1.0]
             b = [10.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
@@ -1058,63 +1058,63 @@ function sdp2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
             c3 = MOI.addconstraint!(m, f[8:10], MOI.PositiveSemidefiniteConeScaled(2))
             c4 = MOI.addconstraint!(m, f[11], MOI.EqualTo(0.))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonpositives}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeScaled}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonpositives}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeScaled}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x[7]], [1.], 0.))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x[7]], [1.], 0.))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            xv = MOI.getattribute(m, MOI.VariablePrimal(), x)
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            xv = MOI.get(m, MOI.VariablePrimal(), x)
             @test all(xv[1:6] .> -atol)
 
             con = A * xv + b
 
-            @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c1)
-            @test MOI.getattribute(m, MOI.ConstraintPrimal(), c1) ≈ con[1] atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.ConstraintPrimal(), c1) ≈ 0.0 atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c2)
-            @test MOI.getattribute(m, MOI.ConstraintPrimal(), c2) ≈ con[2:7] atol=atol rtol=rtol
-            @test all(MOI.getattribute(m, MOI.ConstraintPrimal(), c2) .< atol)
-            @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c3)
-            Xv = MOI.getattribute(m, MOI.ConstraintPrimal(), c3)
+            @test MOI.canget(m, MOI.ConstraintPrimal(), c1)
+            @test MOI.get(m, MOI.ConstraintPrimal(), c1) ≈ con[1] atol=atol rtol=rtol
+            @test MOI.get(m, MOI.ConstraintPrimal(), c1) ≈ 0.0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintPrimal(), c2)
+            @test MOI.get(m, MOI.ConstraintPrimal(), c2) ≈ con[2:7] atol=atol rtol=rtol
+            @test all(MOI.get(m, MOI.ConstraintPrimal(), c2) .< atol)
+            @test MOI.canget(m, MOI.ConstraintPrimal(), c3)
+            Xv = MOI.get(m, MOI.ConstraintPrimal(), c3)
             @test Xv ≈ con[8:10] atol=atol rtol=rtol
             s2 = sqrt(2)
             Xm = [Xv[1]    Xv[2]/s2
                   Xv[2]/s2 Xv[3]]
             @test eigmin(Xm) > -atol
-            @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c4)
-            @test MOI.getattribute(m, MOI.ConstraintPrimal(), c4) ≈ con[11] atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.ConstraintPrimal(), c4) ≈ 0.0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintPrimal(), c4)
+            @test MOI.get(m, MOI.ConstraintPrimal(), c4) ≈ con[11] atol=atol rtol=rtol
+            @test MOI.get(m, MOI.ConstraintPrimal(), c4) ≈ 0.0 atol=atol rtol=rtol
 
-            if MOI.getattribute(solver, MOI.SupportsDuals())
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), c1)
-                y1 = MOI.getattribute(m, MOI.ConstraintDual(), c1)
+            if MOI.get(solver, MOI.SupportsDuals())
+                @test MOI.canget(m, MOI.ConstraintDual(), c1)
+                y1 = MOI.get(m, MOI.ConstraintDual(), c1)
                 @test y1 > -atol
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), c2)
-                y2 = MOI.getattribute(m, MOI.ConstraintDual(), c2)
-                @test all(MOI.getattribute(m, MOI.ConstraintDual(), c2) .< atol)
+                @test MOI.canget(m, MOI.ConstraintDual(), c2)
+                y2 = MOI.get(m, MOI.ConstraintDual(), c2)
+                @test all(MOI.get(m, MOI.ConstraintDual(), c2) .< atol)
 
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), c3)
-                y3 = MOI.getattribute(m, MOI.ConstraintDual(), c3)
+                @test MOI.canget(m, MOI.ConstraintDual(), c3)
+                y3 = MOI.get(m, MOI.ConstraintDual(), c3)
                 s2 = sqrt(2)
                 Ym = [y3[1]    y3[2]/s2
                       y3[2]/s2 y3[3]]
                 @test eigmin(Ym) > -atol
 
-                @test MOI.cangetattribute(m, MOI.ConstraintDual(), c4)
-                y4 = MOI.getattribute(m, MOI.ConstraintDual(), c4)
+                @test MOI.canget(m, MOI.ConstraintDual(), c4)
+                y4 = MOI.get(m, MOI.ConstraintDual(), c4)
 
                 y = [y1; y2; y3; y4]
                 @test dot(c, xv) ≈ dot(b, y) atol=atol rtol=rtol

--- a/test/contlinear.jl
+++ b/test/contlinear.jl
@@ -14,118 +14,118 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
 
         @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
 
-        @test MOI.getattribute(solver, MOI.SupportsAddConstraintAfterSolve())
-        @test MOI.getattribute(solver, MOI.SupportsAddVariableAfterSolve())
-        @test MOI.getattribute(solver, MOI.SupportsDeleteConstraint())
+        @test MOI.get(solver, MOI.SupportsAddConstraintAfterSolve())
+        @test MOI.get(solver, MOI.SupportsAddVariableAfterSolve())
+        @test MOI.get(solver, MOI.SupportsDeleteConstraint())
 
         m = MOI.SolverInstance(solver)
 
         v = MOI.addvariables!(m, 2)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 2
+        @test MOI.get(m, MOI.NumberOfVariables()) == 2
 
         cf = MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0)
         c = MOI.addconstraint!(m, cf, MOI.LessThan(1.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
         vc1 = MOI.addconstraint!(m, MOI.SingleVariable(v[1]), MOI.GreaterThan(0.0))
         # test fallback
         vc2 = MOI.addconstraint!(m, v[2], MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
         objf = MOI.ScalarAffineFunction(v, [-1.0,0.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), objf)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MinSense
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MinSense
 
-        if MOI.cangetattribute(m, MOI.ObjectiveFunction())
-            @test objf ≈ MOI.getattribute(m, MOI.ObjectiveFunction())
+        if MOI.canget(m, MOI.ObjectiveFunction())
+            @test objf ≈ MOI.get(m, MOI.ObjectiveFunction())
         end
 
-        if MOI.cangetattribute(m, MOI.ConstraintFunction(), c)
-            @test cf ≈ MOI.getattribute(m, MOI.ConstraintFunction(), c)
+        if MOI.canget(m, MOI.ConstraintFunction(), c)
+            @test cf ≈ MOI.get(m, MOI.ConstraintFunction(), c)
         end
 
-        if MOI.cangetattribute(m, MOI.ConstraintSet(), c)
-            s = MOI.getattribute(m, MOI.ConstraintSet(), c)
+        if MOI.canget(m, MOI.ConstraintSet(), c)
+            s = MOI.get(m, MOI.ConstraintSet(), c)
             @test s == MOI.LessThan(1.0)
         end
 
-        if MOI.cangetattribute(m, MOI.ConstraintSet(), vc1)
-            s = MOI.getattribute(m, MOI.ConstraintSet(), vc1)
+        if MOI.canget(m, MOI.ConstraintSet(), vc1)
+            s = MOI.get(m, MOI.ConstraintSet(), vc1)
             @test s == MOI.GreaterThan(0.0)
         end
-        if MOI.cangetattribute(m, MOI.ConstraintSet(), vc2)
-            s = MOI.getattribute(m, MOI.ConstraintSet(), vc2)
+        if MOI.canget(m, MOI.ConstraintSet(), vc2)
+            s = MOI.get(m, MOI.ConstraintSet(), vc2)
             @test s == MOI.GreaterThan(0.0)
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c)
-        @test MOI.getattribute(m, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ConstraintPrimal(), c)
+        @test MOI.get(m, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
-        if MOI.getattribute(solver, MOI.SupportsDuals())
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        if MOI.get(solver, MOI.SupportsDuals())
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc1)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc2)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc1)
+            @test MOI.get(m, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc2)
+            @test MOI.get(m, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
         end
 
         # change objective to Max +x
 
         objf = MOI.ScalarAffineFunction(v, [1.0,0.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), objf)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
-        if MOI.cangetattribute(m, MOI.ObjectiveFunction())
-            @test objf ≈ MOI.getattribute(m, MOI.ObjectiveFunction())
+        if MOI.canget(m, MOI.ObjectiveFunction())
+            @test objf ≈ MOI.get(m, MOI.ObjectiveFunction())
         end
 
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MaxSense
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
-        if MOI.getattribute(solver, MOI.SupportsDuals())
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        if MOI.get(solver, MOI.SupportsDuals())
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc1)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc2)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc1)
+            @test MOI.get(m, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc2)
+            @test MOI.get(m, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
         end
 
         # add new variable to get :
@@ -138,7 +138,7 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test v[3] == z
 
         vc3 = MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
         @test MOI.canmodifyconstraint(m, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
         MOI.modifyconstraint!(m, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
@@ -146,41 +146,41 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test MOI.canmodifyobjective(m, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
         MOI.modifyobjective!(m, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
 
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus(1))
-        @test MOI.getattribute(m, MOI.PrimalStatus(1)) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus(1))
+        @test MOI.get(m, MOI.PrimalStatus(1)) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [0, 0, 1] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [0, 0, 1] atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c)
-        @test MOI.getattribute(m, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ConstraintPrimal(), c)
+        @test MOI.get(m, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
-        if MOI.getattribute(solver, MOI.SupportsDuals())
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ -2 atol=atol rtol=rtol
+        if MOI.get(solver, MOI.SupportsDuals())
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ -2 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc1)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc1) ≈ 1 atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc2)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc2) ≈ 2 atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc3)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc3) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc1)
+            @test MOI.get(m, MOI.ConstraintDual(), vc1) ≈ 1 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc2)
+            @test MOI.get(m, MOI.ConstraintDual(), vc2) ≈ 2 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc3)
+            @test MOI.get(m, MOI.ConstraintDual(), vc3) ≈ 0 atol=atol rtol=rtol
         end
 
         # setting lb of x to -1 to get :
@@ -193,17 +193,17 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
         # put lb of x back to 0 and fix z to zero to get :
         # max x + 2z
@@ -216,21 +216,21 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         MOI.delete!(m, vc3)
 
         vc3 = MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
         # modify affine linear constraint set to be == 2 to get :
         # max x + 2z
@@ -240,22 +240,22 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         MOI.delete!(m, c)
         cf = MOI.ScalarAffineFunction(v, [1.0,1.0,1.0], 0.0)
         c = MOI.addconstraint!(m, cf, MOI.EqualTo(2.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
         # modify objective function to x + 2y to get :
         # max x + 2y
@@ -263,25 +263,25 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # x,y >= 0, z = 0
 
         objf = MOI.ScalarAffineFunction(v, [1.0,2.0,0.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), objf)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [0, 2, 0] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [0, 2, 0] atol=atol rtol=rtol
 
         # add constraint x - y >= 0 to get :
         # max x+2y
@@ -291,44 +291,44 @@ function linear1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
 
         cf2 = MOI.ScalarAffineFunction(v, [1.0, -1.0, 0.0], 0.0)
         c2 = MOI.addconstraint!(m, cf2, MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [1, 1, 0] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [1, 1, 0] atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c)
-        @test MOI.getattribute(m, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ConstraintPrimal(), c)
+        @test MOI.get(m, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
 
-        if MOI.getattribute(solver, MOI.SupportsDuals())
-            @test MOI.cangetattribute(m, MOI.DualStatus(1))
-            @test MOI.getattribute(m, MOI.DualStatus(1)) == MOI.FeasiblePoint
+        if MOI.get(solver, MOI.SupportsDuals())
+            @test MOI.canget(m, MOI.DualStatus(1))
+            @test MOI.get(m, MOI.DualStatus(1)) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ -1.5 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c2) ≈ 0.5 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ -1.5 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.ConstraintDual(), c2) ≈ 0.5 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc1)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc2)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc2) ≈ 0 atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc3)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc3) ≈ 1.5 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc1)
+            @test MOI.get(m, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc2)
+            @test MOI.get(m, MOI.ConstraintDual(), vc2) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc3)
+            @test MOI.get(m, MOI.ConstraintDual(), vc3) ≈ 1.5 atol=atol rtol=rtol
         end
     end
 end
@@ -346,53 +346,53 @@ function linear2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         x = MOI.addvariable!(m)
         y = MOI.addvariable!(m)
 
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 2
+        @test MOI.get(m, MOI.NumberOfVariables()) == 2
 
         cf = MOI.ScalarAffineFunction([x, y], [1.0,1.0], 0.0)
         c = MOI.addconstraint!(m, cf, MOI.LessThan(1.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
         vc1 = MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         vc2 = MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
         objf = MOI.ScalarAffineFunction([x, y], [-1.0,0.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), objf)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MinSense
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MinSense
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), x)
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), y)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 0 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), y)
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 0 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c)
-        @test MOI.getattribute(m, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ConstraintPrimal(), c)
+        @test MOI.get(m, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
-        if MOI.getattribute(solver, MOI.SupportsDuals())
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        if MOI.get(solver, MOI.SupportsDuals())
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc1)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), vc2)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc1)
+            @test MOI.get(m, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ConstraintDual(), vc2)
+            @test MOI.get(m, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
         end
     end
 end
@@ -406,32 +406,32 @@ function linear3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         m = MOI.SolverInstance(solver)
 
         x = MOI.addvariable!(m)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 1
+        @test MOI.get(m, MOI.NumberOfVariables()) == 1
 
         MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         cf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
         MOI.addconstraint!(m, cf, MOI.GreaterThan(3.0))
 
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
 
         objf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), objf)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
         # max  x
         # s.t. x <= 0
@@ -440,32 +440,32 @@ function linear3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         m = MOI.SolverInstance(solver)
 
         x = MOI.addvariable!(m)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 1
+        @test MOI.get(m, MOI.NumberOfVariables()) == 1
 
         MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.LessThan(0.0))
         cf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
         MOI.addconstraint!(m, cf, MOI.LessThan(3.0))
 
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
         objf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), objf)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
     end
 end
 
@@ -483,20 +483,20 @@ function linear4test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # s.t. 0.0 <= x          (c1)
         #             y <= 0.0   (c2)
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
         c1 = MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         c2 = MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.LessThan(0.0))
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
 
         # Min  x - y
         # s.t. 100.0 <= x
@@ -504,12 +504,12 @@ function linear4test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test MOI.canmodifyconstraint(m, c1, MOI.GreaterThan(100.0))
         MOI.modifyconstraint!(m, c1, MOI.GreaterThan(100.0))
         MOI.optimize!(m)
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
 
         # Min  x - y
         # s.t. 100.0 <= x
@@ -517,19 +517,19 @@ function linear4test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test MOI.canmodifyconstraint(m, c2, MOI.LessThan(-100.0))
         MOI.modifyconstraint!(m, c2, MOI.LessThan(-100.0))
         MOI.optimize!(m)
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
 
     end
 end
 
 function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
     @testset "Change coeffs, del constr, del var" begin
-        @test MOI.getattribute(solver, MOI.SupportsDeleteVariable())
+        @test MOI.get(solver, MOI.SupportsDeleteVariable())
         #####################################
         # Start from simple LP
         # Solve it
@@ -551,7 +551,7 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         x = MOI.addvariable!(m)
         y = MOI.addvariable!(m)
 
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 2
+        @test MOI.get(m, MOI.NumberOfVariables()) == 2
 
         cf1 = MOI.ScalarAffineFunction([x, y], [2.0,1.0], 0.0)
         cf2 = MOI.ScalarAffineFunction([x, y], [1.0,2.0], 0.0)
@@ -559,30 +559,30 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         c1 = MOI.addconstraint!(m, cf1, MOI.LessThan(4.0))
         c2 = MOI.addconstraint!(m, cf2, MOI.LessThan(4.0))
 
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
 
         vc1 = MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         vc2 = MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
         objf = MOI.ScalarAffineFunction([x, y], [1.0,1.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), objf)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 8/3 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 8/3 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), [x, y])
-        @test MOI.getattribute(m, MOI.VariablePrimal(), [x, y]) ≈ [4/3, 4/3] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), [x, y])
+        @test MOI.get(m, MOI.VariablePrimal(), [x, y]) ≈ [4/3, 4/3] atol=atol rtol=rtol
 
         # copy and solve again
         # missing test
@@ -600,17 +600,17 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         MOI.modifyconstraint!(m, c1, MOI.ScalarCoefficientChange(y, 3.0))
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), [x, y])
-        @test MOI.getattribute(m, MOI.VariablePrimal(), [x, y]) ≈ [2.0, 0.0] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), [x, y])
+        @test MOI.get(m, MOI.VariablePrimal(), [x, y]) ≈ [2.0, 0.0] atol=atol rtol=rtol
 
         # delconstrs and solve
         #   maximize x + y
@@ -624,17 +624,17 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), [x, y])
-        @test MOI.getattribute(m, MOI.VariablePrimal(), [x, y]) ≈ [4.0, 0.0] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), [x, y])
+        @test MOI.get(m, MOI.VariablePrimal(), [x, y]) ≈ [4.0, 0.0] atol=atol rtol=rtol
 
         # delvars and solve
         #   maximize y
@@ -648,17 +648,17 @@ function linear5test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), y)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 2.0 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), y)
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 2.0 atol=atol rtol=rtol
 
     end
 end
@@ -677,20 +677,20 @@ function linear6test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # s.t. 0.0 <= x          (c1)
         #             y <= 0.0   (c2)
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
         c1 = MOI.addconstraint!(m, MOI.ScalarAffineFunction([x],[1.0],0.0), MOI.GreaterThan(0.0))
         c2 = MOI.addconstraint!(m, MOI.ScalarAffineFunction([y],[1.0],0.0), MOI.LessThan(0.0))
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
 
         # Min  x - y
         # s.t. 100.0 <= x
@@ -698,12 +698,12 @@ function linear6test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test MOI.canmodifyconstraint(m, c1, MOI.GreaterThan(100.0))
         MOI.modifyconstraint!(m, c1, MOI.GreaterThan(100.0))
         MOI.optimize!(m)
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
 
         # Min  x - y
         # s.t. 100.0 <= x
@@ -711,12 +711,12 @@ function linear6test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test MOI.canmodifyconstraint(m, c2, MOI.LessThan(-100.0))
         MOI.modifyconstraint!(m, c2, MOI.LessThan(-100.0))
         MOI.optimize!(m)
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
 
     end
 end
@@ -735,20 +735,20 @@ function linear7test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         # s.t. 0.0 <= x          (c1)
         #             y <= 0.0   (c2)
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
         c1 = MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[0.0]), MOI.Nonnegatives(1))
         c2 = MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[y],[1.0],[0.0]), MOI.Nonpositives(1))
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
 
         # Min  x - y
         # s.t. 100.0 <= x
@@ -756,12 +756,12 @@ function linear7test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test MOI.canmodifyconstraint(m, c1, MOI.VectorConstantChange([-100.0]))
         MOI.modifyconstraint!(m, c1, MOI.VectorConstantChange([-100.0]))
         MOI.optimize!(m)
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
 
         # Min  x - y
         # s.t. 100.0 <= x
@@ -769,12 +769,12 @@ function linear7test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         @test MOI.canmodifyconstraint(m, c2, MOI.VectorConstantChange([100.0]))
         MOI.modifyconstraint!(m, c2, MOI.VectorConstantChange([100.0]))
         MOI.optimize!(m)
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
 
     end
 end
@@ -792,31 +792,31 @@ function linear8test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         c = MOI.addconstraint!(m, MOI.ScalarAffineFunction([x,y], [2.0,1.0], 0.0), MOI.LessThan(-1.0))
         bndx = MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         bndy = MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        if MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        if MOI.get(m, MOI.ResultCount()) >= 1
             # solver returned an infeasibility ray
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.InfeasibilityCertificate
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            cd = MOI.getattribute(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(m, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            cd = MOI.get(m, MOI.ConstraintDual(), c)
             @test cd < -atol
             # TODO: farkas dual on bounds - see #127
-            # xd = MOI.getattribute(m, MOI.ConstraintDual(), bndx)
-            # yd = MOI.getattribute(m, MOI.ConstraintDual(), bndy)
+            # xd = MOI.get(m, MOI.ConstraintDual(), bndx)
+            # yd = MOI.get(m, MOI.ConstraintDual(), bndy)
             # @test xd > atol
             # @test yd > atol
             # @test yd ≈ -cd atol=atol rtol=rtol
             # @test xd ≈ -2cd atol=atol rtol=rtol
         else
             # solver returned nothing
-            @test MOI.getattribute(m, MOI.ResultCount()) == 0
-            @test MOI.cangetattribute(m, MOI.PrimalStatus(1)) == false
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
-                MOI.getattribute(m, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+            @test MOI.get(m, MOI.ResultCount()) == 0
+            @test MOI.canget(m, MOI.PrimalStatus(1)) == false
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
+                MOI.get(m, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
     end
     @testset "test unbounded problem" begin
@@ -831,21 +831,21 @@ function linear8test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         MOI.addconstraint!(m, MOI.ScalarAffineFunction([x,y], [-1.0,2.0], 0.0), MOI.LessThan(0.0))
         MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [-1.0, -1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [-1.0, -1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        if MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        if MOI.get(m, MOI.ResultCount()) >= 1
             # solver returned an unbounded ray
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
         else
             # solver returned nothing
-            @test MOI.getattribute(m, MOI.ResultCount()) == 0
-            @test MOI.cangetattribute(m, MOI.PrimalStatus(1)) == false
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
-                MOI.getattribute(m, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+            @test MOI.get(m, MOI.ResultCount()) == 0
+            @test MOI.canget(m, MOI.PrimalStatus(1)) == false
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
+                MOI.get(m, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
     end
     @testset "unbounded problem with unique ray" begin
@@ -860,25 +860,25 @@ function linear8test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
         MOI.addconstraint!(m, MOI.ScalarAffineFunction([x,y], [1.0,-1.0], 0.0), MOI.EqualTo(0.0))
         MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
         MOI.addconstraint!(m, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
-        MOI.setattribute!(m, MOI.ObjectiveFunction(),MOI.ScalarAffineFunction([x, y], [-1.0, -1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(),MOI.ScalarAffineFunction([x, y], [-1.0, -1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        if MOI.getattribute(m, MOI.ResultCount()) > 0
+        @test MOI.canget(m, MOI.ResultCount())
+        if MOI.get(m, MOI.ResultCount()) > 0
             # solver returned an unbounded ray
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), [x, y])
-            ray = MOI.getattribute(m, MOI.VariablePrimal(), [x,y])
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(m, MOI.VariablePrimal(), [x, y])
+            ray = MOI.get(m, MOI.VariablePrimal(), [x,y])
             @test ray[1] ≈ ray[2] atol=atol rtol=rtol
 
         else
             # solver returned nothing
-            @test MOI.getattribute(m, MOI.ResultCount()) == 0
-            @test MOI.cangetattribute(m, MOI.PrimalStatus(1)) == false
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
-                MOI.getattribute(m, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+            @test MOI.get(m, MOI.ResultCount()) == 0
+            @test MOI.canget(m, MOI.PrimalStatus(1)) == false
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
+                MOI.get(m, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
     end
 end
@@ -928,18 +928,18 @@ function linear9test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
             ]
         )
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(),
+        MOI.set!(m, MOI.ObjectiveFunction(),
                           MOI.ScalarAffineFunction([x, y], [1_000.0, 350.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 79e4/11 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 650/11 atol=atol rtol=rtol
-        @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 400/11 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 79e4/11 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 650/11 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 400/11 atol=atol rtol=rtol
     end
 
 end
@@ -968,54 +968,54 @@ function linear10test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64)
 
         c = MOI.addconstraint!(m, MOI.ScalarAffineFunction([x,y], [1.0, 1.0], 0.0), MOI.Interval(5.0, 10.0))
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
 
-        if MOI.getattribute(solver, MOI.SupportsDuals())
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        if MOI.get(solver, MOI.SupportsDuals())
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
         end
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
 
-        if MOI.getattribute(solver, MOI.SupportsDuals())
-            @test MOI.cangetattribute(m, MOI.DualStatus())
-            @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-            @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
+        if MOI.get(solver, MOI.SupportsDuals())
+            @test MOI.canget(m, MOI.DualStatus())
+            @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.ConstraintDual(), c)
+            @test MOI.get(m, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
         end
 
         @test MOI.canmodifyconstraint(m, c, MOI.Interval(2.0, 12.0))
         MOI.modifyconstraint!(m, c, MOI.Interval(2.0, 12.0))
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
     end
 end
 
@@ -1039,14 +1039,14 @@ function linear11test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64)
         c1 = MOI.addconstraint!(m, MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0), MOI.GreaterThan(1.0))
         c2 = MOI.addconstraint!(m, MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0), MOI.GreaterThan(2.0))
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
 
         @test MOI.cantransformconstraint(m, c2, MOI.LessThan(2.0))
         c3 = MOI.transformconstraint!(m, c2, MOI.LessThan(2.0))
@@ -1057,9 +1057,9 @@ function linear11test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64)
 
         MOI.optimize!(m)
 
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 1.0 atol=atol rtol=rtol
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 1.0 atol=atol rtol=rtol
     end
 end
 

--- a/test/contquadratic.jl
+++ b/test/contquadratic.jl
@@ -18,45 +18,45 @@ function qp1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rto
         m = MOI.SolverInstance(solver)
 
         v = MOI.addvariables!(m, 3)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
+        @test MOI.get(m, MOI.NumberOfVariables()) == 3
 
         cf1 = MOI.ScalarAffineFunction(v, [1.0,2.0,3.0], 0.0)
         c1 = MOI.addconstraint!(m, cf1, MOI.GreaterThan(4.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
 
         c2 = MOI.addconstraint!(m, MOI.ScalarAffineFunction([v[1],v[2]], [1.0,1.0], 0.0), MOI.GreaterThan(1.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
 
         obj = MOI.ScalarQuadraticFunction(MOI.VariableReference[], Float64[], v[[1,1,2,2,3]], v[[1,2,2,3,3]], [2.0, 1.0, 2.0, 1.0, 2.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), obj)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MinSense
+        MOI.set!(m, MOI.ObjectiveFunction(), obj)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MinSense
 
-        if MOI.cangetattribute(m, MOI.ObjectiveFunction())
-            @test obj ≈ MOI.getattribute(m, MOI.ObjectiveFunction())
+        if MOI.canget(m, MOI.ObjectiveFunction())
+            @test obj ≈ MOI.get(m, MOI.ObjectiveFunction())
         end
 
-        if MOI.cangetattribute(m, MOI.ConstraintFunction(), c1)
-            @test cf1 ≈ MOI.getattribute(m, MOI.ConstraintFunction(), c1)
+        if MOI.canget(m, MOI.ConstraintFunction(), c1)
+            @test cf1 ≈ MOI.get(m, MOI.ConstraintFunction(), c1)
         end
 
-        if MOI.cangetattribute(m, MOI.ConstraintSet(), c1)
-            @test MOI.GreaterThan(4.0) == MOI.getattribute(m, MOI.ConstraintSet(), c1)
+        if MOI.canget(m, MOI.ConstraintSet(), c1)
+            @test MOI.GreaterThan(4.0) == MOI.get(m, MOI.ConstraintSet(), c1)
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
     end
 end
 
@@ -75,69 +75,69 @@ function qp2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rto
         m = MOI.SolverInstance(solver)
 
         v = MOI.addvariables!(m, 3)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
+        @test MOI.get(m, MOI.NumberOfVariables()) == 3
 
         c1f = MOI.ScalarAffineFunction(v, [1.0,2.0,3.0], 0.0)
         c1 = MOI.addconstraint!(m, c1f, MOI.GreaterThan(4.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
 
         c2 = MOI.addconstraint!(m, MOI.ScalarAffineFunction([v[1],v[2]], [1.0,1.0], 0.0), MOI.GreaterThan(1.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
 
         obj = MOI.ScalarQuadraticFunction(v, [0.0,0.0,0.0],[v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]], [2.0, 0.5, 0.5, 2.0, 1.0, 1.0, 1.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), obj)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MinSense
+        MOI.set!(m, MOI.ObjectiveFunction(), obj)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MinSense
 
-        if MOI.cangetattribute(m, MOI.ObjectiveFunction())
-            @test obj ≈ MOI.getattribute(m, MOI.ObjectiveFunction())
+        if MOI.canget(m, MOI.ObjectiveFunction())
+            @test obj ≈ MOI.get(m, MOI.ObjectiveFunction())
         end
 
-        if MOI.cangetattribute(m, MOI.ConstraintFunction(), c1)
-            @test c1f ≈ MOI.getattribute(m, MOI.ConstraintFunction(), c1)
+        if MOI.canget(m, MOI.ConstraintFunction(), c1)
+            @test c1f ≈ MOI.get(m, MOI.ConstraintFunction(), c1)
         end
 
-        if MOI.cangetattribute(m, MOI.ConstraintSet(), c1)
-            @test MOI.GreaterThan(4.0) == MOI.getattribute(m, MOI.ConstraintSet(), c1)
+        if MOI.canget(m, MOI.ConstraintSet(), c1)
+            @test MOI.GreaterThan(4.0) == MOI.get(m, MOI.ConstraintSet(), c1)
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
 
         # change objective to Max -2(x^2 + xy + y^2 + yz + z^2)
         obj2 = MOI.ScalarQuadraticFunction(v, [0.0,0.0,0.0],[v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]], [-4.0, -1.0, -1.0, -4.0, -2.0, -2.0, -2.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), obj2)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MaxSense
+        MOI.set!(m, MOI.ObjectiveFunction(), obj2)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
 
-        if MOI.cangetattribute(m, MOI.ObjectiveFunction())
-            @test obj2 ≈ MOI.getattribute(m, MOI.ObjectiveFunction())
+        if MOI.canget(m, MOI.ObjectiveFunction())
+            @test obj2 ≈ MOI.get(m, MOI.ObjectiveFunction())
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -2*130/70 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ -2*130/70 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
     end
 end
 
@@ -172,21 +172,21 @@ function qp3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rto
                 [x,y,x], [x,y,y], [4.0, 2.0, 1.0],
                 1.0
               )
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), obj)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), obj)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2.875 atol=atol rtol=rtol
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), [x,y])
-        @test MOI.getattribute(m, MOI.VariablePrimal(), [x,y]) ≈ [0.25, 0.75] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2.875 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), [x,y])
+        @test MOI.get(m, MOI.VariablePrimal(), [x,y]) ≈ [0.25, 0.75] atol=atol rtol=rtol
 
         # change back to linear
         #        max 2x + y + 1
@@ -194,21 +194,21 @@ function qp3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rto
         #             x + y = 1
         # (x,y) = (1,0), obj = 3
         objf = MOI.ScalarAffineFunction([x,y], [2.0,1.0], 1.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), obj)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), obj)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), [x,y])
-        @test MOI.getattribute(m, MOI.VariablePrimal(), [x,y]) ≈ [1.0, 0.0] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), [x,y])
+        @test MOI.get(m, MOI.VariablePrimal(), [x,y]) ≈ [1.0, 0.0] atol=atol rtol=rtol
 
     end
 end
@@ -240,36 +240,36 @@ function qcp1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
 
         x = MOI.addvariable!(m)
         y = MOI.addvariable!(m)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 2
+        @test MOI.get(m, MOI.NumberOfVariables()) == 2
 
         c1 = MOI.addconstraint!(m, MOI.VectorAffineFunction([1,1,2,2], [x,y,x,y],[-1.0,1.0,1.0,1.0], [0.0,0.0]), MOI.Nonnegatives(2))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}()) == 1
 
         c2f = MOI.ScalarQuadraticFunction([y],[1.0],[x],[x],[1.0], 0.0)
         c2 = MOI.addconstraint!(m, c2f, MOI.LessThan(2.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y], [1.0,1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MaxSense
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x,y], [1.0,1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
 
-        if MOI.cangetattribute(m, MOI.ConstraintFunction(), c2)
-            @test c2f ≈ MOI.getattribute(m, MOI.ConstraintFunction(), c2)
+        if MOI.canget(m, MOI.ConstraintFunction(), c2)
+            @test c2f ≈ MOI.get(m, MOI.ConstraintFunction(), c2)
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 2.25 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 2.25 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), [x,y])
-        @test MOI.getattribute(m, MOI.VariablePrimal(), [x,y]) ≈ [0.5,1.75] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), [x,y])
+        @test MOI.get(m, MOI.VariablePrimal(), [x,y]) ≈ [0.5,1.75] atol=atol rtol=rtol
 
         # try delete quadratic constraint and go back to linear
 
@@ -277,14 +277,14 @@ function qcp1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
         #
         # MOI.optimize!(m)
         #
-        # @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        # @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        # @test MOI.canget(m, MOI.TerminationStatus())
+        # @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
         #
-        # @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        # @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        # @test MOI.canget(m, MOI.PrimalStatus())
+        # @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
         #
-        # @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        # @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        # @test MOI.canget(m, MOI.ObjectiveValue())
+        # @test MOI.get(m, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
     end
 end
 
@@ -299,40 +299,40 @@ function qcp2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
         m = MOI.SolverInstance(solver)
 
         x = MOI.addvariable!(m)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 1
+        @test MOI.get(m, MOI.NumberOfVariables()) == 1
 
         cf = MOI.ScalarQuadraticFunction(MOI.VariableReference[x],Float64[0.0],[x],[x],[1.0], 0.0)
         c = MOI.addconstraint!(m, cf, MOI.LessThan(2.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MaxSense
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
 
-        if MOI.cangetattribute(m, MOI.ConstraintFunction(), c)
-            @test cf ≈ MOI.getattribute(m, MOI.ConstraintFunction(), c)
+        if MOI.canget(m, MOI.ConstraintFunction(), c)
+            @test cf ≈ MOI.get(m, MOI.ConstraintFunction(), c)
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.DualStatus())
-        @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.DualStatus())
+        @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), x)
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
 
         # TODO - duals
-        # @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-        # @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ 0.5/sqrt(2) atol=atol rtol=rtol
+        # @test MOI.canget(m, MOI.ConstraintDual(), c)
+        # @test MOI.get(m, MOI.ConstraintDual(), c) ≈ 0.5/sqrt(2) atol=atol rtol=rtol
     end
 end
 
@@ -346,40 +346,40 @@ function qcp3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
         m = MOI.SolverInstance(solver)
 
         x = MOI.addvariable!(m)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 1
+        @test MOI.get(m, MOI.NumberOfVariables()) == 1
 
         cf = MOI.ScalarQuadraticFunction(MOI.VariableReference[],Float64[],[x],[x],[1.0], 0.0)
         c = MOI.addconstraint!(m, cf, MOI.LessThan(2.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x], [-1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MinSense
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([x], [-1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MinSense
 
-        if MOI.cangetattribute(m, MOI.ConstraintFunction(), c)
-            @test cf ≈ MOI.getattribute(m, MOI.ConstraintFunction(), c)
+        if MOI.canget(m, MOI.ConstraintFunction(), c)
+            @test cf ≈ MOI.get(m, MOI.ConstraintFunction(), c)
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.DualStatus())
-        @test MOI.getattribute(m, MOI.DualStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.DualStatus())
+        @test MOI.get(m, MOI.DualStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -sqrt(2) atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ -sqrt(2) atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), x)
+        @test MOI.get(m, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
 
         # TODO - duals
-        # @test MOI.cangetattribute(m, MOI.ConstraintDual(), c)
-        # @test MOI.getattribute(m, MOI.ConstraintDual(), c) ≈ -0.5/sqrt(2) atol=atol rtol=rtol
+        # @test MOI.canget(m, MOI.ConstraintDual(), c)
+        # @test MOI.get(m, MOI.ConstraintDual(), c) ≈ -0.5/sqrt(2) atol=atol rtol=rtol
     end
 end
 
@@ -409,47 +409,47 @@ function socp1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), r
         x = MOI.addvariable!(m)
         y = MOI.addvariable!(m)
         t = MOI.addvariable!(m)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
+        @test MOI.get(m, MOI.NumberOfVariables()) == 3
 
         c1f = MOI.ScalarAffineFunction([x,y],[1.0, 1.0], 0.0)
         c1 = MOI.addconstraint!(m, c1f, MOI.GreaterThan(1.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
 
         c2f = MOI.ScalarQuadraticFunction(MOI.VariableReference[],Float64[],[x,y,t],[x,y,t],[1.0,1.0,-1.0], 0.0)
         c2 = MOI.addconstraint!(m, c2f, MOI.LessThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
         bound = MOI.addconstraint!(m, MOI.SingleVariable(t), MOI.GreaterThan(0.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable, MOI.GreaterThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable, MOI.GreaterThan{Float64}}()) == 1
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([t], [1.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MinSense
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([t], [1.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MinSense
 
-        if MOI.cangetattribute(m, MOI.ConstraintFunction(), c1)
-            @test c1f ≈ MOI.getattribute(m, MOI.ConstraintFunction(), c1)
+        if MOI.canget(m, MOI.ConstraintFunction(), c1)
+            @test c1f ≈ MOI.get(m, MOI.ConstraintFunction(), c1)
         end
 
-        if MOI.cangetattribute(m, MOI.ConstraintFunction(), c2)
-            @test c2f ≈ MOI.getattribute(m, MOI.ConstraintFunction(), c2)
+        if MOI.canget(m, MOI.ConstraintFunction(), c2)
+            @test c2f ≈ MOI.get(m, MOI.ConstraintFunction(), c2)
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ sqrt(1/2) atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ sqrt(1/2) atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), [x,y,t])
-        @test MOI.getattribute(m, MOI.VariablePrimal(), [x,y,t]) ≈ [0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), [x,y,t])
+        @test MOI.get(m, MOI.VariablePrimal(), [x,y,t]) ≈ [0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), [t,x,y,t])
-        @test MOI.getattribute(m, MOI.VariablePrimal(), [t,x,y,t]) ≈ [sqrt(1/2),0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), [t,x,y,t])
+        @test MOI.get(m, MOI.VariablePrimal(), [t,x,y,t]) ≈ [sqrt(1/2),0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
     end
 end
 

--- a/test/intconic.jl
+++ b/test/intconic.jl
@@ -20,15 +20,15 @@ function intsoc1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
 
             x,y,z = MOI.addvariables!(m, 3)
 
-            MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([y,z],[-2.0,-1.0],0.0))
-            MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([y,z],[-2.0,-1.0],0.0))
+            MOI.set!(m, MOI.ObjectiveSense(), MOI.MinSense)
 
             ceq = MOI.addconstraint!(m, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Zeros(1))
             csoc = MOI.addconstraint!(m, MOI.VectorOfVariables([x,y,z]), MOI.SecondOrderCone(3))
 
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-            @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
-            loc = MOI.getattribute(m, MOI.ListOfConstraints())
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+            @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
+            loc = MOI.get(m, MOI.ListOfConstraints())
             @test length(loc) == 2
             @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
             @test (MOI.VectorOfVariables,MOI.SecondOrderCone) in loc
@@ -38,19 +38,19 @@ function intsoc1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64),
 
             MOI.optimize!(m)
 
-            @test MOI.cangetattribute(m, MOI.TerminationStatus())
-            @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.canget(m, MOI.TerminationStatus())
+            @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.cangetattribute(m, MOI.PrimalStatus())
-            @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(m, MOI.PrimalStatus())
+            @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-            @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-            @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ -2 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.ObjectiveValue())
+            @test MOI.get(m, MOI.ObjectiveValue()) ≈ -2 atol=atol rtol=rtol
 
-            @test MOI.cangetattribute(m, MOI.VariablePrimal(), x)
-            @test MOI.getattribute(m, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), y) ≈ 1 atol=atol rtol=rtol
-            @test MOI.getattribute(m, MOI.VariablePrimal(), z) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(m, MOI.VariablePrimal(), x)
+            @test MOI.get(m, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), y) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(m, MOI.VariablePrimal(), z) ≈ 0 atol=atol rtol=rtol
 
         end
     end

--- a/test/intlinear.jl
+++ b/test/intlinear.jl
@@ -21,76 +21,76 @@ function int1test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
         m = MOI.SolverInstance(solver)
 
         v = MOI.addvariables!(m, 3)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
+        @test MOI.get(m, MOI.NumberOfVariables()) == 3
 
         cf = MOI.ScalarAffineFunction(v, [1.0,1.0,1.0], 0.0)
         c = MOI.addconstraint!(m, cf, MOI.LessThan(10.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
         cf2 = MOI.ScalarAffineFunction(v, [1.0,2.0,1.0], 0.0)
         c2 = MOI.addconstraint!(m, cf2, MOI.LessThan(15.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
 
 
         MOI.addconstraint!(m, MOI.SingleVariable(v[1]), MOI.Interval(0.0, 5.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}()) == 1
 
         MOI.addconstraint!(m, MOI.SingleVariable(v[2]), MOI.Interval(0.0, 10.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}()) == 2
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}()) == 2
         MOI.addconstraint!(m, MOI.SingleVariable(v[2]), MOI.Integer())
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Integer}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Integer}()) == 1
 
         MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.ZeroOne())
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 1
 
         objf = MOI.ScalarAffineFunction(v, [1.1, 2.0, 5.0], 0.0)
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), objf)
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
-        @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MaxSense
+        @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.ResultCount())
-        @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+        @test MOI.canget(m, MOI.ResultCount())
+        @test MOI.get(m, MOI.ResultCount()) >= 1
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 19.4 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 19.4 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [4,5,1] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [4,5,1] atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c)
-        @test MOI.getattribute(m, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ConstraintPrimal(), c)
+        @test MOI.get(m, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.ConstraintPrimal(), c2)
-        @test MOI.getattribute(m, MOI.ConstraintPrimal(), c2) ≈ 15 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ConstraintPrimal(), c2)
+        @test MOI.get(m, MOI.ConstraintPrimal(), c2) ≈ 15 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.DualStatus()) == false
+        @test MOI.canget(m, MOI.DualStatus()) == false
 
-        if MOI.cangetattribute(m, MOI.ObjectiveBound())
-            @test MOI.getattribute(m, MOI.ObjectiveBound()) >= 19.4
+        if MOI.canget(m, MOI.ObjectiveBound())
+            @test MOI.get(m, MOI.ObjectiveBound()) >= 19.4
         end
-        if MOI.cangetattribute(m, MOI.RelativeGap())
-            @test MOI.getattribute(m, MOI.RelativeGap()) >= 0.0
+        if MOI.canget(m, MOI.RelativeGap())
+            @test MOI.get(m, MOI.RelativeGap()) >= 0.0
         end
-        if MOI.cangetattribute(m, MOI.SolveTime())
-            @test MOI.getattribute(m, MOI.SolveTime()) >= 0.0
+        if MOI.canget(m, MOI.SolveTime())
+            @test MOI.get(m, MOI.SolveTime()) >= 0.0
         end
-        if MOI.cangetattribute(m, MOI.SimplexIterations())
-            @test MOI.getattribute(m, MOI.SimplexIterations()) >= 0
+        if MOI.canget(m, MOI.SimplexIterations())
+            @test MOI.get(m, MOI.SimplexIterations()) >= 0
         end
-        if MOI.cangetattribute(m, MOI.BarrierIterations())
-            @test MOI.getattribute(m, MOI.BarrierIterations()) >= 0
+        if MOI.canget(m, MOI.BarrierIterations())
+            @test MOI.get(m, MOI.BarrierIterations()) >= 0
         end
-        if MOI.cangetattribute(m, MOI.NodeCount())
-            @test MOI.getattribute(m, MOI.NodeCount()) >= 0
+        if MOI.canget(m, MOI.NodeCount())
+            @test MOI.get(m, MOI.NodeCount()) >= 0
         end
 
     end
@@ -109,51 +109,51 @@ function int2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
                 m = MOI.SolverInstance(solver)
 
                 v = MOI.addvariables!(m, 3)
-                @test MOI.getattribute(m, MOI.NumberOfVariables()) == 3
+                @test MOI.get(m, MOI.NumberOfVariables()) == 3
                 MOI.addconstraint!(m, MOI.SingleVariable(v[1]), MOI.LessThan(1.0))
                 MOI.addconstraint!(m, MOI.SingleVariable(v[2]), MOI.LessThan(1.0))
                 MOI.addconstraint!(m, MOI.SingleVariable(v[3]), MOI.LessThan(2.0))
 
                 c1 = MOI.addconstraint!(m, MOI.VectorOfVariables([v[1], v[2]]), MOI.SOS1([1.0, 2.0]))
                 c2 = MOI.addconstraint!(m, MOI.VectorOfVariables([v[1], v[3]]), MOI.SOS1([1.0, 2.0]))
-                @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SOS1}()) == 2
+                @test MOI.get(m, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SOS1}()) == 2
 
 
-                @test MOI.cangetattribute(m, MOI.ConstraintSet(), c2)
-                @test MOI.cangetattribute(m, MOI.ConstraintFunction(), c2)
+                @test MOI.canget(m, MOI.ConstraintSet(), c2)
+                @test MOI.canget(m, MOI.ConstraintFunction(), c2)
                 #=
                     To allow for permutations in the sets and variable vectors
                     we're going to sort according to the weights
                 =#
-                cs_sos = MOI.getattribute(m, MOI.ConstraintSet(), c2)
-                cf_sos = MOI.getattribute(m, MOI.ConstraintFunction(), c2)
+                cs_sos = MOI.get(m, MOI.ConstraintSet(), c2)
+                cf_sos = MOI.get(m, MOI.ConstraintFunction(), c2)
                 p = sortperm(cs_sos.weights)
                 @test cs_sos.weights[p] ≈ [1.0, 2.0] atol=atol rtol=rtol
                 @test cf_sos.variables[p] == v[[1,3]]
 
                 objf = MOI.ScalarAffineFunction(v, [2.0, 1.0, 1.0], 0.0)
-                MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-                MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
-                @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MaxSense
+                MOI.set!(m, MOI.ObjectiveFunction(), objf)
+                MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+                @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
 
                 MOI.optimize!(m)
 
-                @test MOI.cangetattribute(m, MOI.TerminationStatus())
-                @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+                @test MOI.canget(m, MOI.TerminationStatus())
+                @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-                @test MOI.cangetattribute(m, MOI.ResultCount())
-                @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+                @test MOI.canget(m, MOI.ResultCount())
+                @test MOI.get(m, MOI.ResultCount()) >= 1
 
-                @test MOI.cangetattribute(m, MOI.PrimalStatus())
-                @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+                @test MOI.canget(m, MOI.PrimalStatus())
+                @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-                @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-                @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.ObjectiveValue())
+                @test MOI.get(m, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-                @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-                @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [0,1,2] atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.VariablePrimal(), v)
+                @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [0,1,2] atol=atol rtol=rtol
 
-                @test MOI.cangetattribute(m, MOI.DualStatus()) == false
+                @test MOI.canget(m, MOI.DualStatus()) == false
 
                 @test MOI.candelete(m, c1)
                 MOI.delete!(m, c1)
@@ -162,20 +162,20 @@ function int2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
 
                 MOI.optimize!(m)
 
-                @test MOI.cangetattribute(m, MOI.TerminationStatus())
-                @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+                @test MOI.canget(m, MOI.TerminationStatus())
+                @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-                @test MOI.cangetattribute(m, MOI.ResultCount())
-                @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+                @test MOI.canget(m, MOI.ResultCount())
+                @test MOI.get(m, MOI.ResultCount()) >= 1
 
-                @test MOI.cangetattribute(m, MOI.PrimalStatus())
-                @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+                @test MOI.canget(m, MOI.PrimalStatus())
+                @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-                @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-                @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 5 atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.ObjectiveValue())
+                @test MOI.get(m, MOI.ObjectiveValue()) ≈ 5 atol=atol rtol=rtol
 
-                @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-                @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [1,1,2] atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.VariablePrimal(), v)
+                @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [1,1,2] atol=atol rtol=rtol
             end
             @testset "SOSII" begin
                 @test MOI.supportsproblem(solver,
@@ -191,7 +191,7 @@ function int2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
                 m = MOI.SolverInstance(solver)
 
                 v = MOI.addvariables!(m, 10)
-                @test MOI.getattribute(m, MOI.NumberOfVariables()) == 10
+                @test MOI.get(m, MOI.NumberOfVariables()) == 10
 
                 bin_constraints = []
                 for i in 1:8
@@ -218,41 +218,41 @@ function int2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
                 sos2 = MOI.SOS2([5.0, 4.0, 7.0, 2.0, 1.0])
                 c = MOI.addconstraint!(m, vv, sos2)
 
-                @test MOI.cangetattribute(m, MOI.ConstraintSet(), c)
-                @test MOI.cangetattribute(m, MOI.ConstraintFunction(), c)
+                @test MOI.canget(m, MOI.ConstraintSet(), c)
+                @test MOI.canget(m, MOI.ConstraintFunction(), c)
                 #=
                     To allow for permutations in the sets and variable vectors
                     we're going to sort according to the weights
                 =#
-                cs_sos = MOI.getattribute(m, MOI.ConstraintSet(), c)
-                cf_sos = MOI.getattribute(m, MOI.ConstraintFunction(), c)
+                cs_sos = MOI.get(m, MOI.ConstraintSet(), c)
+                cf_sos = MOI.get(m, MOI.ConstraintFunction(), c)
                 p = sortperm(cs_sos.weights)
                 @test cs_sos.weights[p] ≈ [1.0, 2.0, 4.0, 5.0, 7.0] atol=atol rtol=rtol
                 @test cf_sos.variables[p] == v[[8,7,5,4,6]]
 
                 objf = MOI.ScalarAffineFunction([v[9], v[10]], [1.0, 1.0], 0.0)
-                MOI.setattribute!(m, MOI.ObjectiveFunction(), objf)
-                MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
-                @test MOI.getattribute(m, MOI.ObjectiveSense()) == MOI.MaxSense
+                MOI.set!(m, MOI.ObjectiveFunction(), objf)
+                MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+                @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
 
                 MOI.optimize!(m)
 
-                @test MOI.cangetattribute(m, MOI.TerminationStatus())
-                @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+                @test MOI.canget(m, MOI.TerminationStatus())
+                @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-                @test MOI.cangetattribute(m, MOI.ResultCount())
-                @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+                @test MOI.canget(m, MOI.ResultCount())
+                @test MOI.get(m, MOI.ResultCount()) >= 1
 
-                @test MOI.cangetattribute(m, MOI.PrimalStatus())
-                @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+                @test MOI.canget(m, MOI.PrimalStatus())
+                @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-                @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-                @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 15.0 atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.ObjectiveValue())
+                @test MOI.get(m, MOI.ObjectiveValue()) ≈ 15.0 atol=atol rtol=rtol
 
-                @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-                @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 3.0, 12.0] atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.VariablePrimal(), v)
+                @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 3.0, 12.0] atol=atol rtol=rtol
 
-                @test MOI.cangetattribute(m, MOI.DualStatus()) == false
+                @test MOI.canget(m, MOI.DualStatus()) == false
 
                 for cref in bin_constraints
                     @test MOI.candelete(m, cref)
@@ -261,22 +261,22 @@ function int2test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
 
                 MOI.optimize!(m)
 
-                @test MOI.cangetattribute(m, MOI.TerminationStatus())
-                @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+                @test MOI.canget(m, MOI.TerminationStatus())
+                @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-                @test MOI.cangetattribute(m, MOI.ResultCount())
-                @test MOI.getattribute(m, MOI.ResultCount()) >= 1
+                @test MOI.canget(m, MOI.ResultCount())
+                @test MOI.get(m, MOI.ResultCount()) >= 1
 
-                @test MOI.cangetattribute(m, MOI.PrimalStatus())
-                @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+                @test MOI.canget(m, MOI.PrimalStatus())
+                @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-                @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-                @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 30.0 atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.ObjectiveValue())
+                @test MOI.get(m, MOI.ObjectiveValue()) ≈ 30.0 atol=atol rtol=rtol
 
-                @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-                @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 2.0, 2.0, 0.0, 2.0, 0.0, 0.0, 6.0, 24.0] atol=atol rtol=rtol
+                @test MOI.canget(m, MOI.VariablePrimal(), v)
+                @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 2.0, 2.0, 0.0, 2.0, 0.0, 0.0, 6.0, 24.0] atol=atol rtol=rtol
 
-                @test MOI.cangetattribute(m, MOI.DualStatus()) == false
+                @test MOI.canget(m, MOI.DualStatus()) == false
             end
         end
     end
@@ -313,31 +313,31 @@ function int3test(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64), rt
 
         c = MOI.addconstraint!(m, MOI.ScalarAffineFunction(vcat(z, b), vcat(1.0, fill(-0.5 / 40, 10)), 0.0), MOI.Interval(0.0, 0.999))
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(vcat(z, b[1:3]), vcat(1.0, fill(-0.5 / 40, 3)), 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(vcat(z, b[1:3]), vcat(1.0, fill(-0.5 / 40, 3)), 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
         # test for CPLEX.jl #76
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
     end
 end
 
@@ -356,35 +356,35 @@ function knapsacktest(solver::MOI.AbstractSolver; atol=Base.rtoldefault(Float64)
         @test MOI.supportsproblem(solver, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.ZeroOne),(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64})])
 
         v = MOI.addvariables!(m, 5)
-        @test MOI.getattribute(m, MOI.NumberOfVariables()) == 5
+        @test MOI.get(m, MOI.NumberOfVariables()) == 5
 
         for vi in v
             MOI.addconstraint!(m, MOI.SingleVariable(vi), MOI.ZeroOne())
         end
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 5
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 5
         c = MOI.addconstraint!(m, MOI.ScalarAffineFunction(v, [2.0, 8.0, 4.0, 2.0, 5.0], 0.0), MOI.LessThan(10.0))
-        @test MOI.getattribute(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+        @test MOI.get(m, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
-        MOI.setattribute!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [5.0, 3.0, 2.0, 7.0, 4.0], 0.0))
-        MOI.setattribute!(m, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set!(m, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction(v, [5.0, 3.0, 2.0, 7.0, 4.0], 0.0))
+        MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
 
-        if MOI.cansetattribute(m, MOI.VariablePrimalStart(), v)
-            MOI.setattribute!(m, MOI.VariablePrimalStart(), v, [0.0, 0.0, 0.0, 0.0, 0.0])
+        if MOI.canset(m, MOI.VariablePrimalStart(), v)
+            MOI.set!(m, MOI.VariablePrimalStart(), v, [0.0, 0.0, 0.0, 0.0, 0.0])
         end
 
         MOI.optimize!(m)
 
-        @test MOI.cangetattribute(m, MOI.TerminationStatus())
-        @test MOI.getattribute(m, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.canget(m, MOI.TerminationStatus())
+        @test MOI.get(m, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.cangetattribute(m, MOI.PrimalStatus())
-        @test MOI.getattribute(m, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
+        @test MOI.canget(m, MOI.PrimalStatus())
+        @test MOI.get(m, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
 
-        @test MOI.cangetattribute(m, MOI.ObjectiveValue())
-        @test MOI.getattribute(m, MOI.ObjectiveValue()) ≈ 16 atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.ObjectiveValue())
+        @test MOI.get(m, MOI.ObjectiveValue()) ≈ 16 atol=atol rtol=rtol
 
-        @test MOI.cangetattribute(m, MOI.VariablePrimal(), v)
-        @test MOI.getattribute(m, MOI.VariablePrimal(), v) ≈ [1, 0, 0, 1, 1] atol=atol rtol=rtol
+        @test MOI.canget(m, MOI.VariablePrimal(), v)
+        @test MOI.get(m, MOI.VariablePrimal(), v) ≈ [1, 0, 0, 1, 1] atol=atol rtol=rtol
     end
 end
 


### PR DESCRIPTION
The tests and examples seem to look pretty clean now. This should be fine as along as we never plan on exporting these names.

Will allow us to use `MOI.get` to look up variables and constraints by name (#151). I'll merge this automatically if the following conditions hold:
- 24 hours have passed
- No objections
- At least three thumbs up