### PR TITLE
RFC: make ScalarAffineFunction and ScalarQuadraticFunction mutable.

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -56,6 +56,10 @@ struct ScalarAffineTerm{T}
     variable_index::VariableIndex
 end
 
+# Note: ScalarAffineFunction is mutable because its `constant` field is likely of an immutable
+# type, while its `terms` field is of a mutable type, meaning that creating a `ScalarAffineFunction`
+# allocates, and it is desirable to provide a zero-allocation option for working with
+# ScalarAffineFunctions. See https://github.com/JuliaOpt/MathOptInterface.jl/pull/343.
 """
     ScalarAffineFunction{T}(terms, constant)
 
@@ -67,7 +71,7 @@ The scalar-valued affine function ``a^T x + b``, where:
 Duplicate variable indices in `terms` are accepted, and the corresponding
 coefficients are summed together.
 """
-struct ScalarAffineFunction{T} <: AbstractScalarFunction
+mutable struct ScalarAffineFunction{T} <: AbstractScalarFunction
     terms::Vector{ScalarAffineTerm{T}}
     constant::T
 end
@@ -120,7 +124,10 @@ struct ScalarQuadraticTerm{T}
     variable_index_2::VariableIndex
 end
 
-
+# Note: ScalarQuadraticFunction is mutable because its `constant` field is likely of an immutable
+# type, while its other fields are of mutable types, meaning that creating a `ScalarQuadraticFunction`
+# allocates, and it is desirable to provide a zero-allocation option for working with
+# ScalarQuadraticFunctions. See https://github.com/JuliaOpt/MathOptInterface.jl/pull/343.
 """
     ScalarQuadraticFunction{T}(affine_terms, quadratic_terms, constant)
 
@@ -135,7 +142,7 @@ coefficients are summed together. "Mirrored" indices `(q,r)` and `(r,q)` (where
 `r` and `q` are `VariableIndex`es) are considered duplicates; only one need be
 specified.
 """
-struct ScalarQuadraticFunction{T} <: AbstractScalarFunction
+mutable struct ScalarQuadraticFunction{T} <: AbstractScalarFunction
     affine_terms::Vector{ScalarAffineTerm{T}}
     quadratic_terms::Vector{ScalarQuadraticTerm{T}}
     constant::T
@@ -221,6 +228,10 @@ struct ScalarCoefficientChange{T} <: AbstractFunctionModification
     new_coefficient::T
 end
 
+# Note: MultiRowChange is mutable because its `variable` field of an immutable
+# type, while `new_coefficients` is of a mutable type, meaning that creating a `MultiRowChange`
+# allocates, and it is desirable to provide a zero-allocation option for working with
+# MultiRowChanges. See https://github.com/JuliaOpt/MathOptInterface.jl/pull/343.
 """
     MultirowChange{T}(variable, new_coefficients)
 
@@ -229,7 +240,7 @@ variable in a vector-valued function. New coefficients are specified by
 `(output_index, coefficient)` tuples. Applicable to `VectorAffineFunction` and
 `VectorQuadraticFunction`.
 """
-struct MultirowChange{T} <: AbstractFunctionModification
+mutable struct MultirowChange{T} <: AbstractFunctionModification
     variable::VariableIndex
     new_coefficients::Vector{Tuple{Int64, T}}
 end


### PR DESCRIPTION
`ScalarAffineFunction` and `ScalarQuadraticFunction` are not `isbits` types due to their `Vector` fields, which means that construction necessarily allocates, and as such is not an option if zero allocation is a requirement.

The alternative, pre-allocating `ScalarAffineFunction` and `ScalarQuadraticFunction` objects and then modifying them, is currently almost a solution, save for the `constant` fields, which cannot be modified. Making these types mutable fully enables this second workflow.

An alternative could be to store the constants in `Base.RefValue{T}` fields, but for little gain, and simply making these types mutable seems like the least amount of hassle.