### PR TITLE
Test ConstraintSet after Interval is modified

### DIFF
--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -1250,6 +1250,11 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.canmodifyconstraint(model, c, MOI.Interval{Float64})
     MOI.modifyconstraint!(model, c, MOI.Interval(2.0, 12.0))
 
+    if config.query
+        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
+        @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.Interval(2.0, 12.0)
+    end
+
     if config.solve
         MOI.optimize!(model)
 


### PR DESCRIPTION
This test is the only one which tests `Interval` so we should also add query tests to make sure solvers also implement queries correctly with `Interval`.