### PR TITLE
Add canaddvariable function

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -137,6 +137,7 @@ delete!(::AbstractSolverInstance,::Index)
 Functions for adding variables. For deleting, see index types section.
 
 ```@docs
+canaddvariable
 addvariables!
 addvariable!
 ```

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,6 +1,13 @@
 # Variables
 
 """
+    canaddvariable(instance::AbstractInstance)::Bool
+
+Return a `Bool` indicating whether it is possible to add a variable to the instance `instance`.
+"""
+function canaddvariable end
+
+"""
     addvariables!(instance::AbstractInstance, n::Int)::Vector{VariableIndex}
 
 Add `n` scalar variables to the instance, returning a vector of variable indices.


### PR DESCRIPTION
As raised here:
https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/blob/85d2d0d7ff71a81172a464a0adbfaa893c208147/src/instancemanager.jl#L150-L151
If a solver does not support `addvariable!` (which is the case of SCS, ECOS, CSDP, SDPA, ...), the instance manager needs to know it and switch to the `EmptySolver` state in automatic mode.
This PR fixes the issue.