### PR TITLE
Change packed storage format for PSD cone

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -161,8 +161,8 @@ dimension(s::Union{ExponentialCone, DualExponentialCone, PowerCone, DualPowerCon
     PositiveSemidefiniteConeTriangle(dimension)
 
 The (vectorized) cone of symmetric positive semidefinite matrices, with off-diagonals unscaled.
-The entries of the upper triangular part of the matrix are given row by row (or equivalently, the entries of the lower triangular part are given column by column).
-An ``n \\times n`` matrix has ``n(n+1)/2`` lower-triangular elements, so for the vectorized cone of dimension `dimension`, the corresponding symmetric matrix has side dimension ``\\sqrt (1/4 + 2 dimension) - 1/2`` elements.
+The entries of the upper triangular part of the matrix are given column by column (or equivalently, the entries of the lower triangular part are given row by row).
+An ``n \\times n`` matrix has ``n(n+1)/2`` lower-triangular elements, so for the vectorized cone of dimension ``d``, the corresponding symmetric matrix has side dimension ``\\sqrt{1/4 + 2 d} - 1/2`` elements.
 The scalar product is the sum of the pairwise product of the diagonal entries plus twice the sum of the pairwise product of the upper diagonal entries.
 
 ### Examples
@@ -170,12 +170,23 @@ The scalar product is the sum of the pairwise product of the diagonal entries pl
 The matrix
 ```math
 \\begin{bmatrix}
-  1 & 2 & 3\\\\
-  2 & 4 & 5\\\\
-  3 & 5 & 6
+  1 & 2 & 4\\\\
+  2 & 3 & 5\\\\
+  4 & 5 & 6
 \\end{bmatrix}
 ```
 corresponds to ``(1, 2, 3, 4, 5, 6)`` for `PositiveSemidefiniteConeTriangle`
+
+### Note
+
+Two packed storage formats exist for symmetric matrices, the respective orders of the entries are:
+- upper triangular column by column (or lower triangular row by row);
+- lower triangular column by column (or upper triangular row by row).
+
+The advantage of the first format is the mapping between the `(i, j)` matrix indices and the `k` index of the vectorized form. It is simpler and does not depend on the dimension of the matrix.
+Indeed,
+- the entry of matrix indices `(i, j)` has vectorized index `k = div((j-1)*j, 2) + i` if ``i \\leq j`` and `k = div((i-1)*i, 2) + j` if ``j \\leq i``;
+- and the entry with vectorized index `k` has matrix indices `i = isqrt(2k)` and `j = k - div((i-1)*i, 2)` or `j = isqrt(2k)` and `i = k - div((j-1)*j, 2)`.
 """
 struct PositiveSemidefiniteConeTriangle <: AbstractVectorSet
     dimension::Int
@@ -185,8 +196,8 @@ end
     PositiveSemidefiniteConeScaled(dimension)
 
 The (vectorized) cone of symmetric positive semidefinite matrices, with off-diagonals scaled.
-The entries of the upper triangular part of the matrix are given row by row (or equivalently, the entries of the lower triangular part are given column by column).
-An ``n \\times n`` matrix has ``n(n+1)/2`` lower-triangular elements, so for the vectorized cone of dimension `dimension`, the corresponding symmetric matrix has side dimension ``\\sqrt (1/4 + 2 dimension) - 1/2`` elements.
+The entries of the upper triangular part of the matrix are given column by column (or equivalently, the entries of the lower triangular part are given row by row).
+An ``n \\times n`` matrix has ``n(n+1)/2`` lower-triangular elements, so for the vectorized cone of dimension ``d``, the corresponding symmetric matrix has side dimension ``\\sqrt{1/4 + 2 d} - 1/2`` elements.
 The off-diagonal entries of the matrices of both the cone and its dual are scaled by ``\\sqrt{2}`` and the scalar product is simply the sum of the pairwise product of the entries.
 
 ### Examples
@@ -194,9 +205,9 @@ The off-diagonal entries of the matrices of both the cone and its dual are scale
 The matrix
 ```math
 \\begin{bmatrix}
-  1 & 2 & 3\\\\
-  2 & 4 & 5\\\\
-  3 & 5 & 6
+  1 & 2 & 4\\\\
+  2 & 3 & 5\\\\
+  4 & 5 & 6
 \\end{bmatrix}
 ```
 and to ``(1, 2\\sqrt{2}, 3\\sqrt{2}, 4, 5\\sqrt{2}, 6)`` for `PositiveSemidefiniteConeScaled`.

--- a/test/contconic.jl
+++ b/test/contconic.jl
@@ -960,10 +960,10 @@ function _sdp1test(solver::MOI.AbstractSolver, vecofvars::Bool, sdpcone; atol=Ba
             end
             cx = MOI.addconstraint!(instance, MOI.VectorOfVariables(x), MOI.SecondOrderCone(3))
 
-            c1 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([X[1], X[4], X[6], x[1]], [1., 1, 1, 1], 0.), MOI.EqualTo(1.))
-            c2 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([X; x[2]; x[3]], [1., 2/s, 2/s, 1, 2/s, 1, 1, 1], 0.), MOI.EqualTo(1/2))
+            c1 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([X[1], X[3], X[6], x[1]], [1., 1, 1, 1], 0.), MOI.EqualTo(1.))
+            c2 = MOI.addconstraint!(instance, MOI.ScalarAffineFunction([X; x[2]; x[3]], [1., 2/s, 1, 2/s, 2/s, 1, 1, 1], 0.), MOI.EqualTo(1/2))
 
-            MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([X[1:2]; X[4:6]; x[1]], [2., 2/s, 2, 2/s, 2, 1], 0.))
+            MOI.set!(instance, MOI.ObjectiveFunction(), MOI.ScalarAffineFunction([X[1:3]; X[5:6]; x[1]], [2., 2/s, 2, 2/s, 2, 1], 0.))
             MOI.set!(instance, MOI.ObjectiveSense(), MOI.MinSense)
 
             @test MOI.get(instance, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, sdpcone}()) == 1
@@ -993,8 +993,8 @@ function _sdp1test(solver::MOI.AbstractSolver, vecofvars::Bool, sdpcone; atol=Ba
             @test MOI.canget(instance, MOI.ConstraintDual(), c2)
             y2 = MOI.get(instance, MOI.ConstraintDual(), c2)
 
-            #     X11  X21  X31  X22  X32  X33  x1  x2  x3
-            c = [   2, 2/s,   0,   2, 2/s,   2,  1,  0,  0]
+            #     X11  X21  X22  X31  X32  X33  x1  x2  x3
+            c = [   2, 2/s,   2,   0, 2/s,   2,  1,  0,  0]
             b = [1, 1/2]
             # Check primal objective
             comp_pobj = dot(c, [Xv; xv])
@@ -1004,9 +1004,9 @@ function _sdp1test(solver::MOI.AbstractSolver, vecofvars::Bool, sdpcone; atol=Ba
 
             @test MOI.canget(instance, MOI.ConstraintDual(), cX)
             Xdv = MOI.get(instance, MOI.ConstraintDual(), cX)
-            Xd = [Xdv[1]   Xdv[2]/s Xdv[3]/s;
-                  Xdv[2]/s Xdv[4]   Xdv[5]/s;
-                  Xdv[3]/s Xdv[5]/s Xdv[6]]
+            Xd = [Xdv[1]   Xdv[2]/s Xdv[4]/s;
+                  Xdv[2]/s Xdv[3]   Xdv[5]/s;
+                  Xdv[4]/s Xdv[5]/s Xdv[6]]
 
             C = [2 1 0;
                  1 2 1;


### PR DESCRIPTION
Comparisons between the storage formats can be found [here](http://www.netlib.org/lapack/lug/node123.html) or [here](https://software.intel.com/en-us/mkl-developer-reference-c-matrix-storage-schemes-for-lapack-routines).
The mapping is a lot easier with the `'U'` storage format and it does not depend on the dimension of the matrices. For this reason, I think we should pick this one.