### PR TITLE
Implements mustcopy for MOI attributes

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -415,7 +415,6 @@ mustcopy(::ConstraintName) = false
 An initial assignment of the constraint primal values that the solver may use to warm-start the solve.
 """
 struct ConstraintPrimalStart <: AbstractConstraintAttribute end
-mustcopy(::ConstraintPrimalStart) = false
 
 
 """
@@ -424,7 +423,6 @@ mustcopy(::ConstraintPrimalStart) = false
 An initial assignment of the constraint duals that the solver may use to warm-start the solve.
 """
 struct ConstraintDualStart <: AbstractConstraintAttribute end
-mustcopy(::ConstraintDualStart) = false
 
 """
     ConstraintPrimal(N)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -32,7 +32,7 @@ Returns `true` if it is mandatory to copy the attribute in `MOI.copy!` and `fals
 
 The attributes `ObjectiveFunction` and `ObjectiveSense` are mandatory but a hypothetical attribute such as `GurobiLogLevel` is not mandatory.
 """
-mustcopy(attr::Union{Type{AbstractInstanceAttribute}, Type{AbstractVariableAttribute}, Type{AbstractConstraintAttribute}}) = true
+function mustcopy end
 
 """
     get(instance::AbstractInstance, attr::AbstractInstanceAttribute)
@@ -208,6 +208,7 @@ struct ListOfInstanceAttributesSet <: AbstractInstanceAttribute end
 A string identifying the instance.
 """
 struct Name <: AbstractInstanceAttribute end
+mustcopy(::Name) = false
 
 """
     ObjectiveSense()
@@ -215,6 +216,7 @@ struct Name <: AbstractInstanceAttribute end
 The sense of the objective function, an `OptimizationSense` with value `MinSense`, `MaxSense`, or `FeasiblitySense`.
 """
 struct ObjectiveSense <: AbstractInstanceAttribute end
+mustcopy(::ObjectiveSense) = true
 
 @enum OptimizationSense MinSense MaxSense FeasibilitySense
 
@@ -264,6 +266,7 @@ An `AbstractFunction` instance which represents the objective function.
 It is guaranteed to be equivalent but not necessarily identical to the function provided by the user.
 """
 struct ObjectiveFunction <: AbstractInstanceAttribute end
+mustcopy(::ObjectiveFunction) = true
 
 ## Solver instance attributes
 
@@ -349,6 +352,7 @@ struct ListOfVariableAttributesSet <: AbstractInstanceAttribute end
 A string identifying the variable. It is invalid for two variables to have the same name.
 """
 struct VariableName <: AbstractVariableAttribute end
+mustcopy(::VariableName) = false
 
 """
     VariablePrimalStart()
@@ -406,6 +410,7 @@ struct ListOfConstraintAttributesSet{F,S} <: AbstractInstanceAttribute end
 A string identifying the constraint. It is invalid for two constraints of any kind to have the same name.
 """
 struct ConstraintName <: AbstractConstraintAttribute end
+mustcopy(::ConstraintName) = false
 
 """
     ConstraintPrimalStart()

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -208,7 +208,6 @@ struct ListOfInstanceAttributesSet <: AbstractInstanceAttribute end
 A string identifying the instance.
 """
 struct Name <: AbstractInstanceAttribute end
-mustcopy(::Name) = false
 
 """
     ObjectiveSense()
@@ -350,7 +349,6 @@ struct ListOfVariableAttributesSet <: AbstractInstanceAttribute end
 A string identifying the variable. It is invalid for two variables to have the same name.
 """
 struct VariableName <: AbstractVariableAttribute end
-mustcopy(::VariableName) = false
 
 """
     VariablePrimalStart()
@@ -407,7 +405,6 @@ struct ListOfConstraintAttributesSet{F,S} <: AbstractInstanceAttribute end
 A string identifying the constraint. It is invalid for two constraints of any kind to have the same name.
 """
 struct ConstraintName <: AbstractConstraintAttribute end
-mustcopy(::ConstraintName) = false
 
 """
     ConstraintPrimalStart()

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -416,7 +416,6 @@ An initial assignment of the constraint primal values that the solver may use to
 """
 struct ConstraintPrimalStart <: AbstractConstraintAttribute end
 
-
 """
     ConstraintDualStart()
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -32,7 +32,7 @@ Returns `true` if it is mandatory to copy the attribute in `MOI.copy!` and `fals
 
 The attributes `ObjectiveFunction` and `ObjectiveSense` are mandatory but a hypothetical attribute such as `GurobiLogLevel` is not mandatory.
 """
-function mustcopy end
+mustcopy(attr::Union{Type{AbstractInstanceAttribute}, Type{AbstractVariableAttribute}, Type{AbstractConstraintAttribute}}) = true
 
 """
     get(instance::AbstractInstance, attr::AbstractInstanceAttribute)
