### PR TITLE
define lookup by name 

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -67,6 +67,18 @@ Return an attribute `attr` of the constraint `c` in instance `m`.
 
 Return a vector of attributes corresponding to each constraint in the collection `c` in the instance `m`.
 
+    get(m::AbstractInstance, ::Type{VariableReference}, name::String)
+
+If a variable with name `name` exists in the instance `m`, return the corresponding reference object, otherwise throw a `KeyError`.
+
+    get(m::AbstractInstance, ::Type{ConstraintReference{F,S}}, name::String) where {F<:AbstractFunction,S<:AbstractSet}
+
+If an `F`-in-`S` constraint with name `name` exists in the instance `m`, return the corresponding reference object, otherwise throw a `KeyError`.
+
+    get(m::AbstractInstance, ::Type{ConstraintReference}, name::String)
+
+If *any* constraint with name `name` exists in the instance `m`, return the corresponding reference object, otherwise throw a `KeyError`. This version is available for convenience but may incur a performance penalty because it is not type stable.
+
 ### Examples
 
 ```julia
@@ -74,6 +86,9 @@ get(m, ObjectiveValue())
 get(m, VariablePrimal(), ref)
 get(m, VariablePrimal(5), [ref1, ref2])
 get(m, OtherAttribute("something specific to cplex"))
+get(m, VariableReference, "var1")
+get(m, ConstraintReference{ScalarAffineFunction{Float64},LessThan{Float64}}, "con1")
+get(m, ConstraintReference, "con1")
 ```
 """
 function get end
@@ -108,6 +123,19 @@ Return a `Bool` indicating whether the instance `m` currently has a value for th
 
 Return a `Bool` indicating whether the instance `m` currently has a value for the attributed specified by attribute type `attr` applied to *every* variable references in `v` or constraint reference in `c`.
 
+    canget(m::AbstractInstance, ::Type{VariableReference}, name::String)::Bool
+
+Return a `Bool` indicating if a variable with the name `name` exists in the instance.
+
+    canget(m::AbstractInstance, ::Type{ConstraintReference{F,S}}, name::String)::Bool where {F<:AbstractFunction,S<:AbstractSet}
+
+Return a `Bool` indicating if an `F`-in-`S` constraint with the name `name` exists in the instance `m`.
+
+    canget(m::AbstractInstance, ::Type{ConstraintReference}, name::String)::Bool
+
+Return a `Bool` indicating if a constraint of any kind with the name `name` exists in the instance `m`.
+
+
 ### Examples
 
 ```julia
@@ -115,6 +143,9 @@ canget(m, ObjectiveValue())
 canget(m, VariablePrimalStart(), varref)
 canget(m, ConstraintPrimal(), conref)
 canget(m, VariablePrimal(), [ref1, ref2])
+canget(m, VariableReference, "var1")
+canget(m, ConstraintReference{ScalarAffineFunction{Float64},LessThan{Float64}}, "con1")
+canget(m, ConstraintReference, "con1")
 ```
 """
 function canget end
@@ -369,7 +400,7 @@ struct ResultCount <: AbstractSolverInstanceAttribute end
 """
     VariableName()
 
-A string identifying the variable.
+A string identifying the variable. It is invalid for two variables to have the same name.
 """
 struct VariableName <: AbstractVariableAttribute end
 
@@ -418,7 +449,7 @@ Possible values are:
 """
     ConstraintName()
 
-A string identifying the constraint.
+A string identifying the constraint. It is invalid for two constraints of any kind to have the same name.
 """
 struct ConstraintName <: AbstractConstraintAttribute end
 

--- a/test/instance.jl
+++ b/test/instance.jl
@@ -1,0 +1,45 @@
+using MathOptInterface
+MOI = MathOptInterface
+
+# TODO: Move generic instance tests from MOIU to here
+
+function nametest(instance::MOI.AbstractInstance)
+    @testset "Name test" begin
+        @test MOI.get(instance, MOI.NumberOfVariables()) == 0
+        @test MOI.get(instance, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}) == 0
+
+        v = MOI.addvariables!(instance, 2)
+        @test MOI.canset(instance, MOI.VariableName(), v[1])
+        @test MOI.canget(instance, MOI.VariableName(), v[1])
+        @test MOI.get(instance, MOI.VariableName(), v[1]) == ""
+
+        MOI.set!(instance, MOI.VariableName(), v[1], "Var1")
+        MOI.set!(instance, MOI.VariableName(), v[2], "Var2")
+
+        @test MOI.canget(instance, MOI.VariableReference, "Var1")
+        @test !MOI.canget(instance, MOI.VariableReference, "Var3")
+
+        @test MOI.get(instance, MOI.VariableReference, "Var1") == v[1]
+        @test MOI.get(instance, MOI.VariableReference, "Var2") == v[2]
+        @test_throws KeyError MOI.get(instance, MOI.VariableReference, "Var3")
+
+        c = MOI.addconstraint!(m, MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0), MOI.LessThan(1.0))
+        @test MOI.canset(instance, MOI.ConstraintName(), c)
+        @test MOI.canget(instance, MOI.ConstraintName(), c)
+        @test MOI.get(instance, MOI.ConstraintName(), c) == ""
+
+        MOI.set!(instance, MOI.ConstraintName(), c, "Con1")
+
+        @test MOI.canget(instance, MOI.ConstraintReference{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
+        @test !MOI.canget(instance, MOI.ConstraintReference{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con2")
+        @test MOI.canget(instance, MOI.ConstraintReference, "Con1")
+        @test !MOI.canget(instance, MOI.ConstraintReference, "Con2")
+
+        @test MOI.get(instance, MOI.ConstraintReference{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1") == c
+        @test_throws KeyError MOI.get(instance, MOI.ConstraintReference{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con2")
+        @test MOI.get(instance, MOI.ConstraintReference, "Con1") == c
+        @test_throws KeyError MOI.get(instance, MOI.ConstraintReference, "Con2")
+
+        # TODO: Test for error when duplicate names are assigned
+    end
+end


### PR DESCRIPTION
Overload `get` and `canget` to look up a variable or constraint reference by name as proposed in #151.