### PR TITLE
AbstractInstance for canmodifyobjective fallback

### DIFF
--- a/src/objectives.jl
+++ b/src/objectives.jl
@@ -27,4 +27,4 @@ canmodifyobjective(instance, ScalarConstantChange(10.0))
 ```
 """
 function canmodifyobjective end
-canmodifyobjective(instance::AbstractSolverInstance, change) = false
+canmodifyobjective(instance::AbstractInstance, change) = false


### PR DESCRIPTION
I guess it wasn't intentional to use `AbstractSolverInstance` here.