### PR TITLE
Add MOIT as a submodule

### DIFF
--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -148,6 +148,6 @@ include("variables.jl")
 include("nlp.jl")
 
 # submodules
-include("Test/Test.jl") # MOIT
+include("Test/Test.jl") # MOI.Test
 
 end

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -147,4 +147,7 @@ include("objectives.jl")
 include("variables.jl")
 include("nlp.jl")
 
+# submodules
+include("Test/Test.jl") # MOIT
+
 end

--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -1,0 +1,19 @@
+module Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+
+using Base.Test
+
+include("config.jl")
+
+include("modellike.jl")
+
+include("contlinear.jl")
+include("contconic.jl")
+include("contquadratic.jl")
+
+include("intlinear.jl")
+include("intconic.jl")
+
+end # module

--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -1,0 +1,48 @@
+struct TestConfig
+    atol::Float64 # absolute tolerance for ...
+    rtol::Float64 # relative tolerance for ...
+    solve::Bool # optimize and test result
+    query::Bool # can get objective function, and constraint functions, and constraint sets
+    duals::Bool # test dual solutions
+    infeas_certificates::Bool # check for infeasibility certificates when appropriate
+    function TestConfig(;atol::Float64 = 1e-8, rtol::Float64 = 1e-8, solve::Bool = true, query::Bool = true, duals::Bool = true, infeas_certificates::Bool = true)
+        new(
+            atol,
+            rtol,
+            solve,
+            query,
+            duals,
+            infeas_certificates,
+            )
+    end
+end
+
+"""
+    @moitestset setname subsets
+
+Defines a function `setnametest(model, config, exclude)` that runs the tests defined in the dictionary `setnametests`
+with the model `model` and config `config` except the tests whose dictionary key is in `exclude`.
+If `subsets` is `true` then each test runs in fact multiple tests hence the `exclude` argument is passed
+as it can also contains test to be excluded from these subsets of tests.
+"""
+macro moitestset(setname, subsets=false)
+    testname = Symbol(string(setname) * "test")
+    testdict = Symbol(string(testname) * "s")
+    if subsets
+        runtest = :( f(model, config, exclude) )
+    else
+        runtest = :( f(model, config) )
+    end
+    :(
+        function $testname(model::MOI.ModelLike, config::TestConfig, exclude::Vector{String} = String[])
+            for (name,f) in $testdict
+                if name in exclude
+                    continue
+                end
+                @testset "$name" begin
+                    $runtest
+                end
+            end
+        end
+    )
+end

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1,0 +1,1619 @@
+# Continuous conic problems
+
+function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model,
+    #    MOI.ScalarAffineFunction{Float64},
+    #    [
+    #        (MOI.VectorOfVariables,MOI.Nonnegatives),
+    #        (MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),
+    #        (MOI.VectorAffineFunction{Float64},MOI.Zeros)
+    #    ]
+    #)
+    # linear conic problem
+    # min -3x - 2y - 4z
+    # st    x +  y +  z == 3
+    #            y +  z == 2
+    #       x>=0 y>=0 z>=0
+    # Opt obj = -11, soln x = 1, y = 0, z = 2
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 3)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 3
+
+    vov = MOI.VectorOfVariables(v)
+    if vecofvars
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
+        vc = MOI.addconstraint!(model, vov, MOI.Nonnegatives(3))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+        vc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.Nonnegatives(3))
+    end
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    c = MOI.addconstraint!(model, MOI.VectorAffineFunction([1,1,1,2,2], [v;v[2];v[3]], ones(5), [-3.0,-2.0]), MOI.Zeros(2))
+    @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+    loc = MOI.get(model, MOI.ListOfConstraints())
+    @test length(loc) == 2
+    @test (vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonnegatives) in loc
+    @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [1, 0, 2] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ zeros(2) atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc))
+            @test MOI.get(model, MOI.ConstraintDual(), vc) ≈ [0, 2, 0] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
+        end
+    end
+end
+
+lin1vtest(model::MOI.ModelLike, config::TestConfig) = _lin1test(model, config, false)
+lin1ftest(model::MOI.ModelLike, config::TestConfig) = _lin1test(model, config, false)
+
+function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64},
+    #[
+    #    (MOI.VectorAffineFunction{Float64},MOI.Zeros),
+    #    (MOI.VectorOfVariables,MOI.Nonnegatives),
+    #    (MOI.VectorOfVariables,MOI.Nonpositives)
+    #])
+    # mixed cones
+    # min  3x + 2y - 4z + 0s
+    # st    x           -  s  == -4    (i.e. x >= -4)
+    #            y            == -3
+    #       x      +  z       == 12
+    #       x free
+    #       y <= 0
+    #       z >= 0
+    #       s zero
+    # Opt solution = -82
+    # x = -4, y = -3, z = 16, s == 0
+
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x,y,z,s = MOI.addvariables!(model, 4)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 4
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x,y,z], [3.0, 2.0, -4.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    c = MOI.addconstraint!(model, MOI.VectorAffineFunction([1,1,2,3,3], [x,s,y,x,z], [1.0,-1.0,1.0,1.0,1.0], [4.0,3.0,-12.0]), MOI.Zeros(3))
+
+    vov = MOI.VectorOfVariables([y])
+    if vecofvars
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonpositives)
+        vc = MOI.addconstraint!(model, vov, MOI.Nonpositives(1))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
+        vc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.Nonpositives(1))
+    end
+    if vecofvars
+        # test fallback
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
+        vz = MOI.addconstraint!(model, [z], MOI.Nonnegatives(1))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+        vz = MOI.addconstraint!(model, MOI.VectorAffineFunction([1], [z], [1.], [0.]), MOI.Nonnegatives(1))
+    end
+    vov = MOI.VectorOfVariables([s])
+    if vecofvars
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Zeros)
+        vs = MOI.addconstraint!(model, vov, MOI.Zeros(1))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+        vs = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.Zeros(1))
+    end
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 2 - vecofvars
+    @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ zeros(3) atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [-3] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vz))
+        @test MOI.get(model, MOI.ConstraintPrimal(), vz) ≈ [16] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vs))
+        @test MOI.get(model, MOI.ConstraintPrimal(), vs) ≈ [0] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc))
+            @test MOI.get(model, MOI.ConstraintDual(), vc) ≈ [0] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vz))
+            @test MOI.get(model, MOI.ConstraintDual(), vz) ≈ [0] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vs))
+            @test MOI.get(model, MOI.ConstraintDual(), vs) ≈ [7] atol=atol rtol=rtol
+        end
+    end
+end
+
+lin2vtest(model::MOI.ModelLike, config::TestConfig) = _lin2test(model, config, true)
+lin2ftest(model::MOI.ModelLike, config::TestConfig) = _lin2test(model, config, false)
+
+function lin3test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives)])
+    # Problem LIN3 - Infeasible LP
+    # min  0
+    # s.t. x ≥ 1
+    #      x ≤ -1
+    # in conic form:
+    # min 0
+    # s.t. -1 + x ∈ R₊
+    #       1 + x ∈ R₋
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+    MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Nonnegatives(1))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
+    MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[x],[1.0],[1.0]), MOI.Nonpositives(1))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        if config.infeas_certificates
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        else
+            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+        end
+        if MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+        end
+        if config.duals && config.infeas_certificates
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+        end
+        # TODO test dual feasibility and objective sign
+    end
+end
+
+function lin4test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorOfVariables,MOI.Nonpositives)])
+    # Problem LIN4 - Infeasible LP
+    # min  0
+    # s.t. x ≥ 1
+    #      x ≤ 0
+    # in conic form:
+    # min 0
+    # s.t. -1 + x ∈ R₊
+    #           x ∈ R₋
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+    MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Nonnegatives(1))
+    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonpositives)
+    MOI.addconstraint!(model, MOI.VectorOfVariables([x]), MOI.Nonpositives(1))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        if config.infeas_certificates
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        else
+            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+        end
+
+        if MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+        end
+        if config.duals && config.infeas_certificates
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+        end
+        # TODO test dual feasibility and objective sign
+    end
+end
+
+const lintests = Dict("lin1v" => lin1vtest,
+                      "lin1f" => lin1ftest,
+                      "lin2v" => lin2vtest,
+                      "lin2f" => lin2ftest,
+                      "lin3"  => lin3test,
+                      "lin4"  => lin4test)
+
+@moitestset lin
+
+function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.SecondOrderCone)])
+    # Problem SOC1
+    # max 0x + 1y + 1z
+    #  st  x            == 1
+    #      x >= ||(y,z)||
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x,y,z = MOI.addvariables!(model, 3)
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([y,z],[1.0,1.0],0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    ceq = MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Zeros(1))
+    vov = MOI.VectorOfVariables([x,y,z])
+    if vecofvars
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
+        csoc = MOI.addconstraint!(model, vov, MOI.SecondOrderCone(3))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)
+        csoc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.SecondOrderCone(3))
+    end
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+    loc = MOI.get(model, MOI.ListOfConstraints())
+    @test length(loc) == 2
+    @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
+    @test (vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone) in loc
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 1/sqrt(2) atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ceq))
+        @test MOI.get(model, MOI.ConstraintPrimal(), ceq) ≈ [0.] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(csoc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), csoc) ≈ [1., 1/sqrt(2), 1/sqrt(2)] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ceq))
+            @test MOI.get(model, MOI.ConstraintDual(), ceq) ≈ [-sqrt(2)] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(csoc))
+            @test MOI.get(model, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
+        end
+    end
+end
+
+soc1vtest(model::MOI.ModelLike, config::TestConfig) = _soc1test(model, config, true)
+soc1ftest(model::MOI.ModelLike, config::TestConfig) = _soc1test(model, config, false)
+
+function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Zeros),(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone)])
+    # Problem SOC2
+    # min  x
+    # s.t. y ≥ 1/√2
+    #      x² + y² ≤ 1
+    # in conic form:
+    # min  x
+    # s.t.  -1/√2 + y ∈ R₊
+    #        1 - t ∈ {0}
+    #      (t,x,y) ∈ SOC₃
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x,y,t = MOI.addvariables!(model, 3)
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x],[1.0],0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if nonneg
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+        cnon = MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[y],[1.0],[-1/sqrt(2)]), MOI.Nonnegatives(1))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
+        cnon = MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[y],[-1.0],[1/sqrt(2)]), MOI.Nonpositives(1))
+    end
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    ceq = MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[t],[-1.0],[1.0]), MOI.Zeros(1))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)
+    csoc = MOI.addconstraint!(model, MOI.VectorAffineFunction([1,2,3],[t,x,y],ones(3),zeros(3)), MOI.SecondOrderCone(3))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},nonneg ? MOI.Nonnegatives : MOI.Nonpositives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1/sqrt(2) atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ -1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1/sqrt(2) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cnon))
+        @test MOI.get(model, MOI.ConstraintPrimal(), cnon) ≈ [0.0] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ceq))
+        @test MOI.get(model, MOI.ConstraintPrimal(), ceq) ≈ [0.0] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(csoc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), csoc) ≈ [1., -1/sqrt(2), 1/sqrt(2)] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cnon))
+            @test MOI.get(model, MOI.ConstraintDual(), cnon) ≈ [nonneg ? 1.0 : -1.0] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ceq))
+            @test MOI.get(model, MOI.ConstraintDual(), ceq) ≈ [sqrt(2)] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(csoc))
+            @test MOI.get(model, MOI.ConstraintDual(), csoc) ≈ [sqrt(2), 1.0, -1.0] atol=atol rtol=rtol
+        end
+    end
+end
+
+soc2ntest(model::MOI.ModelLike, config::TestConfig) = _soc2test(model, config, true)
+soc2ptest(model::MOI.ModelLike, config::TestConfig) = _soc2test(model, config, false)
+
+function soc3test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone)])
+    # Problem SOC3 - Infeasible
+    # min 0
+    # s.t. y ≥ 2
+    #      x ≤ 1
+    #      |y| ≤ x
+    # in conic form:
+    # min 0
+    # s.t. -2 + y ∈ R₊
+    #      -1 + x ∈ R₋
+    #       (x,y) ∈ SOC₂
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x,y = MOI.addvariables!(model, 2)
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+    MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[y],[1.0],[-2.0]), MOI.Nonnegatives(1))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
+    MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Nonpositives(1))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)
+    MOI.addconstraint!(model, MOI.VectorAffineFunction([1,2],[x,y],ones(2),zeros(2)), MOI.SecondOrderCone(2))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        if MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+        end
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+        end
+
+        # TODO test dual feasibility and objective sign
+    end
+end
+
+function soc4test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.Zeros),(MOI.VectorOfVariables,MOI.SecondOrderCone)])
+    # Problem SOC4
+    # min 0x[1] - 2x[2] - 1x[3]
+    #  st  x[1]                                == 1 (c1a)
+    #              x[2]         - x[4]         == 0 (c1b)
+    #                      x[3]         - x[5] == 0 (c1c)
+    #      x[1] >= ||(x[4],x[5])||                  (c2)
+    # in conic form:
+    # min  c^Tx
+    # s.t. Ax + b ∈ {0}₃
+    #      (x[1],x[4],x[5]) ∈ SOC₃
+    # Like SOCINT1 but with copies of variables and integrality relaxed
+    # Tests out-of-order indices in cones
+
+    b = [-1.0, 0.0, 0.0]
+    A = [ 1.0  0.0  0.0  0.0  0.0
+          0.0  1.0  0.0 -1.0  0.0
+          0.0  0.0  1.0  0.0 -1.0]
+    c = [ 0.0,-2.0,-1.0, 0.0, 0.0]
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariables!(model, 5)
+
+    A_cols = x
+    A_rows = [1,2,3,2,3]
+    A_vals = [1.0,1.0,1.0,-1.0,-1.0]
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction(A_rows,A_cols,A_vals,b), MOI.Zeros(3))
+    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
+    c2 = MOI.addconstraint!(model, MOI.VectorOfVariables([x[1],x[4],x[5]]), MOI.SecondOrderCone(3))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(x,c,0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        x_primal = MOI.get(model, MOI.VariablePrimal(), x)
+        @test x_primal[1]^2 ≥ x_primal[4]^2 + x_primal[5]^2 - atol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
+            x_dual = MOI.get(model, MOI.ConstraintDual(), c2)
+            @test x_dual[1]^2 ≥ x_dual[2]^2 + x_dual[3]^2 - atol
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
+            c1_dual = MOI.get(model, MOI.ConstraintDual(), c1)
+
+            @test dot(c,x_primal) ≈ -dot(c1_dual,b) atol=atol rtol=rtol
+            @test (c-A'c1_dual) ≈ [x_dual[1], 0, 0, x_dual[2], x_dual[3]] atol=atol rtol=rtol
+        end
+    end
+end
+
+const soctests = Dict("soc1v" => soc1vtest,
+                      "soc1f" => soc1ftest,
+                      "soc2n" => soc2ntest,
+                      "soc2p" => soc2ptest,
+                      "soc3"  => soc3test,
+                      "soc4"  => soc4test)
+
+@moitestset soc
+
+function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64},
+    #    [(MOI.SingleVariable,MOI.EqualTo{Float64}),
+    #     (MOI.VectorOfVariables,MOI.RotatedSecondOrderCone)])
+    # Problem SOCRotated1v
+    # min 0a + 0b - 1x - 1y
+    #  st  a            == 1/2
+    #  st  b            == 1
+    #      2a*b >= x^2+y^2
+    # Problem SOCRotated1f - Problem SOCRotated1v with a and b substituted
+    # min          -y - z
+    #  st [0.5] - [      ] SOCRotated
+    #     [1.0] - [      ] SOCRotated
+    #     [0.0] - [-y    ] SOCRotated
+    #     [0.0] - [    -z] SOCRotated
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariables!(model, 2)
+    if abvars
+        MOI.canaddvariable(model)
+        a = MOI.addvariable!(model)
+        MOI.canaddvariable(model)
+        b = MOI.addvariable!(model)
+        @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
+        vc1 = MOI.addconstraint!(model, MOI.SingleVariable(a), MOI.EqualTo(0.5))
+        @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
+        vc2 = MOI.addconstraint!(model, MOI.SingleVariable(b), MOI.EqualTo(1.0))
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.RotatedSecondOrderCone)
+        rsoc = MOI.addconstraint!(model, MOI.VectorOfVariables([a; b; x]), MOI.RotatedSecondOrderCone(4))
+    else
+        a = 0.5
+        b = 1.0
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)
+        rsoc = MOI.addconstraint!(model, MOI.VectorAffineFunction([3, 4], x, [1., 1.], [a, b, 0., 0.]), MOI.RotatedSecondOrderCone(4))
+    end
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == (abvars ? 2 : 0)
+    @test MOI.get(model, MOI.NumberOfConstraints{abvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 1
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(x,ones(2),0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ sqrt(2.0) atol=atol rtol=rtol
+
+        if abvars
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), a) ≈ 0.5 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), b) ≈ 1.0 atol=atol rtol=rtol
+        end
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
+
+        if abvars
+            @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc1))
+            @test MOI.get(model, MOI.ConstraintPrimal(), vc1) ≈ 0.5
+            @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc2))
+            @test MOI.get(model, MOI.ConstraintPrimal(), vc2) ≈ 1.0
+        end
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(rsoc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), rsoc) ≈ [0.5, 1.0, 1.0/sqrt(2.0), 1.0/sqrt(2.0)] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus(1))
+            @test MOI.get(model, MOI.DualStatus(1)) == MOI.FeasiblePoint
+
+            if abvars
+                @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
+                @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ -sqrt(2) atol=atol rtol=rtol
+                @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
+                @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ -1/sqrt(2) atol=atol rtol=rtol
+            end
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(rsoc))
+            @test MOI.get(model, MOI.ConstraintDual(), rsoc) ≈ [sqrt(2), 1/sqrt(2), -1.0, -1.0] atol=atol rtol=rtol
+        end
+    end
+end
+
+rotatedsoc1vtest(model::MOI.ModelLike, config::TestConfig) = _rotatedsoc1test(model, config, true)
+rotatedsoc1ftest(model::MOI.ModelLike, config::TestConfig) = _rotatedsoc1test(model, config, false)
+
+function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64},
+    #    [(MOI.SingleVariable,MOI.EqualTo{Float64}),
+    #     (MOI.SingleVariable,MOI.LessThan{Float64}),
+    #     (MOI.SingleVariable,MOI.GreaterThan{Float64}),
+    #     (MOI.VectorOfVariables,MOI.RotatedSecondOrderCone)])
+    # Problem SOCRotated2 - Infeasible
+    # min 0
+    # s.t.
+    #      x ≤ 1
+    #      y = 1/2
+    #      z ≥ 2
+    #      z^2 ≤ 2x*y
+    # in conic form:
+    # min 0
+    # s.t.
+    #      -1 + x ∈ R₋
+    #     1/2 - y ∈ {0}
+    #      -2 + z ∈ R₊
+    #       (x,y,z) ∈ SOCRotated
+    b = [-2, -1, 1/2]
+    c = [0.0,0.0,0.0]
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariables!(model, 3)
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
+    vc1 = MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.LessThan(1.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
+    vc2 = MOI.addconstraint!(model, MOI.SingleVariable(x[2]), MOI.EqualTo(0.5))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    vc3 = MOI.addconstraint!(model, MOI.SingleVariable(x[3]), MOI.GreaterThan(2.0))
+
+    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.RotatedSecondOrderCone)
+    rsoc = MOI.addconstraint!(model, MOI.VectorOfVariables(x), MOI.RotatedSecondOrderCone(3))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.RotatedSecondOrderCone}()) == 1
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(x,c,0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+
+        if MOI.get(model, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleOrUnbounded] && config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) in [MOI.InfeasibilityCertificate, MOI.NearlyInfeasibilityCertificate]
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
+            y1 = MOI.get(model, MOI.ConstraintDual(), vc1)
+            @test y1 < -atol # Should be strictly negative
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
+            y2 = MOI.get(model, MOI.ConstraintDual(), vc2)
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc3))
+            y3 = MOI.get(model, MOI.ConstraintDual(), vc3)
+            @test y3 > atol # Should be strictly positive
+
+            y = [y1, y2, y3]
+
+            vardual = MOI.get(model, MOI.ConstraintDual(), rsoc)
+
+            @test vardual ≈ -y atol=atol rtol=rtol
+            @test 2*vardual[1]*vardual[2] ≥ vardual[3]^2 - atol
+            @test dot(b,y) > atol
+        end
+    end
+end
+
+function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
+    atol = config.atol
+    rtol = config.rtol
+    # Problem SOCRotated3
+    # max v
+    # s.t.
+    #      x[1:2] ≥ 0
+    #      0 ≤ u ≤ 3.0
+    #      v
+    #      t1 == 1
+    #      t2 == 1
+    # [t1/√2, t2/√2, x] in SOC4
+    # [x1/√2, u/√2,  v] in SOC3
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariables!(model, n)
+    MOI.canaddvariable(model)
+    u = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    v = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    t = MOI.addvariables!(model, 2)
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
+    ct1 = MOI.addconstraint!(model, MOI.SingleVariable(t[1]), MOI.EqualTo(1.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
+    ct2 = MOI.addconstraint!(model, MOI.SingleVariable(t[2]), MOI.EqualTo(1.0))
+    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
+    cx  = MOI.addconstraint!(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(n))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    cu1 = MOI.addconstraint!(model, MOI.SingleVariable(u), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
+    cu2 = MOI.addconstraint!(model, MOI.SingleVariable(u), MOI.LessThan(ub))
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)
+    c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction(collect(1:(2+n)), [t; x], [1/√2; 1/√2; ones(n)], zeros(2+n)), MOI.RotatedSecondOrderCone(2+n))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)
+    c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction([1, 2, 3], [x[1], u, v], [1/√2; 1/√2; 1.0], zeros(3)), MOI.RotatedSecondOrderCone(3))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 2
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([v],[1.0],0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ √ub atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [1.0; zeros(n-1)] atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), u) ≈ ub atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ √ub atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), t) ≈ ones(2) atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cx))
+        @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ [1.0; zeros(n-1)] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cu1))
+        @test MOI.get(model, MOI.ConstraintPrimal(), cu1) ≈ ub atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cu2))
+        @test MOI.get(model, MOI.ConstraintPrimal(), cu2) ≈ ub atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ct1))
+        @test MOI.get(model, MOI.ConstraintPrimal(), ct1) ≈ 1.0 atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ct1))
+        @test MOI.get(model, MOI.ConstraintPrimal(), ct1) ≈ 1.0 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ [1/√2; 1/√2; 1.0; zeros(n-1)] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ [1/√2, ub/√2, √ub] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cx))
+            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ zeros(n) atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cu1))
+            @test MOI.get(model, MOI.ConstraintDual(), cu1) ≈ 0.0 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cu2))
+            @test MOI.get(model, MOI.ConstraintDual(), cu2) ≈ -1/(2*√ub) atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ct1))
+            @test MOI.get(model, MOI.ConstraintDual(), ct1) ≈ -√ub/4 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ct1))
+            @test MOI.get(model, MOI.ConstraintDual(), ct1) ≈ -√ub/4 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
+            @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ [√ub/(2*√2); √ub/(2*√2); -√ub/2; zeros(n-1)] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
+            @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ [√ub/√2, 1/√(2*ub), -1.0] atol=atol rtol=rtol
+        end
+    end
+end
+
+
+const rsoctests = Dict("rotatedsoc1v" => rotatedsoc1vtest,
+                       "rotatedsoc1f" => rotatedsoc1ftest,
+                       "rotatedsoc2"  => rotatedsoc2test,
+                       "rotatedsoc3"  => rotatedsoc3test)
+
+@moitestset rsoc
+
+function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
+    atol = config.atol
+    rtol = config.rtol
+    # Problem GeoMean1
+    # max (xyz)^(1/3)
+    # s.t.
+    #      x + y + z ≤ 3
+    # in conic form:
+    # max t
+    # s.t.
+    #   (t,x,y,z) ∈ GeometricMeanCone(4)
+    #     x+y+z-3 ∈ LessThan(0.)
+    # By the arithmetic-geometric mean inequality,
+    # (xyz)^(1/3) ≤ (x+y+z)/3 = 1
+    # Therefore xyz ≤ 1
+    # This can be attained using x = y = z = 1 so it is optimal.
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    t = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    x = MOI.addvariables!(model, n)
+
+    vov = MOI.VectorOfVariables([t; x])
+    if vecofvars
+        @test MOI.canaddconstraint(model, typeof(vov), MOI.GeometricMeanCone)
+        gmc = MOI.addconstraint!(model, vov, MOI.GeometricMeanCone(n+1))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone)
+        gmc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.GeometricMeanCone(n+1))
+    end
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(x, ones(n), 0.), MOI.LessThan(Float64(n)))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([t], [1.], 0.))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ ones(n) atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(gmc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ ones(n+1) atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ n atol=atol rtol=rtol
+
+    #    if config.duals
+    #        @test MOI.canget(model, MOI.DualStatus())
+    #        @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+    #
+    #        @test MOI.canget(model, MOI.ConstraintDual(), typeof(gmc))
+    #        @show MOI.get(model, MOI.ConstraintDual(), gmc)
+    #
+    #        @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+    #        @show MOI.get(model, MOI.ConstraintDual(), c)
+    #    end
+    end
+end
+
+geomean1vtest(model::MOI.ModelLike, config::TestConfig) = _geomean1test(model, config, true)
+geomean1ftest(model::MOI.ModelLike, config::TestConfig) = _geomean1test(model, config, false)
+
+geomeantests = Dict("geomean1v" => geomean1vtest,
+                    "geomean1f" => geomean1ftest)
+
+@moitestset geomean
+
+function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
+    atol = config.atol
+    rtol = config.rtol
+    # Problem EXP1 - ExpPrimal
+    # min x + y + z
+    #  st  y e^(x/y) <= z, y > 0 (i.e (x, y, z) are in the exponential primal cone)
+    #      x == 1
+    #      y == 2
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 3)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 3
+
+    vov = MOI.VectorOfVariables(v)
+    vov = MOI.VectorOfVariables(v)
+    if vecofvars
+        @test MOI.canaddconstraint(model, typeof(vov), MOI.ExponentialCone)
+        vc = MOI.addconstraint!(model, vov, MOI.ExponentialCone())
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
+        vc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.ExponentialCone())
+    end
+
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    cx = MOI.addconstraint!(model, MOI.ScalarAffineFunction([v[1]], [1.], 0.), MOI.EqualTo(1.))
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    cy = MOI.addconstraint!(model, MOI.ScalarAffineFunction([v[2]], [1.], 0.), MOI.EqualTo(2.))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(v, ones(3), 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 + 2exp(1/2) atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1., 2., 2exp(1/2)] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [1., 2., 2exp(1/2)] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cx))
+        @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ 1 atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cy))
+        @test MOI.get(model, MOI.ConstraintPrimal(), cy) ≈ 2 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc))
+            u, v, w = MOI.get(model, MOI.ConstraintDual(), vc)
+            @test u ≈ -exp(1/2) atol=atol rtol=rtol
+            @test v ≈ -exp(1/2)/2 atol=atol rtol=rtol
+            @test w ≈ 1 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cx))
+            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ 1 + exp(1/2) atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cy))
+            @test MOI.get(model, MOI.ConstraintDual(), cy) ≈ 1 + exp(1/2)/2 atol=atol rtol=rtol
+        end
+    end
+end
+
+exp1vtest(model::MOI.ModelLike, config::TestConfig) = _exp1test(model, config, true)
+exp1ftest(model::MOI.ModelLike, config::TestConfig) = _exp1test(model, config, false)
+
+function exp2test(model::MOI.ModelLike, config::TestConfig)
+    # Problem EXP2
+    # A problem where ECOS was failing
+    atol = config.atol
+    rtol = config.rtol
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 9)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 9
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
+    ec1 = MOI.addconstraint!(model, MOI.VectorAffineFunction([1, 1, 3], [v[2], v[3], v[4]], ones(3), [0., 1., 0.]), MOI.ExponentialCone())
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
+    ec2 = MOI.addconstraint!(model, MOI.VectorAffineFunction([1, 1, 3], [v[2], v[3], v[5]], [1., -1., 1.], [0., 1., 0.]), MOI.ExponentialCone())
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([v[4], v[5], v[6]], [.5, .5, -1.], 0.), MOI.EqualTo(0.))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+    c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction([1, 2, 3, 1, 2, 3], [v[1], v[2], v[3], v[7], v[8], v[9]], [ 1.,  1.,  1., 0.3, 0.3, 0.3], zeros(3)), MOI.Nonnegatives(3))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+    c3 = MOI.addconstraint!(model, MOI.VectorAffineFunction([1, 2, 3, 1, 2, 3], [v[1], v[2], v[3], v[7], v[8], v[9]], [-1., -1., -1., 0.3, 0.3, 0.3], zeros(3)), MOI.Nonnegatives(3))
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    c4 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([v[7], v[8], v[9]], ones(3), 0.), MOI.LessThan(1.))
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    c5 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([v[7]], [1.], 0.), MOI.EqualTo(0.))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([v[6]], [1.], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ exp(-0.3) atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0., -0.3, 0., exp(-0.3), exp(-0.3), exp(-0.3), 0., 1.0, 0.] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ec1))
+        @test MOI.get(model, MOI.ConstraintPrimal(), ec1) ≈ [-0.3, 1.0, exp(-0.3)] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ec2))
+        @test MOI.get(model, MOI.ConstraintPrimal(), ec2) ≈ [-0.3, 1.0, exp(-0.3)] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ 0. atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ zeros(3) atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c3))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c3) ≈ [0., 0.6, 0.] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c4))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c4) ≈ 1. atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c5))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c5) ≈ 0. atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ec1))
+            @test MOI.get(model, MOI.ConstraintDual(), ec1) ≈ [-exp(-0.3)/2, -1.3exp(-0.3)/2, 0.5] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ec2))
+            @test MOI.get(model, MOI.ConstraintDual(), ec2) ≈ [-exp(-0.3)/2, -1.3exp(-0.3)/2, 0.5] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
+            @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ -1 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c5))
+            d5 = MOI.get(model, MOI.ConstraintDual(), c5) # degree of freedom
+            d23 = (exp(-0.3)*0.3 - d5) / 0.6 # dual constraint corresponding to v[7]
+            @test d23 >= -atol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
+            @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ [d23, exp(-0.3), exp(-0.3)/2] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c3))
+            @test MOI.get(model, MOI.ConstraintDual(), c3) ≈ [d23, 0.0, exp(-0.3)/2] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c4))
+            @test MOI.get(model, MOI.ConstraintDual(), c4) ≈ -exp(-0.3)*0.3 atol=atol rtol=rtol
+        end
+    end
+end
+
+function exp3test(model::MOI.ModelLike, config::TestConfig)
+    # Problem EXP3
+    # A problem where ECOS was failing
+    atol = config.atol
+    rtol = config.rtol
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    xc = MOI.addconstraint!(model, MOI.ScalarAffineFunction([x], [2.], 0.), MOI.LessThan(4.))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
+    yc = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.LessThan(5.))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
+    ec = MOI.addconstraint!(model, MOI.VectorAffineFunction([1, 3], [x, y], ones(2), [0., 1., 0.]), MOI.ExponentialCone())
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x], [1.], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ log(5) atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ log(5) atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 5. atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(xc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), xc) ≈ 2log(5) atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(yc))
+        @test MOI.get(model, MOI.ConstraintPrimal(), yc) ≈ 5 atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ec))
+        @test MOI.get(model, MOI.ConstraintPrimal(), ec) ≈ [log(5), 1., 5.] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(xc))
+            @test MOI.get(model, MOI.ConstraintDual(), xc) ≈ 0. atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(yc))
+            @test MOI.get(model, MOI.ConstraintDual(), yc) ≈ -1/5 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ec))
+            @test MOI.get(model, MOI.ConstraintDual(), ec) ≈ [-1., log(5)-1, 1/5] atol=atol rtol=rtol
+        end
+    end
+end
+
+exptests = Dict("exp1v" => exp1vtest,
+                "exp1f" => exp1ftest,
+                "exp2"  => exp2test,
+                "exp3"  => exp3test)
+
+@moitestset exp
+
+function _sdp0test(model::MOI.ModelLike, vecofvars::Bool, sdpcone, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, sdpcone)])
+    # min X[1,1] + X[2,2]    max y
+    #     X[2,1] = 1         [0   y/2     [ 1  0
+    #                         y/2 0    <=   0  1]
+    #     X >= 0              y free
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    X = MOI.addvariables!(model, 3)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 3
+
+    vov = MOI.VectorOfVariables(X)
+    if vecofvars
+        @test MOI.canaddconstraint(model, typeof(vov), sdpcone)
+        cX = MOI.addconstraint!(model, vov, sdpcone(2))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, sdpcone)
+        cX = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), sdpcone(2))
+    end
+
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    c = MOI.addconstraint!(model, MOI.ScalarAffineFunction([X[2]], [1.], 0.), MOI.EqualTo(1.))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, sdpcone}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([X[1], X[3]], ones(2), 0.))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), X) ≈ [1, 1, 1] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cX))
+        @test MOI.get(model, MOI.ConstraintPrimal(), cX) ≈ [1, 1, 1] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 2 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cX))
+            @test MOI.get(model, MOI.ConstraintDual(), cX) ≈ [1, -1, 1] atol=atol rtol=rtol
+        end
+    end
+end
+
+
+function _sdp1test(model::MOI.ModelLike, vecofvars::Bool, sdpcone, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, sdpcone), (MOI.VectorOfVariables, MOI.SecondOrderCone)])
+    # Problem SDP1 - sdo1 from MOSEK docs
+    # From Mosek.jl/test/mathprogtestextra.jl, under license:
+    #   Copyright (c) 2013 Ulf Worsoe, Mosek ApS
+    #   Permission is hereby granted, free of charge, to any person obtaining a copy of this
+    #   software and associated documentation files (the "Software"), to deal in the Software
+    #   without restriction, including without limitation the rights to use, copy, modify, merge,
+    #   publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+    #   to whom the Software is furnished to do so, subject to the following conditions:
+    #   The above copyright notice and this permission notice shall be included in all copies or
+    #   substantial portions of the Software.
+    #
+    #     | 2 1 0 |
+    # min | 1 2 1 | . X + x1
+    #     | 0 1 2 |
+    #
+    #
+    # s.t. | 1 0 0 |
+    #      | 0 1 0 | . X + x1 = 1
+    #      | 0 0 1 |
+    #
+    #      | 1 1 1 |
+    #      | 1 1 1 | . X + x2 + x3 = 1/2
+    #      | 1 1 1 |
+    #
+    #      (x1,x2,x3) in C^3_q
+    #      X in C_sdp
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    X = MOI.addvariables!(model, 6)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 6
+    MOI.canaddvariable(model)
+    x = MOI.addvariables!(model, 3)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 9
+
+    vov = MOI.VectorOfVariables(X)
+    if vecofvars
+        @test MOI.canaddconstraint(model, typeof(vov), sdpcone)
+        cX = MOI.addconstraint!(model, vov, sdpcone(3))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, sdpcone)
+        cX = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), sdpcone(3))
+    end
+    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
+    cx = MOI.addconstraint!(model, MOI.VectorOfVariables(x), MOI.SecondOrderCone(3))
+
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([X[1], X[3], X[6], x[1]], [1., 1, 1, 1], 0.), MOI.EqualTo(1.))
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([X; x[2]; x[3]], [1., 2, 1, 2, 2, 1, 1, 1], 0.), MOI.EqualTo(1/2))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([X[1:3]; X[5:6]; x[1]], [2., 2, 2, 2, 2, 1], 0.))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, sdpcone}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables, MOI.SecondOrderCone}()) == 1
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.705710509 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        Xv = MOI.get(model, MOI.VariablePrimal(), X)
+        Xp = [Xv[1] Xv[2] Xv[4]
+              Xv[2] Xv[3] Xv[5]
+              Xv[4] Xv[5] Xv[6]]
+        @test eigmin(Xp) > -atol
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        xv = MOI.get(model, MOI.VariablePrimal(), x)
+        @test xv[2]^2 + xv[3]^2 - xv[1]^2 < atol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), cX) ≈ Xv atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ xv atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ Xv[1]+Xv[3]+Xv[6]+xv[1] atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ Xv[1]+2Xv[2]+Xv[3]+2Xv[4]+2Xv[5]+Xv[6]+xv[2]+xv[3] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
+            y1 = MOI.get(model, MOI.ConstraintDual(), c1)
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
+            y2 = MOI.get(model, MOI.ConstraintDual(), c2)
+
+            #     X11  X21  X22  X31  X32  X33  x1  x2  x3
+            c = [   2,   2,   2,   0,   2,   2,  1,  0,  0]
+            b = [1, 1/2]
+            # Check primal objective
+            comp_pobj = dot(c, [Xv; xv])
+            # Check dual objective
+            comp_dobj = dot([y1, y2], b)
+            @test comp_pobj ≈ comp_dobj atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cX))
+            Xdv = MOI.get(model, MOI.ConstraintDual(), cX)
+            Xd = [Xdv[1] Xdv[2] Xdv[4];
+                  Xdv[2] Xdv[3] Xdv[5];
+                  Xdv[4] Xdv[5] Xdv[6]]
+
+            C = [2 1 0;
+                 1 2 1;
+                 0 1 2]
+            A1 = [1 0 0;
+                  0 1 0;
+                  0 0 1]
+            A2 = [1 1 1;
+                  1 1 1;
+                  1 1 1]
+
+            @test C ≈ y1 * A1 + y2 * A2 + Xd atol=atol rtol=rtol
+
+            @test eigmin(Xd) > -atol
+        end
+    end
+end
+
+sdp0tvtest(model::MOI.ModelLike, config::TestConfig) = _sdp0test(model, true, MOI.PositiveSemidefiniteConeTriangle, config)
+sdp0tftest(model::MOI.ModelLike, config::TestConfig) = _sdp0test(model, false, MOI.PositiveSemidefiniteConeTriangle, config)
+sdp1tvtest(model::MOI.ModelLike, config::TestConfig) = _sdp1test(model, true, MOI.PositiveSemidefiniteConeTriangle, config)
+sdp1tftest(model::MOI.ModelLike, config::TestConfig) = _sdp1test(model, false, MOI.PositiveSemidefiniteConeTriangle, config)
+
+function sdp2test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}), (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle)])
+    # Caused getdual to fail on SCS and Mosek
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariables!(model, 7)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 7
+
+    η = 10.0
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
+    c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(x[1:6], -ones(6), η), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
+    c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction(collect(1:6), x[1:6], -ones(6), zeros(6)), MOI.Nonpositives(6))
+    α = 0.8
+    δ = 0.9
+    c3 = MOI.addconstraint!(model, MOI.VectorAffineFunction([fill(1, 7); fill(2, 5);     fill(3, 6)],
+                                                               [x[1:7];     x[1:3]; x[5:6]; x[1:3]; x[5:7]],
+                                                               [ δ/2,       α,   δ, δ/4, δ/8,      0.0, -1.0,
+                                                                -δ/(2*√2), -δ/4, 0,     -δ/(8*√2), 0.0,
+                                                                 δ/2,     δ-α,   0,      δ/8,      δ/4, -1.0],
+                                                               zeros(3)), MOI.PositiveSemidefiniteConeTriangle(2))
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    c4 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([x[1:3]; x[5:6]], zeros(5), 0.0), MOI.EqualTo(0.))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonpositives}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x[7]], [1.], 0.))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+        end
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [2η/3, 0, η/3, 0, 0, 0, η*δ*(1 - 1/√3)/2] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ [-2η/3, 0, -η/3, 0, 0, 0] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c3))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c3) ≈ [η*δ*(1/√3+1/3)/2, -η*δ/(3*√2), η*δ*(1/√3-1/3)/2] atol=atol rtol=rtol
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c4))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c4) ≈ 0.0 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
+            @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ δ*(1-1/√3)/2 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
+            @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ [0, -α/√3+δ/(2*√6)*(2*√2-1), 0, -3δ*(1-1/√3)/8, -3δ*(1-1/√3)/8, -δ*(3 - 2*√3 + 1/√3)/8] atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c3))
+            @test MOI.get(model, MOI.ConstraintDual(), c3) ≈ [(1-1/√3)/2, 1/√6, (1+1/√3)/2] atol=atol rtol=rtol
+            # Dual of c4 could be anything
+        end
+    end
+end
+
+const sdptests = Dict("sdp0tv" => sdp0tvtest,
+                      "sdp0tf" => sdp0tftest,
+                      "sdp1tv" => sdp1tvtest,
+                      "sdp1tf" => sdp1tftest,
+                      "sdp2"   => sdp2test)
+
+@moitestset sdp
+
+function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, detcone)
+    atol = config.atol
+    rtol = config.rtol
+    square = detcone == MOI.LogDetConeSquare || detcone == MOI.RootDetConeSquare
+    logdet = detcone == MOI.LogDetConeTriangle || detcone == MOI.LogDetConeSquare
+    # We look for an ellipsoid x^T P x ≤ 1 contained in the square.
+    # Let Q = inv(P) (x^T Q x ≤ 1 is its polar ellipsoid), we have
+    # max t
+    #     t <= log det Q (or t <= (det Q)^(1/n))
+    #             Q22 ≤ 1
+    #            _________
+    #           |         |
+    #           |         |
+    # -Q11 ≥ -1 |    +    | Q11 ≤ 1
+    #           |         |
+    #           |_________|
+    #            -Q22 ≥ -1
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    t = MOI.addvariable!(model)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+    MOI.canaddvariable(model)
+    Q = MOI.addvariables!(model, square ? 4 : 3)
+    @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 5 : 4)
+
+    vov = MOI.VectorOfVariables([t; Q])
+    if vecofvars
+        @test MOI.canaddconstraint(model, typeof(vov), detcone)
+        cX = MOI.addconstraint!(model, vov, detcone(2))
+    else
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, detcone)
+        cX = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), detcone(2))
+    end
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+    c = MOI.addconstraint!(model, MOI.VectorAffineFunction(collect(1:2), [Q[1], Q[end]], [-1., -1.], ones(2)), MOI.Nonnegatives(2))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, detcone}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}()) == 1
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([t], ones(1), 0.))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        expectedobjval = logdet ? 0. : 1.
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ expectedobjval atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), t) ≈ expectedobjval atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        Qv = MOI.get(model, MOI.VariablePrimal(), Q)
+        @test Qv[1] ≈ 1. atol=atol rtol=rtol
+        @test Qv[2] ≈ 0. atol=atol rtol=rtol
+        if square
+            @test Qv[3] ≈ 0. atol=atol rtol=rtol
+        end
+        @test Qv[end] ≈ 1. atol=atol rtol=rtol
+    end
+end
+
+logdet1tvtest(model::MOI.ModelLike, config::TestConfig) = _det1test(model, config, true, MOI.LogDetConeTriangle)
+logdet1tftest(model::MOI.ModelLike, config::TestConfig) = _det1test(model, config, false, MOI.LogDetConeTriangle)
+
+const logdettests = Dict("logdet1tv" => logdet1tvtest,
+                         "logdet1tf" => logdet1tftest)
+
+@moitestset logdet
+
+rootdet1tvtest(model::MOI.ModelLike, config::TestConfig) = _det1test(model, config, true, MOI.RootDetConeTriangle)
+rootdet1tftest(model::MOI.ModelLike, config::TestConfig) = _det1test(model, config, false, MOI.RootDetConeTriangle)
+
+const rootdettests = Dict("rootdet1tv" => rootdet1tvtest,
+                          "rootdet1tf" => rootdet1tftest)
+
+@moitestset rootdet
+
+const contconictests = Dict("lin" => lintest,
+                            "soc" => soctest,
+                            "rsoc" => rsoctest,
+                            "geomean" => geomeantest,
+                            "exp" => exptest,
+                            "sdp" => sdptest,
+                            "logdet" => logdettest,
+                            "rootdet" => rootdettest)
+
+@moitestset contconic true

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -1,0 +1,1384 @@
+# Continuous linear problems
+
+# Basic solver, query, resolve
+function linear1test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # simple 2 variable, 1 constraint problem
+    # min -x
+    # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
+    #       x, y >= 0   (x, y ∈ Nonnegatives)
+
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+
+    #@test MOI.get(model, MOI.SupportsAddConstraintAfterSolve())
+    #@test MOI.get(model, MOI.SupportsAddVariableAfterSolve())
+    #@test MOI.get(model, MOI.SupportsDeleteConstraint())
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 2)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    cf = MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
+    c = MOI.addconstraint!(model, cf, MOI.LessThan(1.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    vc1 = MOI.addconstraint!(model, MOI.SingleVariable(v[1]), MOI.GreaterThan(0.0))
+    # test fallback
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    vc2 = MOI.addconstraint!(model, v[2], MOI.GreaterThan(0.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+
+    objf = MOI.ScalarAffineFunction(v, [-1.0,0.0], 0.0)
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+
+    if config.query
+        @test MOI.canget(model, MOI.ListOfVariableIndices())
+        vrs = MOI.get(model, MOI.ListOfVariableIndices())
+        @test vrs == v || vrs == reverse(v)
+
+        @test !MOI.canget(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
+        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+
+        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
+        @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
+
+        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
+        s = MOI.get(model, MOI.ConstraintSet(), c)
+        @test s == MOI.LessThan(1.0)
+
+        @test MOI.canget(model, MOI.ConstraintSet(), typeof(vc1))
+        s = MOI.get(model, MOI.ConstraintSet(), vc1)
+        @test s == MOI.GreaterThan(0.0)
+
+        @test MOI.canget(model, MOI.ConstraintSet(), typeof(vc2))
+        s = MOI.get(model, MOI.ConstraintSet(), vc2)
+        @test s == MOI.GreaterThan(0.0)
+    end
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+
+            # reduced costs
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
+            @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
+            @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+        end
+    end
+
+    # change objective to Max +x
+
+    objf = MOI.ScalarAffineFunction(v, [1.0,0.0], 0.0)
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.query
+        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    end
+
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
+            @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
+            @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+        end
+    end
+
+    # add new variable to get :
+    # max x + 2z
+    # s.t. x + y + z <= 1
+    # x,y,z >= 0
+
+    MOI.canaddvariable(model)
+    z = MOI.addvariable!(model)
+    push!(v, z)
+    @test v[3] == z
+
+    if config.query
+        # Test that the modifcation of v has not affected the model
+        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
+        vars = MOI.get(model, MOI.ConstraintFunction(), c).variables
+        @test vars == [v[1], v[2]] || vars == [v[2], v[1]]
+        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test MOI.ScalarAffineFunction([v[1]], [1.0], 0.0) ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    end
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    vc3 = MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.GreaterThan(0.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
+
+    @test MOI.canmodifyconstraint(model, c, MOI.ScalarCoefficientChange{Float64})
+    MOI.modifyconstraint!(model, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
+
+    @test MOI.canmodifyobjective(model, MOI.ScalarCoefficientChange{Float64})
+    MOI.modifyobjective!(model, MOI.ScalarCoefficientChange{Float64}(z, 2.0))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus(1))
+        @test MOI.get(model, MOI.PrimalStatus(1)) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 0, 1] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -2 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
+            @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 1 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
+            @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 2 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc3))
+            @test MOI.get(model, MOI.ConstraintDual(), vc3) ≈ 0 atol=atol rtol=rtol
+        end
+    end
+
+    # setting lb of x to -1 to get :
+    # max x + 2z
+    # s.t. x + y + z <= 1
+    # x >= -1
+    # y,z >= 0
+    @test MOI.canmodifyconstraint(model, vc1, MOI.GreaterThan{Float64})
+    MOI.modifyconstraint!(model, vc1, MOI.GreaterThan(-1.0))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+    end
+
+    # put lb of x back to 0 and fix z to zero to get :
+    # max x + 2z
+    # s.t. x + y + z <= 1
+    # x, y >= 0, z = 0
+    @test MOI.canmodifyconstraint(model, vc1, MOI.GreaterThan{Float64})
+    MOI.modifyconstraint!(model, vc1, MOI.GreaterThan(0.0))
+
+    @test MOI.candelete(model, vc3)
+    MOI.delete!(model, vc3)
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
+    vc3 = MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+    end
+
+    # modify affine linear constraint set to be == 2 to get :
+    # max x + 2z
+    # s.t. x + y + z == 2
+    # x,y >= 0, z = 0
+    @test MOI.candelete(model, c)
+    MOI.delete!(model, c)
+    cf = MOI.ScalarAffineFunction(v, [1.0,1.0,1.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf), MOI.EqualTo{Float64})
+    c = MOI.addconstraint!(model, cf, MOI.EqualTo(2.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+    end
+
+    # modify objective function to x + 2y to get :
+    # max x + 2y
+    # s.t. x + y + z == 2
+    # x,y >= 0, z = 0
+
+    objf = MOI.ScalarAffineFunction(v, [1.0,2.0,0.0], 0.0)
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 2, 0] atol=atol rtol=rtol
+    end
+
+    # add constraint x - y >= 0 to get :
+    # max x+2y
+    # s.t. x + y + z == 2
+    # x - y >= 0
+    # x,y >= 0, z = 0
+
+    cf2 = MOI.ScalarAffineFunction(v, [1.0, -1.0, 0.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf2), MOI.GreaterThan{Float64})
+    c2 = MOI.addconstraint!(model, cf2, MOI.GreaterThan(0.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 1, 0] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus(1))
+            @test MOI.get(model, MOI.DualStatus(1)) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1.5 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ 0.5 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
+            @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
+            @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc3))
+            @test MOI.get(model, MOI.ConstraintDual(), vc3) ≈ 1.5 atol=atol rtol=rtol
+        end
+    end
+
+    if config.query
+        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c2))
+        @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ cf2
+    end
+
+    # delete variable x to get :
+    # max 2y
+    # s.t. y + z == 2
+    # - y >= 0
+    # y >= 0, z = 0
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+    MOI.delete!(model, v[1])
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+
+    if config.query
+        @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ MOI.ScalarAffineFunction([v[2], z], [-1.0, 0.0], 0.0)
+
+        @test MOI.canget(model, MOI.ListOfVariableIndices())
+        vrs = MOI.get(model, MOI.ListOfVariableIndices())
+        @test vrs == [v[2], z] || vrs == [z, v[2]]
+        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()) ≈ MOI.ScalarAffineFunction([v[2], z], [2.0, 0.0], 0.0)
+    end
+end
+
+# addvariable! (one by one)
+function linear2test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # Min -x
+    # s.t. x + y <= 1
+    # x, y >= 0
+
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    cf = MOI.ScalarAffineFunction([x, y], [1.0,1.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
+    c = MOI.addconstraint!(model, cf, MOI.LessThan(1.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    vc1 = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    vc2 = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+
+    objf = MOI.ScalarAffineFunction([x, y], [-1.0,0.0], 0.0)
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+
+            # reduced costs
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
+            @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
+            @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
+        end
+    end
+end
+
+# Issue #40 from Gurobi.jl
+function linear3test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # min  x
+    # s.t. x >= 0
+    #      x >= 3
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    cf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf), MOI.GreaterThan{Float64})
+    MOI.addconstraint!(model, cf, MOI.GreaterThan(3.0))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
+
+    objf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+    end
+
+    # max  x
+    # s.t. x <= 0
+    #      x <= 3
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
+    MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.LessThan(0.0))
+    cf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
+    MOI.addconstraint!(model, cf, MOI.LessThan(3.0))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+
+    objf = MOI.ScalarAffineFunction([x], [1.0], 0.0)
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
+    end
+end
+
+# Modify GreaterThan and LessThan sets as bounds
+function linear4test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.LessThan{Float64})])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+
+    # Min  x - y
+    # s.t. 0.0 <= x          (c1)
+    #             y <= 0.0   (c2)
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    c1 = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
+    c2 = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.LessThan(0.0))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
+
+    # Min  x - y
+    # s.t. 100.0 <= x
+    #               y <= 0.0
+    @test MOI.canmodifyconstraint(model, c1, MOI.GreaterThan{Float64})
+    MOI.modifyconstraint!(model, c1, MOI.GreaterThan(100.0))
+    if config.solve
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
+
+    # Min  x - y
+    # s.t. 100.0 <= x
+    #               y <= -100.0
+    @test MOI.canmodifyconstraint(model, c2, MOI.LessThan{Float64})
+    MOI.modifyconstraint!(model, c2, MOI.LessThan(-100.0))
+    if config.solve
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+    end
+end
+
+# Change coeffs, del constr, del var
+function linear5test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.get(model, MOI.SupportsDeleteVariable())
+    #####################################
+    # Start from simple LP
+    # Solve it
+    # Copy and solve again
+    # Chg coeff, solve, change back solve
+    # del constr and solve
+    # del var and solve
+
+    #   maximize x + y
+    #
+    #   s.t. 2 x + 1 y <= 4
+    #        1 x + 2 y <= 4
+    #        x >= 0, y >= 0
+    #
+    #   solution: x = 1.3333333, y = 1.3333333, objv = 2.66666666
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    cf1 = MOI.ScalarAffineFunction([x, y], [2.0,1.0], 0.0)
+    cf2 = MOI.ScalarAffineFunction([x, y], [1.0,2.0], 0.0)
+
+    @test MOI.canaddconstraint(model, typeof(cf1), MOI.LessThan{Float64})
+    c1 = MOI.addconstraint!(model, cf1, MOI.LessThan(4.0))
+    @test MOI.canaddconstraint(model, typeof(cf2), MOI.LessThan{Float64})
+    c2 = MOI.addconstraint!(model, cf2, MOI.LessThan(4.0))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    vc1 = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    vc2 = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+
+    objf = MOI.ScalarAffineFunction([x, y], [1.0,1.0], 0.0)
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 8/3 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [4/3, 4/3] atol=atol rtol=rtol
+    end
+
+    # copy and solve again
+    # missing test
+
+    # change coeff
+    #   maximize x + y
+    #
+    #   s.t. 2 x + 3 y <= 4
+    #        1 x + 2 y <= 4
+    #        x >= 0, y >= 0
+    #
+    #   solution: x = 2, y = 0, objv = 2
+
+    @test MOI.canmodifyconstraint(model, c1, MOI.ScalarCoefficientChange{Float64})
+    MOI.modifyconstraint!(model, c1, MOI.ScalarCoefficientChange(y, 3.0))
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [2.0, 0.0] atol=atol rtol=rtol
+    end
+
+    # delconstrs and solve
+    #   maximize x + y
+    #
+    #   s.t. 1 x + 2 y <= 4
+    #        x >= 0, y >= 0
+    #
+    #   solution: x = 4, y = 0, objv = 4
+    @test MOI.candelete(model, c1)
+    MOI.delete!(model, c1)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [4.0, 0.0] atol=atol rtol=rtol
+    end
+
+    # delvars and solve
+    #   maximize y
+    #
+    #   s.t.  2 y <= 4
+    #           y >= 0
+    #
+    #   solution: y = 2, objv = 2
+    @test MOI.candelete(model, x)
+    MOI.delete!(model, x)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 2.0 atol=atol rtol=rtol
+    end
+end
+
+# Modify GreaterThan and LessThan sets as linear constraints
+function linear6test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64})])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+
+    # Min  x - y
+    # s.t. 0.0 <= x          (c1)
+    #             y <= 0.0   (c2)
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
+    c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([x],[1.0],0.0), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([y],[1.0],0.0), MOI.LessThan(0.0))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
+
+    # Min  x - y
+    # s.t. 100.0 <= x
+    #               y <= 0.0
+    @test MOI.canmodifyconstraint(model, c1, MOI.GreaterThan{Float64})
+    MOI.modifyconstraint!(model, c1, MOI.GreaterThan(100.0))
+    if config.solve
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
+
+    # Min  x - y
+    # s.t. 100.0 <= x
+    #               y <= -100.0
+    @test MOI.canmodifyconstraint(model, c2, MOI.LessThan{Float64})
+    MOI.modifyconstraint!(model, c2, MOI.LessThan(-100.0))
+    if config.solve
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+    end
+end
+
+# Modify constants in Nonnegatives and Nonpositives
+function linear7test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonpositives),(MOI.VectorAffineFunction{Float64},MOI.Nonpositives)])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+
+    # Min  x - y
+    # s.t. 0.0 <= x          (c1)
+    #             y <= 0.0   (c2)
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x,y], [1.0, -1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+    c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[x],[1.0],[0.0]), MOI.Nonnegatives(1))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
+    c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[y],[1.0],[0.0]), MOI.Nonpositives(1))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
+
+    # Min  x - y
+    # s.t. 100.0 <= x
+    #               y <= 0.0
+    @test MOI.canmodifyconstraint(model, c1, MOI.VectorConstantChange{Float64})
+    MOI.modifyconstraint!(model, c1, MOI.VectorConstantChange([-100.0]))
+    if config.solve
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+    end
+
+    # Min  x - y
+    # s.t. 100.0 <= x
+    #               y <= -100.0
+    @test MOI.canmodifyconstraint(model, c2, MOI.VectorConstantChange{Float64})
+    MOI.modifyconstraint!(model, c2, MOI.VectorConstantChange([100.0]))
+    if config.solve
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+    end
+end
+
+# infeasible problem
+function linear8atest(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # min x
+    # s.t. 2x+y <= -1
+    # x,y >= 0
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    c = MOI.addconstraint!(model, MOI.ScalarAffineFunction([x,y], [2.0,1.0], 0.0), MOI.LessThan(-1.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    bndx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    bndy = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.ResultCount())
+        if config.infeas_certificates
+            # solver returned an infeasibility ray
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            cd = MOI.get(model, MOI.ConstraintDual(), c)
+            @test cd < -atol
+            # TODO: farkas dual on bounds - see #127
+            # xd = MOI.get(model, MOI.ConstraintDual(), bndx)
+            # yd = MOI.get(model, MOI.ConstraintDual(), bndy)
+            # @test xd > atol
+            # @test yd > atol
+            # @test yd ≈ -cd atol=atol rtol=rtol
+            # @test xd ≈ -2cd atol=atol rtol=rtol
+        else
+            # solver returned nothing
+            @test MOI.get(model, MOI.ResultCount()) == 0
+            @test MOI.canget(model, MOI.PrimalStatus(1)) == false
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
+                MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        end
+    end
+end
+
+# unbounded problem
+function linear8btest(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # min -x-y
+    # s.t. -x+2y <= 0
+    # x,y >= 0
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    MOI.addconstraint!(model, MOI.ScalarAffineFunction([x,y], [-1.0,2.0], 0.0), MOI.LessThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x, y], [-1.0, -1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.ResultCount())
+        if config.infeas_certificates
+            # solver returned an unbounded ray
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
+        else
+            # solver returned nothing
+            @test MOI.get(model, MOI.ResultCount()) == 0
+            @test MOI.canget(model, MOI.PrimalStatus(1)) == false
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
+                MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        end
+    end
+end
+
+# unbounded problem with unique ray
+function linear8ctest(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # min -x-y
+    # s.t. x-y == 0
+    # x,y >= 0
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+    MOI.addconstraint!(model, MOI.ScalarAffineFunction([x,y], [1.0,-1.0], 0.0), MOI.EqualTo(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),MOI.ScalarAffineFunction([x, y], [-1.0, -1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.ResultCount())
+        if config.infeas_certificates
+            # solver returned an unbounded ray
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            ray = MOI.get(model, MOI.VariablePrimal(), [x,y])
+            @test ray[1] ≈ ray[2] atol=atol rtol=rtol
+
+        else
+            # solver returned nothing
+            @test MOI.get(model, MOI.ResultCount()) == 0
+            @test MOI.canget(model, MOI.PrimalStatus(1)) == false
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
+                MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        end
+    end
+end
+
+# addconstraints
+function linear9test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #   maximize 1000 x + 350 y
+    #
+    #       s.t.                x >= 30
+    #                           y >= 0
+    #                 x -   1.5 y >= 0
+    #            12   x +   8   y <= 1000
+    #            1000 x + 300   y <= 70000
+    #
+    #   solution: (59.0909, 36.3636)
+    #   objv: 71818.1818
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64},
+    #    [
+    #        (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),
+    #        (MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),
+    #        (MOI.SingleVariable,MOI.GreaterThan{Float64})
+    #    ]
+    #)
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+
+    MOI.addconstraints!(model,
+        [MOI.SingleVariable(x), MOI.SingleVariable(y)],
+        [MOI.GreaterThan(30.0), MOI.GreaterThan(0.0)]
+    )
+
+    MOI.addconstraints!(model,
+        [MOI.ScalarAffineFunction([x, y], [1.0, -1.5], 0.0)],
+        [MOI.GreaterThan(0.0)]
+    )
+
+    MOI.addconstraints!(model,
+        [
+            MOI.ScalarAffineFunction([x, y], [12.0, 8.0], 0.0),
+            MOI.ScalarAffineFunction([x, y], [1_000.0, 300.0], 0.0)
+        ],
+        [
+            MOI.LessThan(1_000.0),
+            MOI.LessThan(70_000.0)
+        ]
+    )
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                      MOI.ScalarAffineFunction([x, y], [1_000.0, 350.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 79e4/11 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 650/11 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 400/11 atol=atol rtol=rtol
+    end
+end
+
+# ranged constraints
+function linear10test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #   maximize x + y
+    #
+    #       s.t.  5 <= x + y <= 10
+    #                  x,  y >= 0
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64},
+    #    [
+    #        (MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64}),
+    #        (MOI.SingleVariable,MOI.GreaterThan{Float64})
+    #    ]
+    #)
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+
+    MOI.addconstraints!(model,
+        [MOI.SingleVariable(x), MOI.SingleVariable(y)],
+        [MOI.GreaterThan(0.0), MOI.GreaterThan(0.0)]
+    )
+
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
+    c = MOI.addconstraint!(model, MOI.ScalarAffineFunction([x,y], [1.0, 1.0], 0.0), MOI.Interval(5.0, 10.0))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
+        end
+    end
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+            @test MOI.canget(model, MOI.DualStatus())
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
+        end
+    end
+
+    @test MOI.canmodifyconstraint(model, c, MOI.Interval{Float64})
+    MOI.modifyconstraint!(model, c, MOI.Interval(2.0, 12.0))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+    end
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x, y], [1.0, 1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
+    end
+end
+
+# changing constraint sense
+function linear11test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # simple 2 variable, 1 constraint problem
+    # min x + y
+    # st   x + y >= 1
+    #      x + y >= 2
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64},
+    #    [
+    #        (MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),
+    #        (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64})
+    #    ]
+    #)
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 2)
+
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
+    c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0), MOI.GreaterThan(1.0))
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
+    c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0), MOI.GreaterThan(2.0))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+    end
+
+    @test MOI.cantransformconstraint(model, c2, MOI.LessThan{Float64})
+    c3 = MOI.transformconstraint!(model, c2, MOI.LessThan(2.0))
+
+    @test isa(c3, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}})
+    @test MOI.isvalid(model, c2) == false
+    @test MOI.isvalid(model, c3) == true
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol=atol rtol=rtol
+    end
+end
+
+# infeasible problem with 2 linear constraints
+function linear12test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # min x
+    # s.t. 2x-3y <= -7
+    #      y <= 2
+    # x,y >= 0
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64})])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    MOI.canaddvariable(model)
+    y = MOI.addvariable!(model)
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([x,y], [2.0,-3.0], 0.0), MOI.LessThan(-7.0))
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([y], [1.0], 0.0), MOI.LessThan(2.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    bndx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    bndy = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.ResultCount())
+        if config.infeas_certificates
+            # solver returned an infeasibility ray
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
+            cd1 = MOI.get(model, MOI.ConstraintDual(), c1)
+            cd2 = MOI.get(model, MOI.ConstraintDual(), c2)
+            bndxd = MOI.get(model, MOI.ConstraintDual(), bndx)
+            bndyd = MOI.get(model, MOI.ConstraintDual(), bndy)
+            @test cd1 < - atol
+            @test cd2 < - atol
+            @test - 3 * cd1 + cd2 ≈ -bndyd atol=atol rtol=rtol
+            @test 2 * cd1 ≈ -bndxd atol=atol rtol=rtol
+            @test -7 * cd1 + 2 * cd2 > atol
+        else
+            # solver returned nothing
+            @test MOI.get(model, MOI.ResultCount()) == 0
+            @test MOI.canget(model, MOI.PrimalStatus(1)) == false
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
+                MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        end
+    end
+end
+
+const contlineartests = Dict("linear1" => linear1test,
+                              "linear2" => linear2test,
+                              "linear3" => linear3test,
+                              "linear4" => linear4test,
+                              "linear5" => linear5test,
+                              "linear6" => linear6test,
+                              "linear7" => linear7test,
+                              "linear8a" => linear8atest,
+                              "linear8b" => linear8btest,
+                              "linear8c" => linear8ctest,
+                              "linear9" => linear9test,
+                              "linear10" => linear10test,
+                              "linear11" => linear11test,
+                              "linear12" => linear12test)
+
+@moitestset contlinear

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -1,0 +1,553 @@
+# Continuous quadratic problems
+
+function qp1test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    @testset "QP1 - Quadratic objective" begin
+        # simple quadratic objective
+        # Min x^2 + xy + y^2 + yz + z^2
+        # st  x + 2y + 3z >= 4 (c1)
+        #     x +  y      >= 1 (c2)
+        #     x,y \in R
+
+        #@test MOI.supportsproblem(model, MOI.ScalarQuadraticFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64})])
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        v = MOI.addvariables!(model, 3)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 3
+
+        cf1 = MOI.ScalarAffineFunction(v, [1.0,2.0,3.0], 0.0)
+        @test MOI.canaddconstraint(model, typeof(cf1), MOI.GreaterThan{Float64})
+        c1 = MOI.addconstraint!(model, cf1, MOI.GreaterThan(4.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
+
+        @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
+        c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([v[1],v[2]], [1.0,1.0], 0.0), MOI.GreaterThan(1.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
+
+        obj = MOI.ScalarQuadraticFunction(MOI.VariableIndex[], Float64[], v[[1,1,2,2,3]], v[[1,2,2,3,3]], [2.0, 1.0, 2.0, 1.0, 2.0], 0.0)
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+
+        if config.query
+            @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+            @test obj ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+
+            @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c1))
+            @test cf1 ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
+
+            @test MOI.canget(model, MOI.ConstraintSet(), typeof(c1))
+            @test MOI.GreaterThan(4.0) == MOI.get(model, MOI.ConstraintSet(), c1)
+        end
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        end
+    end
+end
+
+function qp2test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    @testset "QP2" begin
+        # same as QP0 but with duplicate terms
+        # then change the objective and sense
+        # simple quadratic objective
+        # Min x^2 + xy + y^2 + yz + z^2
+        # st  x + 2y + 3z >= 4 (c1)
+        #     x +  y      >= 1 (c2)
+        #     x,y \in R
+
+        #@test MOI.supportsproblem(model, MOI.ScalarQuadraticFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64})])
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        v = MOI.addvariables!(model, 3)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 3
+
+        c1f = MOI.ScalarAffineFunction(v, [1.0,2.0,3.0], 0.0)
+        @test MOI.canaddconstraint(model, typeof(c1f), MOI.GreaterThan{Float64})
+        c1 = MOI.addconstraint!(model, c1f, MOI.GreaterThan(4.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
+
+        @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
+        c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([v[1],v[2]], [1.0,1.0], 0.0), MOI.GreaterThan(1.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
+
+        obj = MOI.ScalarQuadraticFunction(v, [0.0,0.0,0.0],[v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]], [2.0, 0.5, 0.5, 2.0, 1.0, 1.0, 1.0], 0.0)
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+
+        if config.query
+            @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+            @test obj ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+
+            @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c1))
+            @test c1f ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
+
+            @test MOI.canget(model, MOI.ConstraintSet(), typeof(c1))
+            @test MOI.GreaterThan(4.0) == MOI.get(model, MOI.ConstraintSet(), c1)
+        end
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 130/70 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        end
+
+        # change objective to Max -2(x^2 + xy + y^2 + yz + z^2)
+        obj2 = MOI.ScalarQuadraticFunction(v, [0.0,0.0,0.0],[v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]], [-4.0, -1.0, -1.0, -4.0, -2.0, -2.0, -2.0], 0.0)
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj2)
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+
+        if config.query
+            @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+            @test obj2 ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+        end
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ -2*130/70 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0.5714285714285715,0.4285714285714285,0.8571428571428572] atol=atol rtol=rtol
+        end
+    end
+end
+
+function qp3test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    @testset "qp3test - Linear Quadratic objective" begin
+        # simple quadratic objective
+        #    minimize 2 x^2 + y^2 + xy + x + y + 1
+        #       s.t.  x, y >= 0
+        #             x + y = 1
+
+        #@test MOI.supportsproblem(model, MOI.ScalarQuadraticFunction{Float64},
+        #    [
+        #        (MOI.SingleVariable,MOI.GreaterThan{Float64}),
+        #        (MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64})
+        #    ]
+        #)
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        x = MOI.addvariable!(model)
+        MOI.canaddvariable(model)
+        y = MOI.addvariable!(model)
+
+        MOI.addconstraint!(model,
+            MOI.ScalarAffineFunction([x,y], [1.0,1.0], 0.0),
+            MOI.EqualTo(1.0)
+        )
+
+        @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+        MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+        @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+        MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+
+        obj = MOI.ScalarQuadraticFunction(
+                [x,y], [1.0,1.0],
+                [x,y,x], [x,y,y], [4.0, 2.0, 1.0],
+                1.0
+              )
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.875 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), [x,y]) ≈ [0.25, 0.75] atol=atol rtol=rtol
+        end
+
+        # change back to linear
+        #        max 2x + y + 1
+        #       s.t.  x, y >= 0
+        #             x + y = 1
+        # (x,y) = (1,0), obj = 3
+        objf = MOI.ScalarAffineFunction([x,y], [2.0,1.0], 1.0)
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), [x,y]) ≈ [1.0, 0.0] atol=atol rtol=rtol
+        end
+
+    end
+end
+
+
+function qptests(model::MOI.ModelLike; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    @testset "Quadratic Programs (quad. objective)" begin
+        qp1test(model, atol=atol, rtol=rtol)
+        qp2test(model, atol=atol, rtol=rtol)
+        qp3test(model, atol=atol, rtol=rtol)
+    end
+end
+
+#=
+    Quadratically constrained programs
+=#
+
+function qcp1test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    @testset "qcp1" begin
+        # quadratic constraint
+        # Max x + y
+        # st  - x + y >= 0 (c1[1])
+        #       x + y >= 0 (c1[2])
+        #     0.5x^2 + y <= 2 (c2)
+
+        #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorAffineFunction{Float64},MOI.Nonnegatives),(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        x = MOI.addvariable!(model)
+        MOI.canaddvariable(model)
+        y = MOI.addvariable!(model)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
+        c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction([1,1,2,2], [x,y,x,y], [-1.0,1.0,1.0,1.0], [0.0,0.0]), MOI.Nonnegatives(2))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}()) == 1
+
+        c2f = MOI.ScalarQuadraticFunction([y],[1.0],[x],[x],[1.0], 0.0)
+        @test MOI.canaddconstraint(model, typeof(c2f), MOI.LessThan{Float64})
+        c2 = MOI.addconstraint!(model, c2f, MOI.LessThan(2.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x,y], [1.0,1.0], 0.0))
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+
+        if config.query
+            @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c2))
+            @test c2f ≈ MOI.get(model, MOI.ConstraintFunction(), c2)
+        end
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.25 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), [x,y]) ≈ [0.5,1.75] atol=atol rtol=rtol
+        end
+
+        # try delete quadratic constraint and go back to linear
+
+        # MOI.delete!(model, c2)
+        #
+        # MOI.optimize!(model)
+        #
+        # @test MOI.canget(model, MOI.TerminationStatus())
+        # @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        #
+        # @test MOI.canget(model, MOI.PrimalStatus())
+        # @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        #
+        # @test MOI.canget(model, MOI.ObjectiveValue())
+        # @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+    end
+end
+
+
+function qcp2test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    @testset "qcp2" begin
+        # Max x
+        # s.t. x^2 <= 2 (c)
+
+        #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        x = MOI.addvariable!(model)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 1
+
+        cf = MOI.ScalarQuadraticFunction(MOI.VariableIndex[x],Float64[0.0],[x],[x],[1.0], 0.0)
+        @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
+        c = MOI.addconstraint!(model, cf, MOI.LessThan(2.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x], [1.0], 0.0))
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+
+        if config.query
+            @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
+            @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
+        end
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            if config.duals
+                @test MOI.canget(model, MOI.DualStatus())
+                @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            end
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
+
+            # TODO - duals
+            # @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            # @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 0.5/sqrt(2) atol=atol rtol=rtol
+        end
+    end
+end
+
+function qcp3test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    @testset "qcp3" begin
+        # Min -x
+        # s.t. x^2 <= 2
+
+        #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})])
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        x = MOI.addvariable!(model)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 1
+
+        cf = MOI.ScalarQuadraticFunction(MOI.VariableIndex[],Float64[],[x],[x],[1.0], 0.0)
+        @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
+        c = MOI.addconstraint!(model, cf, MOI.LessThan(2.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([x], [-1.0], 0.0))
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+
+        if config.query
+            @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
+            @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
+        end
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            if config.duals
+                @test MOI.canget(model, MOI.DualStatus())
+                @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            end
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ -sqrt(2) atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
+
+            # TODO - duals
+            # @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
+            # @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -0.5/sqrt(2) atol=atol rtol=rtol
+        end
+    end
+end
+
+function qcptests(model::MOI.ModelLike; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    @testset "Quadratic Constrainted Programs (quad. constraints only)" begin
+        qcp1test(model, atol=atol, rtol=rtol)
+        qcp2test(model, atol=atol, rtol=rtol)
+        qcp3test(model, atol=atol, rtol=rtol)
+    end
+end
+
+#=
+    SOCP
+=#
+
+function socp1test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    @testset "socp1" begin
+        # min t
+        # s.t. x + y >= 1 (c1)
+        #      x^2 + y^2 <= t^2 (c2)
+        #      t >= 0 (bound)
+
+        #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64}), (MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}), (MOI.SingleVariable,MOI.GreaterThan{Float64})])
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        x = MOI.addvariable!(model)
+        MOI.canaddvariable(model)
+        y = MOI.addvariable!(model)
+        MOI.canaddvariable(model)
+        t = MOI.addvariable!(model)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 3
+
+        c1f = MOI.ScalarAffineFunction([x,y],[1.0, 1.0], 0.0)
+        @test MOI.canaddconstraint(model, typeof(c1f), MOI.GreaterThan{Float64})
+        c1 = MOI.addconstraint!(model, c1f, MOI.GreaterThan(1.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
+
+        c2f = MOI.ScalarQuadraticFunction(MOI.VariableIndex[],Float64[],[x,y,t],[x,y,t],[1.0,1.0,-1.0], 0.0)
+        @test MOI.canaddconstraint(model, typeof(c2f), MOI.LessThan{Float64})
+        c2 = MOI.addconstraint!(model, c2f, MOI.LessThan(0.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+
+        @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+        bound = MOI.addconstraint!(model, MOI.SingleVariable(t), MOI.GreaterThan(0.0))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable, MOI.GreaterThan{Float64}}()) == 1
+
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([t], [1.0], 0.0))
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+
+        if config.query
+            @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c1))
+            @test c1f ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
+
+            @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c2))
+            @test c2f ≈ MOI.get(model, MOI.ConstraintFunction(), c2)
+        end
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ sqrt(1/2) atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), [x,y,t]) ≈ [0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), [t,x,y,t]) ≈ [sqrt(1/2),0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
+        end
+    end
+end
+
+function socptests(model::MOI.ModelLike; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    @testset "Second Order Cone Programs" begin
+        socp1test(model, atol=atol, rtol=rtol)
+    end
+end
+
+const contquadratictests = Dict("quadratic1" => qp1test,
+                                "quadratic2" => qp2test,
+                                "quadratic3" => qp3test,
+                                "quadratic4" => qcp1test,
+                                "quadratic5" => qcp2test,
+                                "quadratic6" => qcp3test,
+                                "quadratic7" => socp1test)
+
+@moitestset contquadratic

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -1,0 +1,71 @@
+# Integer conic problems
+
+function intsoc1test(model::MOI.ModelLike; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64},
+    #    [(MOI.VectorAffineFunction{Float64},MOI.Zeros),
+    #     (MOI.SingleVariable,MOI.ZeroOne),
+    #     (MOI.VectorOfVariables,MOI.SecondOrderCone)])
+    @testset "INTSOC1" begin
+
+        # Problem SINTSOC1
+        # min 0x - 2y - 1z
+        #  st  x            == 1
+        #      x >= ||(y,z)||
+        #      (y,z) binary
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        x,y,z = MOI.addvariables!(model, 3)
+
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([y,z],[-2.0,-1.0],0.0))
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+        ceq = MOI.addconstraint!(model, MOI.VectorAffineFunction([1],[x],[1.0],[-1.0]), MOI.Zeros(1))
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
+        csoc = MOI.addconstraint!(model, MOI.VectorOfVariables([x,y,z]), MOI.SecondOrderCone(3))
+
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
+        loc = MOI.get(model, MOI.ListOfConstraints())
+        @test length(loc) == 2
+        @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
+        @test (MOI.VectorOfVariables,MOI.SecondOrderCone) in loc
+
+        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(y)), typeof(MOI.ZeroOne))
+        bin1 = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.ZeroOne)
+        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(z)), typeof(MOI.ZeroOne))
+        bin2 = MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.ZeroOne)
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ -2 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 0 atol=atol rtol=rtol
+        end
+
+    end
+end
+
+function intsoctests(model::MOI.ModelLike; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    intsoc1test(model, atol=atol, rtol=rtol)
+end
+
+function intconictests(model::MOI.ModelLike; atol=Base.rtoldefault(Float64), rtol=Base.rtoldefault(Float64))
+    intsoctests(model, atol=atol, rtol=rtol)
+end

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -1,0 +1,446 @@
+# MIP01 from CPLEX.jl
+function int1test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # an example on mixed integer programming
+    #
+    #   maximize 1.1x + 2 y + 5 z
+    #
+    #   s.t.  x + y + z <= 10
+    #         x + 2 y + z <= 15
+    #
+    #         x is continuous: 0 <= x <= 5
+    #         y is integer: 0 <= y <= 10
+    #         z is binary
+
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}),(MOI.SingleVariable,MOI.GreaterThan{Float64}), (MOI.SingleVariable, MOI.ZeroOne), (MOI.SingleVariable, MOI.Integer)])
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 3)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 3
+
+    cf = MOI.ScalarAffineFunction(v, [1.0,1.0,1.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
+    c = MOI.addconstraint!(model, cf, MOI.LessThan(10.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+
+    cf2 = MOI.ScalarAffineFunction(v, [1.0,2.0,1.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf2), MOI.LessThan{Float64})
+    c2 = MOI.addconstraint!(model, cf2, MOI.LessThan(15.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
+
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Interval{Float64})
+    MOI.addconstraint!(model, MOI.SingleVariable(v[1]), MOI.Interval(0.0, 5.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}()) == 1
+
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Interval{Float64})
+    MOI.addconstraint!(model, MOI.SingleVariable(v[2]), MOI.Interval(0.0, 10.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}()) == 2
+    @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[2])), MOI.Integer)
+    MOI.addconstraint!(model, MOI.SingleVariable(v[2]), MOI.Integer())
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Integer}()) == 1
+
+    @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[3])), MOI.ZeroOne)
+    MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.ZeroOne())
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 1
+
+    objf = MOI.ScalarAffineFunction(v, [1.1, 2.0, 5.0], 0.0)
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 19.4 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4,5,1] atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
+        @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 15 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.DualStatus()) == false
+
+        if MOI.canget(model, MOI.ObjectiveBound())
+            @test MOI.get(model, MOI.ObjectiveBound()) >= 19.4
+        end
+        if MOI.canget(model, MOI.RelativeGap())
+            @test MOI.get(model, MOI.RelativeGap()) >= 0.0
+        end
+        if MOI.canget(model, MOI.SolveTime())
+            @test MOI.get(model, MOI.SolveTime()) >= 0.0
+        end
+        if MOI.canget(model, MOI.SimplexIterations())
+            @test MOI.get(model, MOI.SimplexIterations()) >= 0
+        end
+        if MOI.canget(model, MOI.BarrierIterations())
+            @test MOI.get(model, MOI.BarrierIterations()) >= 0
+        end
+        if MOI.canget(model, MOI.NodeCount())
+            @test MOI.get(model, MOI.NodeCount()) >= 0
+        end
+    end
+end
+
+Base.isapprox(a::T, b::T; kwargs...) where T <: Union{MOI.SOS1, MOI.SOS2} = isapprox(a.weights, b.weights; kwargs...)
+
+# sos from CPLEX.jl" begin
+function int2test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [ (MOI.VectorOfVariables, MOI.SOS1),
+    #                                                                    (MOI.VectorOfVariables, MOI.SOS2) ])
+    @testset "SOSI" begin
+        #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.VectorOfVariables,MOI.SOS1), (MOI.SingleVariable,MOI.LessThan{Float64})])
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        v = MOI.addvariables!(model, 3)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 3
+        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[1])), MOI.LessThan{Float64})
+        MOI.addconstraint!(model, MOI.SingleVariable(v[1]), MOI.LessThan(1.0))
+        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[2])), MOI.LessThan{Float64})
+        MOI.addconstraint!(model, MOI.SingleVariable(v[2]), MOI.LessThan(1.0))
+        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[3])), MOI.LessThan{Float64})
+        MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.LessThan(2.0))
+
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
+        c1 = MOI.addconstraint!(model, MOI.VectorOfVariables([v[1], v[2]]), MOI.SOS1([1.0, 2.0]))
+        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
+        c2 = MOI.addconstraint!(model, MOI.VectorOfVariables([v[1], v[3]]), MOI.SOS1([1.0, 2.0]))
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SOS1}()) == 2
+
+
+        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c2))
+        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c2))
+        #=
+            To allow for permutations in the sets and variable vectors
+            we're going to sort according to the weights
+        =#
+        cs_sos = MOI.get(model, MOI.ConstraintSet(), c2)
+        cf_sos = MOI.get(model, MOI.ConstraintFunction(), c2)
+        p = sortperm(cs_sos.weights)
+        @test cs_sos.weights[p] ≈ [1.0, 2.0] atol=atol rtol=rtol
+        @test cf_sos.variables[p] == v[[1,3]]
+
+        objf = MOI.ScalarAffineFunction(v, [2.0, 1.0, 1.0], 0.0)
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.ResultCount())
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,1,2] atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.DualStatus()) == false
+        end
+
+        @test MOI.candelete(model, c1)
+        MOI.delete!(model, c1)
+        @test MOI.candelete(model, c2)
+        MOI.delete!(model, c2)
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.ResultCount())
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1,1,2] atol=atol rtol=rtol
+        end
+    end
+    @testset "SOSII" begin
+        #@test MOI.supportsproblem(model,
+        #    MOI.ScalarAffineFunction{Float64},
+        #    [
+        #        (MOI.VectorOfVariables,MOI.SOS1),
+        #        (MOI.VectorOfVariables,MOI.SOS2),
+        #        (MOI.SingleVariable, MOI.ZeroOne),
+        #        (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+        #        ]
+        #)
+
+        MOI.empty!(model)
+        @test MOI.isempty(model)
+
+        MOI.canaddvariable(model)
+        v = MOI.addvariables!(model, 10)
+        @test MOI.get(model, MOI.NumberOfVariables()) == 10
+
+        bin_constraints = []
+        for i in 1:8
+            @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Interval{Float64})
+            MOI.addconstraint!(model, MOI.SingleVariable(v[i]), MOI.Interval(0.0, 2.0))
+            @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[i])), MOI.ZeroOne)
+            push!(bin_constraints, MOI.addconstraint!(model, MOI.SingleVariable(v[i]), MOI.ZeroOne()))
+        end
+
+        MOI.addconstraint!(model,
+            MOI.ScalarAffineFunction(v[[1,2,3,9]], [1.0,2.0,3.0,-1.0], 0.0),
+            MOI.EqualTo(0.0)
+        )
+
+        MOI.addconstraint!(model,
+            MOI.ScalarAffineFunction(v[[4,5,6,7,8,10]], [5.0,4.0,7.0,2.0,1.0,-1.0], 0.0),
+            MOI.EqualTo(0.0)
+        )
+
+        MOI.addconstraint!(model,
+            MOI.VectorOfVariables(v[[1, 2, 3]]),
+            MOI.SOS1([1.0, 2.0, 3.0])
+        )
+
+        vv   = MOI.VectorOfVariables(v[[4,5,6,7,8]])
+        sos2 = MOI.SOS2([5.0, 4.0, 7.0, 2.0, 1.0])
+        @test MOI.canaddconstraint(model, typeof(vv), MOI.SOS2{Float64})
+        c = MOI.addconstraint!(model, vv, sos2)
+
+        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
+        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
+        #=
+            To allow for permutations in the sets and variable vectors
+            we're going to sort according to the weights
+        =#
+        cs_sos = MOI.get(model, MOI.ConstraintSet(), c)
+        cf_sos = MOI.get(model, MOI.ConstraintFunction(), c)
+        p = sortperm(cs_sos.weights)
+        @test cs_sos.weights[p] ≈ [1.0, 2.0, 4.0, 5.0, 7.0] atol=atol rtol=rtol
+        @test cf_sos.variables[p] == v[[8,7,5,4,6]]
+
+        objf = MOI.ScalarAffineFunction([v[9], v[10]], [1.0, 1.0], 0.0)
+        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+        @test MOI.canset(model, MOI.ObjectiveSense())
+        MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.ResultCount())
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 15.0 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 3.0, 12.0] atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.DualStatus()) == false
+        end
+
+        for cref in bin_constraints
+            @test MOI.candelete(model, cref)
+            MOI.delete!(model, cref)
+        end
+
+        if config.solve
+            MOI.optimize!(model)
+
+            @test MOI.canget(model, MOI.TerminationStatus())
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+            @test MOI.canget(model, MOI.ResultCount())
+            @test MOI.get(model, MOI.ResultCount()) >= 1
+
+            @test MOI.canget(model, MOI.PrimalStatus())
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+            @test MOI.canget(model, MOI.ObjectiveValue())
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 30.0 atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 2.0, 2.0, 0.0, 2.0, 0.0, 0.0, 6.0, 24.0] atol=atol rtol=rtol
+
+            @test MOI.canget(model, MOI.DualStatus()) == false
+        end
+    end
+end
+
+# CPLEX #76
+function int3test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # integer knapsack problem
+    # max   z - 0.5 ( b1 + b2 + b3) / 40
+    # s.t.  0 <= z - 0.5 eᵀ b / 40 <= 0.999
+    #       b1, b2, ... b10 ∈ {0, 1}
+    #       z in {0, 1, 2, ..., 100}
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64},
+    #    [
+    #        (MOI.SingleVariable,MOI.ZeroOne),
+    #        (MOI.SingleVariable,MOI.Integer),
+    #        (MOI.SingleVariable,MOI.Interval{Float64}),
+    #        (MOI.ScalarAffineFunction{Float64},MOI.Interval{Float64})
+    #    ]
+    #)
+
+    MOI.canaddvariable(model)
+    z = MOI.addvariable!(model)
+    @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(z)), MOI.Integer)
+    MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.Integer())
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Integer)
+    MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.Interval(0.0, 100.0))
+
+    MOI.canaddvariable(model)
+    b = MOI.addvariables!(model, 10)
+
+    for bi in b
+        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(bi)), MOI.ZeroOne)
+        MOI.addconstraint!(model, MOI.SingleVariable(bi), MOI.ZeroOne())
+    end
+
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
+    c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(vcat(z, b), vcat(1.0, fill(-0.5 / 40, 10)), 0.0), MOI.Interval(0.0, 0.999))
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(vcat(z, b[1:3]), vcat(1.0, fill(-0.5 / 40, 3)), 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+
+        # test for CPLEX.jl #76
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+    end
+end
+
+
+# Mixed-integer linear problems
+
+function knapsacktest(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # integer knapsack problem
+    # max 5a + 3b + 2c + 7d + 4e
+    # st  2a + 8b + 4c + 2d + 5e <= 10
+    #                  a,b,c,d,e ∈ binary
+
+    MOI.empty!(model)
+    @test MOI.isempty(model)
+
+    #@test MOI.supportsproblem(model, MOI.ScalarAffineFunction{Float64}, [(MOI.SingleVariable,MOI.ZeroOne),(MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64})])
+
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 5)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 5
+
+    for vi in v
+        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(vi)), MOI.ZeroOne)
+        MOI.addconstraint!(model, MOI.SingleVariable(vi), MOI.ZeroOne())
+    end
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 5
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(v, [2.0, 8.0, 4.0, 2.0, 5.0], 0.0), MOI.LessThan(10.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+
+    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(v, [5.0, 3.0, 2.0, 7.0, 4.0], 0.0))
+    @test MOI.canset(model, MOI.ObjectiveSense())
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
+
+    if MOI.canset(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
+        MOI.set!(model, MOI.VariablePrimalStart(), v, [0.0, 0.0, 0.0, 0.0, 0.0])
+    end
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.canget(model, MOI.TerminationStatus())
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
+        @test MOI.canget(model, MOI.PrimalStatus())
+        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
+
+        @test MOI.canget(model, MOI.ObjectiveValue())
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 16 atol=atol rtol=rtol
+
+        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0, 0, 1, 1] atol=atol rtol=rtol
+    end
+end
+
+const intlineartests = Dict("knapsack" => knapsacktest,
+                            "int1"     => int1test,
+                            "int2"     => int2test,
+                            "int3"     => int3test)
+
+@moitestset intlinear

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -1,0 +1,237 @@
+# TODO: Move generic model tests from MOIU to here
+
+struct UnknownSet <: MOI.AbstractSet end
+
+function nametest(model::MOI.ModelLike)
+    @testset "Name test" begin
+        @test MOI.get(model, MOI.NumberOfVariables()) == 0
+        @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
+
+        MOI.canaddvariable(model)
+        v = MOI.addvariables!(model, 2)
+        @test MOI.canget(model, MOI.VariableName(), typeof(v[1]))
+        @test MOI.get(model, MOI.VariableName(), v[1]) == ""
+
+        @test MOI.canset(model, MOI.VariableName(), typeof(v[1]))
+        MOI.set!(model, MOI.VariableName(), v[1], "")
+        MOI.set!(model, MOI.VariableName(), v[2], "") # Shouldn't error with duplicate empty name
+
+        MOI.set!(model, MOI.VariableName(), v[1], "Var1")
+        @test_throws Exception MOI.set!(model, MOI.VariableName(), v[2], "Var1")
+        MOI.set!(model, MOI.VariableName(), v[2], "Var2")
+
+        @test MOI.canget(model, MOI.VariableIndex, "Var1")
+        @test !MOI.canget(model, MOI.VariableIndex, "Var3")
+
+        @test MOI.get(model, MOI.VariableIndex, "Var1") == v[1]
+        @test MOI.get(model, MOI.VariableIndex, "Var2") == v[2]
+        @test_throws KeyError MOI.get(model, MOI.VariableIndex, "Var3")
+
+        MOI.set!(model, MOI.VariableName(), v, ["VarX","Var2"])
+        @test MOI.get(model, MOI.VariableName(), v) == ["VarX", "Var2"]
+
+        if MOI.candelete(model, v[2])
+            MOI.delete!(model, v[2])
+            @test !MOI.canget(model, MOI.VariableIndex, "Var2")
+            @test_throws KeyError MOI.get(model, MOI.VariableIndex, "Var2")
+        end
+
+        @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+        c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0), MOI.LessThan(1.0))
+        @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
+        c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(v, [-1.0,1.0], 0.0), MOI.EqualTo(0.0))
+        @test MOI.canget(model, MOI.ConstraintName(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintName(), c) == ""
+
+        @test MOI.canset(model, MOI.ConstraintName(), typeof(c))
+        MOI.set!(model, MOI.ConstraintName(), c, "")
+        MOI.set!(model, MOI.ConstraintName(), c2, "") # Shouldn't error with duplicate empty name
+
+        MOI.set!(model, MOI.ConstraintName(), c, "Con0")
+        @test MOI.get(model, MOI.ConstraintName(), c) == "Con0"
+        @test_throws Exception MOI.set!(model, MOI.ConstraintName(), c2, "Con0")
+
+        MOI.set!(model, MOI.ConstraintName(), [c], ["Con1"])
+        @test MOI.get(model, MOI.ConstraintName(), [c]) == ["Con1"]
+
+
+        @test MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
+        @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con2")
+        @test MOI.canget(model, MOI.ConstraintIndex, "Con1")
+        @test !MOI.canget(model, MOI.ConstraintIndex, "Con2")
+
+        @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1") == c
+        @test_throws KeyError MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con2")
+        @test MOI.get(model, MOI.ConstraintIndex, "Con1") == c
+        @test_throws KeyError MOI.get(model, MOI.ConstraintIndex, "Con2")
+
+        if MOI.candelete(model, c)
+            MOI.delete!(model, c)
+            @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
+            @test !MOI.canget(model, MOI.ConstraintIndex, "Con1")
+            @test_throws KeyError MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
+            @test_throws KeyError MOI.get(model, MOI.ConstraintIndex, "Con1")
+        end
+    end
+end
+
+# Taken from https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/41
+function validtest(model::MOI.ModelLike)
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 2)
+    @test MOI.isvalid(model, v[1])
+    @test MOI.isvalid(model, v[2])
+    MOI.canaddvariable(model)
+    x = MOI.addvariable!(model)
+    @test MOI.isvalid(model, x)
+    MOI.delete!(model, x)
+    @test !MOI.isvalid(model, x)
+    cf = MOI.ScalarAffineFunction(v, [1.0,1.0], 0.0)
+    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
+    c = MOI.addconstraint!(model, cf, MOI.LessThan(1.0))
+    @test MOI.isvalid(model, c)
+    @test !MOI.isvalid(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float32},MOI.LessThan{Float32}}(1))
+    @test !MOI.isvalid(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float32},MOI.LessThan{Float64}}(1))
+    @test !MOI.isvalid(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float32}}(1))
+    @test !MOI.isvalid(model, MOI.ConstraintIndex{MOI.VectorQuadraticFunction{Float64},MOI.SecondOrderCone}(1))
+end
+
+function emptytest(model::MOI.ModelLike)
+    # Taken from LIN1
+    MOI.canaddvariable(model)
+    v = MOI.addvariables!(model, 3)
+    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
+    vc = MOI.addconstraint!(model, MOI.VectorOfVariables(v), MOI.Nonnegatives(3))
+    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    c = MOI.addconstraint!(model, MOI.VectorAffineFunction([1,1,1,2,2], [v;v[2];v[3]], ones(5), [-3.0,-2.0]), MOI.Zeros(2))
+    MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+
+    @test !MOI.isempty(model)
+
+    MOI.empty!(model)
+
+    @test MOI.isempty(model)
+
+    @test MOI.get(model, MOI.NumberOfVariables()) == 0
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 0
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 0
+    @test isempty(MOI.get(model, MOI.ListOfConstraints()))
+
+    @test !MOI.isvalid(model, v[1])
+    @test !MOI.isvalid(model, vc)
+    @test !MOI.isvalid(model, c)
+end
+
+abstract type BadModel <: MOI.ModelLike end
+MOI.get(src::BadModel, ::MOI.ListOfModelAttributesSet) = MOI.AbstractModelAttribute[]
+MOI.get(src::BadModel, ::MOI.NumberOfVariables) = 1
+MOI.get(src::BadModel, ::MOI.ListOfVariableIndices) = [MOI.VariableIndex(1)]
+MOI.get(src::BadModel, ::MOI.ListOfVariableAttributesSet) = MOI.AbstractVariableAttribute[]
+MOI.get(src::BadModel, ::MOI.ListOfConstraints) = [(MOI.SingleVariable, MOI.EqualTo{Float64})]
+MOI.get(src::BadModel, ::MOI.ListOfConstraintIndices{F,S}) where {F,S} = [MOI.ConstraintIndex{F,S}(1)]
+MOI.get(src::BadModel, ::MOI.ConstraintFunction, ::MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Float64}}) = MOI.SingleVariable(MOI.VariableIndex(1))
+MOI.get(src::BadModel, ::MOI.ConstraintSet, ::MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Float64}}) = MOI.EqualTo(0.0)
+MOI.get(src::BadModel, ::MOI.ListOfConstraintAttributesSet) = MOI.AbstractConstraintAttribute[]
+
+struct BadConstraintModel <: BadModel end
+MOI.get(src::BadConstraintModel, ::MOI.ListOfConstraints) = [(MOI.SingleVariable, MOI.EqualTo{Float64}), (MOI.SingleVariable, UnknownSet)]
+MOI.get(src::BadModel, ::MOI.ConstraintFunction, ::MOI.ConstraintIndex{MOI.SingleVariable,UnknownSet}) = MOI.SingleVariable(MOI.VariableIndex(1))
+MOI.get(src::BadModel, ::MOI.ConstraintSet, ::MOI.ConstraintIndex{MOI.SingleVariable,UnknownSet}) = UnknownSet()
+
+struct BadModelAttribute <: MOI.AbstractModelAttribute end
+struct BadModelAttributeModel <: BadModel end
+MOI.canget(src::BadModelAttributeModel, ::BadModelAttribute) = true
+MOI.get(src::BadModelAttributeModel, ::BadModelAttribute) = 0
+MOI.get(src::BadModelAttributeModel, ::MOI.ListOfModelAttributesSet) = MOI.AbstractModelAttribute[BadModelAttribute()]
+
+struct BadVariableAttribute <: MOI.AbstractVariableAttribute end
+struct BadVariableAttributeModel <: BadModel end
+MOI.canget(src::BadVariableAttributeModel, ::BadVariableAttribute, ::Type{MOI.VariableIndex}) = true
+MOI.get(src::BadVariableAttributeModel, ::BadVariableAttribute, ::Vector{MOI.VariableIndex}) = [0]
+MOI.get(src::BadVariableAttributeModel, ::MOI.ListOfVariableAttributesSet) = MOI.AbstractVariableAttribute[BadVariableAttribute()]
+
+struct BadConstraintAttribute <: MOI.AbstractConstraintAttribute end
+struct BadConstraintAttributeModel <: BadModel end
+MOI.canget(src::BadConstraintAttributeModel, ::BadConstraintAttribute, ::Type{<:MOI.ConstraintIndex}) = true
+MOI.get(src::BadConstraintAttributeModel, ::BadConstraintAttribute, ::Vector{<:MOI.ConstraintIndex}) = [0]
+MOI.get(src::BadConstraintAttributeModel, ::MOI.ListOfConstraintAttributesSet) = MOI.AbstractConstraintAttribute[BadConstraintAttribute()]
+
+function failcopytest(dest::MOI.ModelLike, src::MOI.ModelLike, expected_status)
+    copyresult = MOI.copy!(dest, src)
+    @test copyresult.status == expected_status
+end
+
+failcopytestc(dest::MOI.ModelLike) = failcopytest(dest, BadConstraintModel(), MOI.CopyUnsupportedConstraint)
+failcopytestia(dest::MOI.ModelLike) = failcopytest(dest, BadModelAttributeModel(), MOI.CopyUnsupportedAttribute)
+failcopytestva(dest::MOI.ModelLike) = failcopytest(dest, BadVariableAttributeModel(), MOI.CopyUnsupportedAttribute)
+failcopytestca(dest::MOI.ModelLike) = failcopytest(dest, BadConstraintAttributeModel(), MOI.CopyUnsupportedAttribute)
+
+function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
+    MOI.canaddvariable(src)
+    v = MOI.addvariables!(src, 3)
+    csv = MOI.addconstraint!(src, MOI.SingleVariable(v[2]), MOI.EqualTo(2.))
+    cvv = MOI.addconstraint!(src, MOI.VectorOfVariables(v), MOI.Nonnegatives(3))
+    csa = MOI.addconstraint!(src, MOI.ScalarAffineFunction([v[3], v[1]], [1., 3.], 2.), MOI.LessThan(2.))
+    cva = MOI.addconstraint!(src, MOI.VectorAffineFunction([1, 2], [v[3], v[2]], ones(2), [-3.0,-2.0]), MOI.Zeros(2))
+    MOI.set!(src, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(v, [-3.0, -2.0, -4.0], 0.0))
+    MOI.set!(src, MOI.ObjectiveSense(), MOI.MinSense)
+
+    copyresult = MOI.copy!(dest, src)
+    @test copyresult.status == MOI.CopySuccess
+    dict = copyresult.indexmap
+
+    @test MOI.get(dest, MOI.NumberOfVariables()) == 3
+    @test MOI.get(dest, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 1
+    @test MOI.get(dest, MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == [dict[csv]]
+    @test MOI.get(dest, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
+    @test MOI.get(dest, MOI.ListOfConstraintIndices{MOI.VectorOfVariables,MOI.Nonnegatives}()) == [dict[cvv]]
+    @test MOI.get(dest, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+    @test MOI.get(dest, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == [dict[csa]]
+    @test MOI.get(dest, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
+    @test MOI.get(dest, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == [dict[cva]]
+    loc = MOI.get(dest, MOI.ListOfConstraints())
+    @test length(loc) == 4
+    @test (MOI.SingleVariable,MOI.EqualTo{Float64}) in loc
+    @test (MOI.VectorOfVariables,MOI.Nonnegatives) in loc
+    @test (MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}) in loc
+    @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
+
+    @test MOI.canget(dest, MOI.ConstraintFunction(), typeof(dict[csv]))
+    @test MOI.get(dest, MOI.ConstraintFunction(), dict[csv]) == MOI.SingleVariable(dict[v[2]])
+    @test MOI.canget(dest, MOI.ConstraintSet(), typeof(dict[csv]))
+    @test MOI.get(dest, MOI.ConstraintSet(), dict[csv]) == MOI.EqualTo(2.)
+    @test MOI.canget(dest, MOI.ConstraintFunction(), typeof(dict[cvv]))
+    @test MOI.get(dest, MOI.ConstraintFunction(), dict[cvv]) == MOI.VectorOfVariables(getindex.(dict, v))
+    @test MOI.canget(dest, MOI.ConstraintSet(), typeof(dict[cvv]))
+    @test MOI.get(dest, MOI.ConstraintSet(), dict[cvv]) == MOI.Nonnegatives(3)
+    @test MOI.canget(dest, MOI.ConstraintFunction(), typeof(dict[csa]))
+    @test MOI.get(dest, MOI.ConstraintFunction(), dict[csa]) ≈ MOI.ScalarAffineFunction([dict[v[3]], dict[v[1]]], [1., 3.], 2.)
+    @test MOI.canget(dest, MOI.ConstraintSet(), typeof(dict[csa]))
+    @test MOI.get(dest, MOI.ConstraintSet(), dict[csa]) == MOI.LessThan(2.)
+    @test MOI.canget(dest, MOI.ConstraintFunction(), typeof(dict[cva]))
+    @test MOI.get(dest, MOI.ConstraintFunction(), dict[cva]) ≈ MOI.VectorAffineFunction([1, 2], [dict[v[3]], dict[v[2]]], ones(2), [-3.0,-2.0])
+    @test MOI.canget(dest, MOI.ConstraintSet(), typeof(dict[cva]))
+    @test MOI.get(dest, MOI.ConstraintSet(), dict[cva]) == MOI.Zeros(2)
+
+    @test MOI.canget(dest, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.get(dest, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()) ≈ MOI.ScalarAffineFunction([dict[v[1]], dict[v[2]], dict[v[3]]], [-3.0, -2.0, -4.0], 0.0)
+    @test MOI.canget(dest, MOI.ObjectiveSense())
+    @test MOI.get(dest, MOI.ObjectiveSense()) == MOI.MinSense
+end
+
+function canaddconstrainttest(model::MOI.ModelLike, ::Type{GoodT}, ::Type{BadT}) where {GoodT, BadT}
+    MOI.canaddvariable(model)
+    v = MOI.addvariable!(model)
+    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{GoodT})
+    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{GoodT}, MOI.EqualTo{GoodT})
+    # Bad type
+    @test !MOI.canaddconstraint(model, MOI.ScalarAffineFunction{BadT}, MOI.EqualTo{GoodT})
+    @test !MOI.canaddconstraint(model, MOI.ScalarAffineFunction{BadT}, MOI.EqualTo{BadT})
+    @test !MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{BadT})
+
+    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Zeros)
+    @test !MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.EqualTo{GoodT}) # vector in scalar
+    @test !MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Zeros) # scalar in vector
+    @test !MOI.canaddconstraint(model, MOI.VectorOfVariables, UnknownSet) # set not supported
+end


### PR DESCRIPTION
See https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/89

I run a few benchmarks with Julia v0.6.2, ses the results below.

Currently, we have
```julia
julia> @time using MathOptInterface
  0.458081 seconds (431.28 k allocations: 22.743 MiB, 1.22% gc time)

julia> @time using MathOptInterfaceTests
  1.685874 seconds (600.04 k allocations: 34.764 MiB, 0.50% gc time)
```
The long time for MOIT is due to the fact that it is not precompiled. If we add `__precompile__()` in `MathOptInterfaceTests.jl`, we get
```julia
julia> @time using MathOptInterface
  0.452718 seconds (431.28 k allocations: 22.739 MiB, 1.25% gc time)

julia> @time using MathOptInterfaceTests
  0.003029 seconds (3.56 k allocations: 889.141 KiB)
```
With this PR, we have
```julia
julia> @time using MathOptInterface
  0.456814 seconds (434.57 k allocations: 23.591 MiB, 1.22% gc time)
```
This shows that once it is precompiled, the increased loading time of this PR is negligible. I don't really know why MOIT so much lighter than MOI in terms of loading time, If someone has an idea, I'd be interested :-P