### PR TITLE
 Explicit initialization of vector with undef

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.51
+Compat 0.59

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -113,7 +113,7 @@ function Base.getindex(it::ScalarFunctionIterator{MOI.VectorAffineFunction{T}}, 
     outputindex = Int[]
     variables = VI[]
     coefficients = T[]
-    constant = Vector{T}(length(I))
+    constant = Vector{T}(undef, length(I))
     for (i, j) in enumerate(I)
         g = it[j]
         append!(outputindex, repmat(i:i, length(g.variables)))


### PR DESCRIPTION
It requires Compat v0.59 hence the bump of the lower bound