### PR TITLE
Check that optimizer is empty in constructor

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -43,7 +43,10 @@ Creates an `CachingOptimizer` in `Automatic` mode, with the optimizer `optimizer
 The model_cache manager returned behaves like an `AbstractOptimizer` as long as no
 `CachingOptimizer`-specific functions (e.g. `dropoptimizer!`) are called on it.
 """
-CachingOptimizer(model_cache::MOI.ModelLike, optimizer::MOI.AbstractOptimizer) = CachingOptimizer(model_cache, optimizer, AttachedOptimizer, Automatic, IndexMap(), IndexMap())
+function CachingOptimizer(model_cache::MOI.ModelLike, optimizer::MOI.AbstractOptimizer)
+    @assert MOI.isempty(optimizer)
+    CachingOptimizer(model_cache, optimizer, AttachedOptimizer, Automatic, IndexMap(), IndexMap())
+end
 
 ## Methods for managing the state of CachingOptimizer.
 

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -44,6 +44,7 @@ The model_cache manager returned behaves like an `AbstractOptimizer` as long as 
 `CachingOptimizer`-specific functions (e.g. `dropoptimizer!`) are called on it.
 """
 function CachingOptimizer(model_cache::MOI.ModelLike, optimizer::MOI.AbstractOptimizer)
+    @assert MOI.isempty(model_cache)
     @assert MOI.isempty(optimizer)
     CachingOptimizer(model_cache, optimizer, AttachedOptimizer, Automatic, IndexMap(), IndexMap())
 end

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -163,22 +163,25 @@ end
 end
 
 @testset "CachingOptimizer constructor with optimizer" begin
-    s = MOIU.MockOptimizer(ModelForMock{Float64}())
-    model = ModelForCachingOptimizer{Float64}()
     @testset "Empty model and optimizer" begin
+        s = MOIU.MockOptimizer(ModelForMock{Float64}())
+        model = ModelForCachingOptimizer{Float64}()
         m = MOIU.CachingOptimizer(model, s)
         @test MOI.isempty(m)
         @test MOIU.state(m) == MOIU.AttachedOptimizer
         @test MOIU.mode(m) == MOIU.Automatic
     end
     @testset "Non-empty optimizer" begin
+        s = MOIU.MockOptimizer(ModelForMock{Float64}())
         MOI.addvariable!(s)
+        model = ModelForCachingOptimizer{Float64}()
         @test MOI.isempty(model)
         @test !MOI.isempty(s)
         @test_throws AssertionError MOIU.CachingOptimizer(model, s)
-        MOI.empty!(s)
     end
     @testset "Non-empty model" begin
+        s = MOIU.MockOptimizer(ModelForMock{Float64}())
+        model = ModelForCachingOptimizer{Float64}()
         MOI.addvariable!(model)
         @test !MOI.isempty(model)
         @test MOI.isempty(s)

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -168,6 +168,9 @@ end
     @test MOI.isempty(m)
     @test MOIU.state(m) == MOIU.AttachedOptimizer
     @test MOIU.mode(m) == MOIU.Automatic
+    MOI.addvariable!(s)
+    # s is not empty
+    @test_throws AssertionError MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), s)
 end
 
 for state in (MOIU.NoOptimizer, MOIU.EmptyOptimizer, MOIU.AttachedOptimizer)

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -165,19 +165,25 @@ end
 @testset "CachingOptimizer constructor with optimizer" begin
     s = MOIU.MockOptimizer(ModelForMock{Float64}())
     model = ModelForCachingOptimizer{Float64}()
-    m = MOIU.CachingOptimizer(model, s)
-    @test MOI.isempty(m)
-    @test MOIU.state(m) == MOIU.AttachedOptimizer
-    @test MOIU.mode(m) == MOIU.Automatic
-    MOI.addvariable!(s)
-    @test MOI.isempty(model)
-    @test !MOI.isempty(s)
-    @test_throws AssertionError MOIU.CachingOptimizer(model, s)
-    MOI.empty!(s)
-    MOI.addvariable!(model)
-    @test !MOI.isempty(model)
-    @test MOI.isempty(s)
-    @test_throws AssertionError MOIU.CachingOptimizer(model, s)
+    @testset "Empty model and optimizer" begin
+        m = MOIU.CachingOptimizer(model, s)
+        @test MOI.isempty(m)
+        @test MOIU.state(m) == MOIU.AttachedOptimizer
+        @test MOIU.mode(m) == MOIU.Automatic
+    end
+    @testset "Non-empty optimizer" begin
+        MOI.addvariable!(s)
+        @test MOI.isempty(model)
+        @test !MOI.isempty(s)
+        @test_throws AssertionError MOIU.CachingOptimizer(model, s)
+        MOI.empty!(s)
+    end
+    @testset "Non-empty model" begin
+        MOI.addvariable!(model)
+        @test !MOI.isempty(model)
+        @test MOI.isempty(s)
+        @test_throws AssertionError MOIU.CachingOptimizer(model, s)
+    end
 end
 
 for state in (MOIU.NoOptimizer, MOIU.EmptyOptimizer, MOIU.AttachedOptimizer)

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -164,13 +164,20 @@ end
 
 @testset "CachingOptimizer constructor with optimizer" begin
     s = MOIU.MockOptimizer(ModelForMock{Float64}())
-    m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), s)
+    model = ModelForCachingOptimizer{Float64}()
+    m = MOIU.CachingOptimizer(model, s)
     @test MOI.isempty(m)
     @test MOIU.state(m) == MOIU.AttachedOptimizer
     @test MOIU.mode(m) == MOIU.Automatic
     MOI.addvariable!(s)
-    # s is not empty
-    @test_throws AssertionError MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), s)
+    @test MOI.isempty(model)
+    @test !MOI.isempty(s)
+    @test_throws AssertionError MOIU.CachingOptimizer(model, s)
+    MOI.empty!(s)
+    MOI.addvariable!(model)
+    @test !MOI.isempty(model)
+    @test MOI.isempty(s)
+    @test_throws AssertionError MOIU.CachingOptimizer(model, s)
 end
 
 for state in (MOIU.NoOptimizer, MOIU.EmptyOptimizer, MOIU.AttachedOptimizer)


### PR DESCRIPTION
The optimizer and model need to be empty in order to be in sync at the start.
This has the additional advantage that if solvers use this constructor for testing, they will be tested with `isempty` so that they will also work when they will be used with `resetsolver!` which calls `isempty` (issue raised by @joaquimg on Gitter).