### PR TITLE
Implements Base.isapprox

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -195,12 +195,12 @@ _dicts(f::ScalarAffineFunction) = sum_dict(Pair.(f.variables, f.coefficients))
 _dicts(f::VectorAffineFunction) = sum_dict(Pair.(tuple.(f.outputindex, f.variables), f.coefficients))
 
 # For quadratic terms, x*y == y*x
-_sort(v1::VariableIndex, v2::VariableIndex) = VariableIndex.(extrema((v1.value, v2.value)))
+_canonicalize(v1::VariableIndex, v2::VariableIndex) = VariableIndex.(extrema((v1.value, v2.value)))
 
 _dicts(f::ScalarQuadraticFunction) = (sum_dict(Pair.(f.affine_variables, f.affine_coefficients)),
-                                      sum_dict(Pair.(_sort.(f.quadratic_rowvariables, f.quadratic_colvariables), f.quadratic_coefficients)))
+                                      sum_dict(Pair.(_canonicalize.(f.quadratic_rowvariables, f.quadratic_colvariables), f.quadratic_coefficients)))
 _dicts(f::VectorQuadraticFunction) = (sum_dict(Pair.(tuple.(f.affine_outputindex, f.affine_variables), f.affine_coefficients)),
-                                      sum_dict(Pair.(tuple.(f.quadratic_outputindex, _sort.(f.quadratic_rowvariables, f.quadratic_colvariables)), f.quadratic_coefficients)))
+                                      sum_dict(Pair.(tuple.(f.quadratic_outputindex, _canonicalize.(f.quadratic_rowvariables, f.quadratic_colvariables)), f.quadratic_coefficients)))
 
 function Base.isapprox(f::F, g::G; kwargs...) where {F<:Union{ScalarAffineFunction, ScalarQuadraticFunction, VectorAffineFunction, VectorQuadraticFunction},
                                                      G<:Union{ScalarAffineFunction, ScalarQuadraticFunction, VectorAffineFunction, VectorQuadraticFunction}}

--- a/test/isapprox.jl
+++ b/test/isapprox.jl
@@ -1,0 +1,77 @@
+@testset "Functions isapprox" begin
+    x = MOI.VariableIndex(1)
+    y = MOI.VariableIndex(2)
+    z = MOI.VariableIndex(3)
+    @testset "Variable" begin
+        @testset "Single" begin
+            @test MOI.SingleVariable(x) == MOI.SingleVariable(x)
+            @test MOI.SingleVariable(x) != MOI.SingleVariable(y)
+        end
+        @testset "Vector" begin
+            @test MOI.VectorOfVariables([x, y]) == MOI.VectorOfVariables([x, y])
+            @test MOI.VectorOfVariables([y, x]) != MOI.VectorOfVariables([x, y])
+            @test MOI.VectorOfVariables([x, x]) != MOI.VectorOfVariables([x])
+            @test MOI.VectorOfVariables([x]) != MOI.VectorOfVariables([y])
+        end
+    end
+    @testset "Affine" begin
+        @testset "Scalar" begin
+            @test MOI.ScalarAffineFunction([x, z], [1, 1], 1) ≈ MOI.ScalarAffineFunction([x, y, z], [1, 1e-7, 1], 1.) atol=1e-6
+            @test MOI.ScalarAffineFunction([x, y], [1, 1e-7], 1.) ≈ MOI.ScalarAffineFunction([x], [1], 1) atol=1e-6
+            f = MOI.ScalarAffineFunction([x, y], [2, 4], 6)
+            g = deepcopy(f)
+            @test g ≈ f
+            f.coefficients[2] = 3
+            @test !(g ≈ f)
+        end
+        @testset "Vector" begin
+            f = MOI.VectorAffineFunction([1, 1, 2],
+                                         [x, y, y],
+                                         [2, 4, 3], [6, 8])
+            g = deepcopy(f)
+            @test f ≈ g
+            f.coefficients[3] = 9
+            @test !(f ≈ g)
+            push!(f.outputindex, 2)
+            push!(f.variables, y)
+            push!(f.coefficients, -6)
+            @test f ≈ g
+        end
+    end
+    @testset "Quadratic" begin
+        @testset "Affine" begin
+            f = MOI.ScalarQuadraticFunction([x], [3], [x, y, x], [x, y, y], [1, 2, 3], 8)
+            g = deepcopy(f)
+            @test f ≈ g
+            push!(f.affine_variables, y)
+            push!(f.affine_coefficients, 2)
+            @test !(f ≈ g)
+            g = deepcopy(f)
+            push!(f.quadratic_rowvariables, y)
+            push!(f.quadratic_colvariables, x)
+            push!(f.quadratic_coefficients, 2)
+            @test !(f ≈ g)
+            push!(f.quadratic_rowvariables, y)
+            push!(f.quadratic_colvariables, x)
+            push!(f.quadratic_coefficients, -2)
+            @test f ≈ g
+        end
+        @testset "Vector" begin
+            f = MOI.VectorQuadraticFunction([1, 2, 1], [x, x, y], [3, 1, 1], [1, 1, 2], [x, y, x], [x, y, y], [1, 2, 3], [10, 11, 12])
+            g = deepcopy(f)
+            @test f ≈ g
+            f.affine_outputindex[1] = 3
+            f.affine_coefficients[1] = 4
+            @test !(f ≈ g)
+            push!(g.affine_outputindex, 1)
+            push!(g.affine_variables, x)
+            push!(g.affine_coefficients, -3)
+            push!(g.affine_outputindex, 3)
+            push!(g.affine_variables, x)
+            push!(g.affine_coefficients, 4)
+            @test f ≈ g
+            f.quadratic_outputindex[1] = 3
+            @test !(f ≈ g)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,7 @@
 using MathOptInterface, Base.Test
+const MOI = MathOptInterface
 
 # There is no standalone code in this package to test.
 # Tests for solvers are located in MathOptInterfaceTests.
+
+include("isapprox.jl")


### PR DESCRIPTION
Closes https://github.com/JuliaOpt/MathOptInterfaceTests.jl/issues/33.
MOIU used to implements indexing, copy and comparison of MOI types. Thanks to `eachscalar`, it does not directly define Base methods on MOI types. With https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/pull/72, it does not implement copy anymore.
The last remaining type piracy is with `isapprox`.
Adding a method define externally with arguments having only external types should be avoided in Julia. Here `isapprox` is defined in Base so MOIU shouldn't define it for MOI types.
If MOIT defines it, that automatically makes it impossible to use by another package without adding MOIT in its requirement. If it doesn't know about it, it might give a weird failure, the first time sometime try to load the package with MOIT at the same time.
It seems to me that the only clean way to deal with this is to define `isapprox` in MOI directly.

What do you think ?