@@ -356,6 +356,7 @@ struct VariableName <: AbstractVariableAttribute end
 An initial assignment of the variables that the solver may use to warm-start the solve.
 """
 struct VariablePrimalStart <: AbstractVariableAttribute end
+mustcopy(::VariablePrimalStart) = false
 
 """
     VariablePrimal(N)
@@ -412,6 +413,8 @@ struct ConstraintName <: AbstractConstraintAttribute end
 An initial assignment of the constraint primal values that the solver may use to warm-start the solve.
 """
 struct ConstraintPrimalStart <: AbstractConstraintAttribute end
+mustcopy(::ConstraintPrimalStart) = false
+
 
 """
     ConstraintDualStart()
@@ -419,6 +422,7 @@ struct ConstraintPrimalStart <: AbstractConstraintAttribute end
 An initial assignment of the constraint duals that the solver may use to warm-start the solve.
 """
 struct ConstraintDualStart <: AbstractConstraintAttribute end
+mustcopy(::ConstraintDualStart) = false
 
 """
     ConstraintPrimal(N)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -32,7 +32,7 @@ Returns `true` if it is mandatory to copy the attribute in `MOI.copy!` and `fals
 
 The attributes `ObjectiveFunction` and `ObjectiveSense` are mandatory but a hypothetical attribute such as `GurobiLogLevel` is not mandatory.
 """
-function mustcopy end
+mustcopy(attr::Union{Type{AbstractInstanceAttribute}, Type{AbstractVariableAttribute}, Type{AbstractConstraintAttribute}}) = true
 
 """
     get(instance::AbstractInstance, attr::AbstractInstanceAttribute)
@@ -216,7 +216,6 @@ mustcopy(::Name) = false
 The sense of the objective function, an `OptimizationSense` with value `MinSense`, `MaxSense`, or `FeasiblitySense`.
 """
 struct ObjectiveSense <: AbstractInstanceAttribute end
-mustcopy(::ObjectiveSense) = true
 
 @enum OptimizationSense MinSense MaxSense FeasibilitySense
 
@@ -266,7 +265,6 @@ An `AbstractFunction` instance which represents the objective function.
 It is guaranteed to be equivalent but not necessarily identical to the function provided by the user.
 """
 struct ObjectiveFunction <: AbstractInstanceAttribute end
-mustcopy(::ObjectiveFunction) = true
 
 ## Solver instance attributes
 
@@ -360,7 +358,6 @@ mustcopy(::VariableName) = false
 An initial assignment of the variables that the solver may use to warm-start the solve.
 """
 struct VariablePrimalStart <: AbstractVariableAttribute end
-mustcopy(::VariablePrimalStart) = false
 
 """
     VariablePrimal(N)


### PR DESCRIPTION
Should we set `mustcopy` to `true` or `false` by default or no no default ?
If we set it to `true`, it may mean more work from the wrapper since most of their attributes will need to return `false` but it may be safer.