### PR TITLE
Add function readinstance

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -53,6 +53,7 @@ AbstractInstance
 AbstractStandaloneInstance
 AbstractSolverInstance
 writeinstance
+readinstance
 ```
 
 List of instance attributes

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -53,7 +53,7 @@ AbstractInstance
 AbstractStandaloneInstance
 AbstractSolverInstance
 writeinstance
-readinstance
+readinstance!
 ```
 
 List of instance attributes

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -52,8 +52,9 @@ SupportsConicThroughQuadratic
 AbstractInstance
 AbstractStandaloneInstance
 AbstractSolverInstance
-writeinstance
-readinstance!
+write
+read!
+copy!
 ```
 
 List of instance attributes

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -70,6 +70,14 @@ Supported file types depend on the solver or standalone instance type.
 function writeinstance end
 
 """
+    readinstance(solver::AbstractSolver, filename::String)
+
+Create a new solver instance from the file `filename` using the solver `solver`.
+Supported file types depend on the solver.
+"""
+function readinstance end
+
+"""
     supportsproblem(s::AbstractSolver, objective_type::F, constraint_types::Vector)::Bool
 
 Return `true` if the solver supports optimizing a problem with objective type `F` and constraints of the types specified by `constraint_types` which is a list of tuples `(F,S)` for `F`-in-`S` constraints. Return false if the solver does not support this problem class.

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -82,7 +82,7 @@ Supported file types depend on the instance type.
 Read the model from the instance `src` into the instance `m`. If `m` is
 non-empty, this may throw an error.
 """
-function readinstance end
+function readinstance! end
 
 """
     supportsproblem(s::AbstractSolver, objective_type::F, constraint_types::Vector)::Bool

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -70,10 +70,17 @@ Supported file types depend on the solver or standalone instance type.
 function writeinstance end
 
 """
-    readinstance(solver::AbstractSolver, filename::String)
+    readinstance!(m::AbstractInstance, filename::String)
 
-Create a new solver instance from the file `filename` using the solver `solver`.
-Supported file types depend on the solver.
+Read the file `filename` into the instance `m`. If `m` is non-empty, this may
+throw an error.
+
+Supported file types depend on the instance type.
+
+    readinstance!(m::AbstractInstance, src::AbstractInstance)
+
+Read the model from the instance `src` into the instance `m`. If `m` is
+non-empty, this may throw an error.
 """
 function readinstance end
 

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -62,27 +62,30 @@ Users must discard the solver instance object after this method is invoked.
 function free! end
 
 """
-    writeinstance(m::AbstractInstance, filename::String)
+    write(m::AbstractInstance, filename::String)
 
 Writes the current instance data to the given file.
 Supported file types depend on the solver or standalone instance type.
 """
-function writeinstance end
+function write end
 
 """
-    readinstance!(m::AbstractInstance, filename::String)
+    read!(m::AbstractInstance, filename::String)
 
 Read the file `filename` into the instance `m`. If `m` is non-empty, this may
 throw an error.
 
 Supported file types depend on the instance type.
+"""
+function read! end
 
-    readinstance!(m::AbstractInstance, src::AbstractInstance)
+"""
+    copy!(dest::AbstractInstance, src::AbstractInstance)
 
-Read the model from the instance `src` into the instance `m`. If `m` is
+Copy the model from the instance `src` into the instance `dest`. If `dest` is
 non-empty, this may throw an error.
 """
-function readinstance! end
+function copy! end
 
 """
     supportsproblem(s::AbstractSolver, objective_type::F, constraint_types::Vector)::Bool


### PR DESCRIPTION
This PR renames `writeinstance` to `write` and adds two new methods:

`MathOptInstance.read!(instance::AbstractInstance, filename::String)`

and

`MathOptInstance.copy!(dest::AbstractInstance, src::AbstractInstance)`

We use `MathOptInstance.copy!` over `Base.copy!` for consistency with other MathOptInterface methods that have identical names (i.e. `get`) but do not overload the Base version.

For example:
```julia
grb = MOI.SolverInstance(GurobiSolver())
# ... problem creation etc ...
MOI.write(grb, "test.mps")

cpx = MOI.SolverInstance(CPLEXSolver())
MOI.read!(cpx, "test.mps")

xpr = MOI.SolverInstance(XpressSolver())
MOI.copy!(xpr, cpx)
```
<s>Another option is

```julia
"""
    SolverInstance(solver::AbstractSolver)

Create a solver instance from the given solver.

    SolverInstance(solver::AbstractSolver, filename::String)

Create a new solver instance from the file `filename` using the solver `solver`.
Supported file types depend on the solver.
"""
function SolverInstance end
```</s>