### PR TITLE
Add support for ConstraintPrimal for MockOptimizer

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1,5 +1,22 @@
 using Base.Test
 
+"""
+    evalvariables(varval::Function, f::AbstractFunction)
+
+Returns the value of function `f` if each variable index `vi` is evaluate as `varval(vi)`.
+"""
+function evalvariables end
+evalvariables(varval::Function, f::MOI.SingleVariable) = varval(f.variable)
+evalvariables(varval::Function, f::MOI.VectorOfVariables) = varval.(f.variables)
+evalvariables(varval::Function, f::MOI.ScalarAffineFunction) = dot(varval.(f.variables), f.coefficients) + f.constant
+function evalvariables(varval::Function, f::MOI.VectorAffineFunction)
+    out = f.constant
+    for i in eachindex(f.variables)
+        out[f.outputindex[i]] += varval(f.variables[i]) * f.coefficients[i]
+    end
+    out
+end
+
 mapvariables(varmap::Function, f::MOI.SingleVariable) = MOI.SingleVariable(varmap(f.variable))
 mapvariables(varmap::Function, f::MOI.VectorOfVariables) = MOI.VectorOfVariables(varmap.(f.variables))
 mapvariables(varmap::Function, f::MOI.ScalarAffineFunction) = MOI.ScalarAffineFunction(varmap.(f.variables), f.coefficients, f.constant)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -123,7 +123,11 @@ function MOI.isvalid(model::AbstractModel, ci::CI{F, S}) where {F, S}
 end
 MOI.isvalid(model::AbstractModel, vi::VI) = in(vi, model.varindices)
 
-MOI.get(model::AbstractModel, ::MOI.ListOfVariableIndices) = collect(model.varindices)
+function MOI.get(model::AbstractModel, ::MOI.ListOfVariableIndices)
+    vis = collect(model.varindices)
+    sort!(vis, by=vi->vi.value) # It needs to be sorted by order of creation
+    vis
+end
 
 # Names
 MOI.canset(model::AbstractModel, ::MOI.VariableName, vi::Type{VI}) = true

--- a/test/mockoptimizer.jl
+++ b/test/mockoptimizer.jl
@@ -1,7 +1,25 @@
+# Sets variable primal to varprim
+function mock_optimize!(optimizer::MOIU.MockOptimizer, varprim::Vector)
+    MOI.set!(optimizer, MOI.TerminationStatus(), MOI.Success)
+    MOI.set!(optimizer, MOI.ResultCount(), 1)
+    MOI.set!(optimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
+    MOI.set!(optimizer, MOI.VariablePrimal(), MOI.get(optimizer, MOI.ListOfVariableIndices()), varprim)
+end
+
 @testset "Mock optimizer continuous linear tests" begin
     optimizer = MOIU.MockOptimizer(ModelForMock{Float64}())
     config = MOIT.TestConfig(solve=false)
     MOIT.contlineartest(optimizer, config)
+end
+
+# This both tests the ConstraintPrimal value requested in the tests and the ConstraintPrimal implemented in MockOptimizer
+@testset "Mock optimizer automatic constraint primal" begin
+    optimizer = MOIU.MockOptimizer(ModelForMock{Float64}())
+    config = MOIT.TestConfig(duals=false)
+    optimizer.evalobjective = true
+    optimizer.optimize! = (optimizer::MOIU.MockOptimizer) -> mock_optimize!(optimizer, [1.0, 0.0, 2.0])
+    MOIT.lin1vtest(optimizer, config)
+    MOIT.lin1ftest(optimizer, config)
 end
 
 @testset "Mock optimizer optimizer attributes" begin

--- a/test/model.jl
+++ b/test/model.jl
@@ -17,14 +17,14 @@ end
     MOIT.canaddconstrainttest(Model{Int}(), Int, Float64)
 end
 
-# Only config.query is true as MOI.optimize! is not implemented
-const config = MOIT.TestConfig(solve=false)
 
 @testset "Continuous Linear tests" begin
+    config = MOIT.TestConfig(solve=false)
     MOIT.contlineartest(Model{Float64}(), config)
 end
 
 @testset "Continuous Conic tests" begin
+    config = MOIT.TestConfig(solve=false)
     MOIT.contconictest(Model{Float64}(), config)
 end
 


### PR DESCRIPTION
Adds support for automatically computing ConstraintPrimal and ObjectiveFunction based on the variable primal values. This is tested with a test of MOIT hence it also checks that ConstraintPrimal and ObjectiveFunction is consistent with variable primal for this test.
It also updates MOIU model so that variable indices are sorted in order of creation as required by https://github.com/JuliaOpt/MathOptInterface.jl/issues/230. It helps for setting variable primal in `test/mockoptimizer.jl`