### PR TITLE
Add list of attributes set

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -42,6 +42,7 @@ Copying
 copy!
 CopyResult
 CopyStatusCode
+mustcopy
 ```
 
 List of instance attributes
@@ -54,6 +55,9 @@ ListOfVariableIndices
 ListOfConstraints
 NumberOfConstraints
 ListOfConstraintIndices
+ListOfInstanceAttributesSet
+ListOfVariableAttributesSet
+ListOfConstraintAttributesSet
 ```
 
 There are no attributes specific to a standalone instance.

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -113,7 +113,11 @@ end
 
 Copy the model from the instance `src` into the instance `dest`. The target instance `dest` is emptied, and all previous indices to variables or constraints in `dest` are invalidated. Returns a `CopyResult` object. If the copy is successfully, the `CopyResult` contains a dictionary-like object that translates variable and constraint indices from the `src` instance to the corresponding indices in the `dest` instance.
 
-If an attribute `attr` cannot be copied from `src` to `dest` then if `MOI.mustcopy(attr)` is `true` then an error is thrown and otherwise, if `warnattributes` is `true`, a warning is displayed.
+If an attribute `attr` cannot be copied from `src` to `dest` then:
+
+* If `mustcopy(attr)` is `true` then an error is thrown, otherwise,
+* If `warnattributes` is `true`, a warning is displayed, otherwise,
+* The attribute is silently ignored.
 
 ### Example
 

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -109,9 +109,11 @@ struct CopyResult{T}
 end
 
 """
-    copy!(dest::AbstractInstance, src::AbstractInstance)::CopyResult
+    copy!(dest::AbstractInstance, src::AbstractInstance, warnattributes=true)::CopyResult
 
 Copy the model from the instance `src` into the instance `dest`. The target instance `dest` is emptied, and all previous indices to variables or constraints in `dest` are invalidated. Returns a `CopyResult` object. If the copy is successfully, the `CopyResult` contains a dictionary-like object that translates variable and constraint indices from the `src` instance to the corresponding indices in the `dest` instance.
+
+If an attribute `attr` cannot be copied from `src` to `dest` then if `MOI.mustcopy(attr)` is `true` then an error is thrown and otherwise, if `warnattributes` is `true`, a warning is displayed.
 
 ### Example
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -185,6 +185,13 @@ end
 ## Instance attributes
 
 """
+    ListOfInstanceAttributesSet()
+
+A `Vector{AbstractInstanceAttribute}` of all instance attributes that were set to the instance and are not instance-specific.
+"""
+struct ListOfInstanceAttributesSet <: AbstractInstanceAttribute end
+
+"""
     Name()
 
 A string identifying the instance.
@@ -319,6 +326,13 @@ struct ResultCount <: AbstractInstanceAttribute end
 ## Variable attributes
 
 """
+    ListOfVariableAttributesSet()
+
+A `Vector{AbstractVariableAttribute}` of all variable attributes that were set to the variable and are not instance-specific.
+"""
+struct ListOfVariableAttributesSet <: AbstractVariableAttribute end
+
+"""
     VariableName()
 
 A string identifying the variable. It is invalid for two variables to have the same name.
@@ -366,6 +380,13 @@ Possible values are:
 @enum BasisStatusCode Basic Nonbasic NonbasicAtLower NonbasicAtUpper SuperBasic
 
 ## Constraint attributes
+
+"""
+    ListOfConstraintAttributesSet()
+
+A `Vector{AbstractConstraintAttribute}` of all constraint attributes that were set to the constraint and are not instance-specific.
+"""
+struct ListOfConstraintAttributesSet <: AbstractVariableAttribute end
 
 """
     ConstraintName()

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -24,6 +24,13 @@ abstract type AbstractConstraintAttribute end
 const AnyAttribute = Union{AbstractInstanceAttribute, AbstractVariableAttribute, AbstractConstraintAttribute}
 
 """
+    mustcopy(attr::Union{Type{AbstractInstanceAttribute}, Type{AbstractVariableAttribute}, Type{AbstractConstraintAttribute}})
+
+Returns whether the attribute affects the instance is thus mandatory to copy in `MOI.copy!` or whether it only affects how the instance is solved.
+"""
+function mustcopy end
+
+"""
     get(instance::AbstractInstance, attr::AbstractInstanceAttribute)
 
 Return an attribute `attr` of the instance `instance`.
@@ -187,7 +194,7 @@ end
 """
     ListOfInstanceAttributesSet()
 
