### PR TITLE
Parametrize CachingOptimizer and MockOptimizer on model type

### DIFF
--- a/perf/cachingoptimizer.jl
+++ b/perf/cachingoptimizer.jl
@@ -1,0 +1,24 @@
+# Current output:
+#  38.889 ns (4 allocations: 112 bytes)
+# 252.048 ns (11 allocations: 288 bytes)
+#  24.412 ns (3 allocations: 96 bytes)
+#  24.982 ns (3 allocations: 96 bytes)
+# See https://github.com/JuliaOpt/MathOptInterface.jl/issues/321
+
+using BenchmarkTools
+using MathOptInterface
+const MOI = MathOptInterface
+const MOIU = MOI.Utilities
+
+@MOIU.model Model () (Interval,) () () () (ScalarAffineFunction,) () ()
+optimizer = MOIU.MockOptimizer(Model{Float64}())
+caching_optimizer = MOIU.CachingOptimizer(Model{Float64}(), optimizer)
+MOIU.resetoptimizer!(caching_optimizer) # detach optimizer
+v = MOI.addvariables!(caching_optimizer, 2)
+cf = MOI.ScalarAffineFunction(v, [0.0, 0.0], 0.0)
+c = MOI.addconstraint!(caching_optimizer, cf, MOI.Interval(-Inf, 1.0))
+@btime MOI.modifyconstraint!($caching_optimizer, $c, $(MOI.Interval(0.0, 2.0)))
+MOIU.attachoptimizer!(caching_optimizer)
+@btime MOI.modifyconstraint!($caching_optimizer, $c, $(MOI.Interval(0.0, 2.0)))
+@btime MOI.modifyconstraint!($(caching_optimizer.model_cache), $c, $(MOI.Interval(0.0, 2.0)))
+@btime MOI.modifyconstraint!($(caching_optimizer.optimizer), $(caching_optimizer.model_to_optimizer_map[c]), $(MOI.Interval(0.0, 2.0)))

--- a/perf/cachingoptimizer.jl
+++ b/perf/cachingoptimizer.jl
@@ -1,9 +1,4 @@
-# Current output:
-#  38.889 ns (4 allocations: 112 bytes)
-# 252.048 ns (11 allocations: 288 bytes)
-#  24.412 ns (3 allocations: 96 bytes)
-#  24.982 ns (3 allocations: 96 bytes)
-# See https://github.com/JuliaOpt/MathOptInterface.jl/issues/321
+# See https://github.com/JuliaOpt/MathOptInterface.jl/issues/321 and https://github.com/JuliaOpt/MathOptInterface.jl/pull/323
 
 using BenchmarkTools
 using MathOptInterface

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -22,8 +22,8 @@ A `CachingOptimizer` has two modes of operation (`CachingOptimizerMode`):
 - `Manual`: The only methods that change the state of the `CachingOptimizer` are [`resetoptimizer!`](@ref), [`dropoptimizer!`](@ref), and [`attachoptimizer!`](@ref). Attempting to perform an operation in the incorrect state results in an error.
 - `Automatic`: The `CachingOptimizer` changes its state when necessary. For example, `optimize!` will automatically call `attachoptimizer!` (an optimizer must have been previously set). Attempting to add a constraint or perform a modification not supported by the optimizer results in a drop to `EmptyOptimizer` mode.
 """
-mutable struct CachingOptimizer <: MOI.AbstractOptimizer
-    model_cache::MOI.ModelLike
+mutable struct CachingOptimizer{MT<:MOI.ModelLike} <: MOI.AbstractOptimizer
+    model_cache::MT
     optimizer::Union{Void,MOI.AbstractOptimizer}
     state::CachingOptimizerState
     mode::CachingOptimizerMode

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -12,8 +12,8 @@ struct MockConstraintAttribute <: MOI.AbstractConstraintAttribute
 end
 
 # A mock optimizer used for testing.
-mutable struct MockOptimizer <: MOI.AbstractOptimizer
-    inner_model::MOI.ModelLike
+mutable struct MockOptimizer{MT<:MOI.ModelLike} <: MOI.AbstractOptimizer
+    inner_model::MT
     attribute::Int # MockModelAttribute
     varattribute::Dict{MOI.VariableIndex,Int} # MockVariableAttribute
     conattribute::Dict{MOI.ConstraintIndex,Int} # MockConstraintAttribute


### PR DESCRIPTION
Initial benchmark:
```
v0.6
126.218 ns (7 allocations: 176 bytes)
452.726 ns (17 allocations: 416 bytes)
 23.927 ns (3 allocations: 96 bytes)
 40.416 ns (5 allocations: 144 bytes)
v0.7
105.262 ns (5 allocations: 128 bytes)
414.565 ns (12 allocations: 304 bytes)
  9.623 ns (1 allocation: 48 bytes)
 29.113 ns (3 allocations: 96 bytes)
```
After parametrization of the MockOptimizer:
```
v0.6
121.149 ns (7 allocations: 176 bytes)
357.014 ns (14 allocations: 352 bytes)
 24.722 ns (3 allocations: 96 bytes)
 24.712 ns (3 allocations: 96 bytes)
v0.7
104.708 ns (5 allocations: 128 bytes)
311.206 ns (9 allocations: 240 bytes)
  9.306 ns (1 allocation: 48 bytes)
  9.400 ns (1 allocation: 48 bytes)
```
After parametrization of CachingOptimizer
```
v0.6
 38.889 ns (4 allocations: 112 bytes)
252.048 ns (11 allocations: 288 bytes)
 24.412 ns (3 allocations: 96 bytes)
 24.982 ns (3 allocations: 96 bytes)
v0.7
 23.149 ns (2 allocations: 64 bytes)
207.150 ns (6 allocations: 176 bytes)
  9.761 ns (1 allocation: 48 bytes)
  9.591 ns (1 allocation: 48 bytes)
```

Related to #321 