### PR TITLE
Update findfirst for Julia v0.7

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -358,8 +358,8 @@ end
 function _modifycoefficient(variables::Vector{MOI.VariableIndex}, coefficients::Vector, variable::MOI.VariableIndex, new_coefficient)
     variables = copy(variables)
     coefficients = copy(coefficients)
-    i = findfirst(variables, variable)
-    if (VERSION >= v"0.7.0-DEV.3395" && i === nothing) || (VERSION < v"0.7.0-DEV.3395" && iszero(i))
+    i = coalesce(findfirst(isequal(variable), variables), 0)
+    if iszero(i)
         # The variable was not already in the function
         if !iszero(new_coefficient)
             push!(variables, variable)


### PR DESCRIPTION
`coalesce(i::Int, 0)` returns i and `coalesce(nothing, 0)` returns 0, this is the new way to deal with the deprecation recommended by the warning on nightly.