-A `Vector{AbstractInstanceAttribute}` of all instance attributes that were set to the instance and are not instance-specific.
+A `Vector{AbstractInstanceAttribute}` of all instance attributes that were set to the instance.
 """
 struct ListOfInstanceAttributesSet <: AbstractInstanceAttribute end
 
@@ -328,7 +335,7 @@ struct ResultCount <: AbstractInstanceAttribute end
 """
     ListOfVariableAttributesSet()
 
-A `Vector{AbstractVariableAttribute}` of all variable attributes that were set to the variable and are not instance-specific.
+A `Vector{AbstractVariableAttribute}` of all variable attributes that were set to the variable.
 """
 struct ListOfVariableAttributesSet <: AbstractVariableAttribute end
 
@@ -384,7 +391,7 @@ Possible values are:
 """
     ListOfConstraintAttributesSet()
 
-A `Vector{AbstractConstraintAttribute}` of all constraint attributes that were set to the constraint and are not instance-specific.
+A `Vector{AbstractConstraintAttribute}` of all constraint attributes that were set to the constraint.
 """
 struct ListOfConstraintAttributesSet <: AbstractVariableAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -26,7 +26,11 @@ const AnyAttribute = Union{AbstractInstanceAttribute, AbstractVariableAttribute,
 """
     mustcopy(attr::Union{Type{AbstractInstanceAttribute}, Type{AbstractVariableAttribute}, Type{AbstractConstraintAttribute}})
 
-Returns whether the attribute affects the instance is thus mandatory to copy in `MOI.copy!` or whether it only affects how the instance is solved.
+Returns is mandatory to copy in `MOI.copy!` or whether it only affects how the instance is solved.
+
+### Examples
+
+The attributes `ObjectiveFunction` and `ObjectiveSense` are mandatory but an hypothetical attribute such as `GurobiLogLevel` is not mandatory.
 """
 function mustcopy end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -337,7 +337,7 @@ struct ResultCount <: AbstractInstanceAttribute end
 
 A `Vector{AbstractVariableAttribute}` of all variable attributes that were set to the instance.
 """
-struct ListOfVariableAttributesSet <: AbstractVariableAttribute end
+struct ListOfVariableAttributesSet <: AbstractInstanceAttribute end
 
 """
     VariableName()
@@ -389,11 +389,11 @@ Possible values are:
 ## Constraint attributes
 
 """
-    ListOfConstraintAttributesSet()
+    ListOfConstraintAttributesSet{F, S}()
 
-A `Vector{AbstractConstraintAttribute}` of all constraint attributes that were set to the instance.
+A `Vector{AbstractConstraintAttribute}` of all constraint attributes that were set to `F`-in-`S` constraints.
 """
-struct ListOfConstraintAttributesSet <: AbstractVariableAttribute end
+struct ListOfConstraintAttributesSet{F,S} <: AbstractInstanceAttribute end
 
 """
     ConstraintName()

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -335,7 +335,7 @@ struct ResultCount <: AbstractInstanceAttribute end
 """
     ListOfVariableAttributesSet()
 
-A `Vector{AbstractVariableAttribute}` of all variable attributes that were set to the variable.
+A `Vector{AbstractVariableAttribute}` of all variable attributes that were set to the instance.
 """
 struct ListOfVariableAttributesSet <: AbstractVariableAttribute end
 
@@ -391,7 +391,7 @@ Possible values are:
 """
     ListOfConstraintAttributesSet()
 
-A `Vector{AbstractConstraintAttribute}` of all constraint attributes that were set to the constraint.
+A `Vector{AbstractConstraintAttribute}` of all constraint attributes that were set to the instance.
 """
 struct ListOfConstraintAttributesSet <: AbstractVariableAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -26,11 +26,11 @@ const AnyAttribute = Union{AbstractInstanceAttribute, AbstractVariableAttribute,
 """
     mustcopy(attr::Union{Type{AbstractInstanceAttribute}, Type{AbstractVariableAttribute}, Type{AbstractConstraintAttribute}})
 
-Returns is mandatory to copy in `MOI.copy!` or whether it only affects how the instance is solved.
+Returns `true` if it is mandatory to copy the attribute in `MOI.copy!` and `false` if the attribute only affects how the instance is solved.
 
 ### Examples
 
-The attributes `ObjectiveFunction` and `ObjectiveSense` are mandatory but an hypothetical attribute such as `GurobiLogLevel` is not mandatory.
+The attributes `ObjectiveFunction` and `ObjectiveSense` are mandatory but a hypothetical attribute such as `GurobiLogLevel` is not mandatory.
 """
 function mustcopy end
 


### PR DESCRIPTION
It seems to me that *copyable* attribute is vague but it corresponds precisely to non-solver specific attributes that were set.