### PR TITLE
Disallow non-optimizer in bridge

### DIFF
--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -3,9 +3,9 @@ export @bridge
 """
     AbstractBridge
 
-A bridge represents a bridged constraint in an `AbstractBridgeOptimizer`. It contains the indices of the constraints that it has created in the model.
-These can be obtained using `MOI.NumberOfConstraints` and `MOI.ListOfConstraintIndices` and using the bridge in place of a `ModelLike`.
-Attributes of the bridged model such as `MOI.ConstraintDual` and `MOI.ConstraintPrimal`, can be obtained using the bridge in place of the constraint index.
+A bridge represents a bridged constraint in an `AbstractBridgeOptimizer`. It contains the indices of the constraints that it has been created in the optimizer.
+These can be obtained using `MOI.NumberOfConstraints` and `MOI.ListOfConstraintIndices` using the bridge in place of a `ModelLike` in the `MOI.get` function.
+Attributes of the bridged optimizer such as `MOI.ConstraintDual` and `MOI.ConstraintPrimal`, can be obtained using the bridge in place of the constraint index in `MOI.get`.
 These calls are used by the `AbstractBridgeOptimizer` to communicate with the bridge so they should be implemented by the bridge.
 """
 abstract type AbstractBridge end
@@ -13,29 +13,29 @@ abstract type AbstractBridge end
 """
     MOI.get(b::AbstractBridge, ::MOI.NumberOfVariables)
 
-The number of variables created by the bridge `b` in the model.
+The number of variables created by the bridge `b` in the optimizer.
 """
 MOI.get(b::AbstractBridge, ::MOI.NumberOfVariables) = 0
 """
     MOI.get(b::AbstractBridge, ::MOI.NumberOfConstraints{F, S}) where {F, S}
 
-The number of constraints of the type `F`-in-`S` created by the bridge `b` in the model.
+The number of constraints of the type `F`-in-`S` created by the bridge `b` in the optimizer.
 """
 MOI.get(b::AbstractBridge, ::MOI.NumberOfConstraints) = 0
 """
     MOI.get(b::AbstractBridge, ::MOI.NumberOfConstraints{F, S}) where {F, S}
 
 A `Vector{ConstraintIndex{F,S}}` with indices of all constraints of
-type `F`-in`S` created by the bride `b` in the model (i.e., of length equal to the value of `NumberOfConstraints{F,S}()`).
+type `F`-in`S` created by the bride `b` in the optimizer (i.e., of length equal to the value of `NumberOfConstraints{F,S}()`).
 """
 MOI.get(b::AbstractBridge, ::MOI.ListOfConstraintIndices{F, S}) where {F, S} = CI{F, S}[]
 
 """
-    MOI.candelete(model::MOI.ModelLike, b::AbstractBridge)
+    MOI.candelete(optimizer::MOI.AbstractOptimizer, b::AbstractBridge)
 
-Return a `Bool` indicating whether the bridge `b` can be removed from the model `model`.
+Return a `Bool` indicating whether the bridge `b` can be removed from the optimizer `optimizer`.
 """
-MOI.candelete(model::MOI.ModelLike, c::AbstractBridge) = true
+MOI.candelete(optimizer::MOI.AbstractOptimizer, c::AbstractBridge) = true
 
 const InstanceConstraintAttribute = Union{MOI.ConstraintName, MOI.ConstraintFunction, MOI.ConstraintSet}
 const SolverConstraintAttribute = Union{MOI.ConstraintPrimalStart, MOI.ConstraintDualStart, MOI.ConstraintPrimal, MOI.ConstraintDual, MOI.ConstraintBasisStatus}
@@ -48,25 +48,25 @@ The attributes of the bridge optimizer are automatically computed to make the br
 """
 abstract type AbstractBridgeOptimizer <: MOI.AbstractOptimizer end
 bridge(b::AbstractBridgeOptimizer, ci::CI) = b.bridges[ci.value]
-MOI.optimize!(b::AbstractBridgeOptimizer) = MOI.optimize!(b.model)
+MOI.optimize!(b::AbstractBridgeOptimizer) = MOI.optimize!(b.optimizer)
 
-MOI.isempty(b::AbstractBridgeOptimizer) = isempty(b.bridges) && MOI.isempty(b.model)
+MOI.isempty(b::AbstractBridgeOptimizer) = isempty(b.bridges) && MOI.isempty(b.optimizer)
 function MOI.empty!(b::AbstractBridgeOptimizer)
-    MOI.empty!(b.model)
+    MOI.empty!(b.optimizer)
     MOI.empty!(b.bridged)
     empty!(b.bridges)
 end
-MOI.supports(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractModelAttribute, MOI.AbstractOptimizerAttribute}) = MOI.supports(b.model, attr)
+MOI.supports(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractModelAttribute, MOI.AbstractOptimizerAttribute}) = MOI.supports(b.optimizer, attr)
 MOI.copy!(b::AbstractBridgeOptimizer, src::MOI.ModelLike; copynames=false) = MOIU.defaultcopy!(b, src, copynames)
 
 # References
-MOI.candelete(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.candelete(b.model, idx)
-MOI.isvalid(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.isvalid(b.model, idx)
-MOI.delete!(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.delete!(b.model, idx)
+MOI.candelete(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.candelete(b.optimizer, idx)
+MOI.isvalid(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.isvalid(b.optimizer, idx)
+MOI.delete!(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.delete!(b.optimizer, idx)
 
 # Attributes
 function MOI.get(b::AbstractBridgeOptimizer, loc::MOI.ListOfConstraintIndices)
-    locr = MOI.get(b.model, loc)
+    locr = MOI.get(b.optimizer, loc)
     for bridge in values(b.bridges)
         for c in MOI.get(bridge, loc)
             i = findfirst(locr, c)
@@ -78,67 +78,67 @@ function MOI.get(b::AbstractBridgeOptimizer, loc::MOI.ListOfConstraintIndices)
     locr
 end
 function MOI.get(b::AbstractBridgeOptimizer, attr::Union{MOI.NumberOfConstraints, MOI.NumberOfVariables})
-    s = MOI.get(b.model, attr)
+    s = MOI.get(b.optimizer, attr)
     for v in values(b.bridges)
         s -= MOI.get(v, attr)
     end
     s
 end
-MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints) = MOI.canget(b.model, attr) && MOI.canget(b.bridged, attr)
+MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints) = MOI.canget(b.optimizer, attr) && MOI.canget(b.bridged, attr)
 _noc(b, fs) = MOI.get(b, MOI.NumberOfConstraints{fs...}())
 function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints)
-    loc = MOI.get(b.model, attr)
+    loc = MOI.get(b.optimizer, attr)
     rm = find(_noc.(b, loc) .== 0)
     deleteat!(loc, rm)
     append!(loc, MOI.get(b.bridged, attr))
 end
 for f in (:canget, :canset, :get, :get!)
     @eval begin
-        MOI.$f(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractModelAttribute, MOI.AbstractOptimizerAttribute}) = MOI.$f(b.model, attr)
+        MOI.$f(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractModelAttribute, MOI.AbstractOptimizerAttribute}) = MOI.$f(b.optimizer, attr)
     end
 end
 # Objective function and model name
-MOI.set!(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractModelAttribute, MOI.AbstractOptimizerAttribute}, value) = MOI.set!(b.model, attr, value)
+MOI.set!(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractModelAttribute, MOI.AbstractOptimizerAttribute}, value) = MOI.set!(b.optimizer, attr, value)
 for f in (:canget, :canset)
     @eval begin
-        MOI.$f(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, index::Type{<:MOI.Index}) = MOI.$f(b.model, attr, index)
+        MOI.$f(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, index::Type{<:MOI.Index}) = MOI.$f(b.optimizer, attr, index)
     end
 end
-MOI.get(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, index::MOI.Index) = MOI.get(b.model, attr, index)
-MOI.get(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector{<:MOI.Index}) = MOI.get(b.model, attr, indices)
-MOI.set!(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, index::MOI.Index, value) = MOI.set!(b.model, attr, index, value)
-MOI.set!(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector{<:MOI.Index}, values::Vector) = MOI.set!(b.model, attr, indices, values)
+MOI.get(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, index::MOI.Index) = MOI.get(b.optimizer, attr, index)
+MOI.get(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector{<:MOI.Index}) = MOI.get(b.optimizer, attr, indices)
+MOI.set!(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, index::MOI.Index, value) = MOI.set!(b.optimizer, attr, index, value)
+MOI.set!(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector{<:MOI.Index}, values::Vector) = MOI.set!(b.optimizer, attr, indices, values)
 
 # Name
-MOI.canget(b::AbstractBridgeOptimizer, IdxT::Type{<:MOI.Index}, name::String) = MOI.canget(b.model, IdxT, name)
-MOI.get(b::AbstractBridgeOptimizer, IdxT::Type{<:MOI.Index}, name::String) = MOI.get(b.model, IdxT, name)
+MOI.canget(b::AbstractBridgeOptimizer, IdxT::Type{<:MOI.Index}, name::String) = MOI.canget(b.optimizer, IdxT, name)
+MOI.get(b::AbstractBridgeOptimizer, IdxT::Type{<:MOI.Index}, name::String) = MOI.get(b.optimizer, IdxT, name)
 
 # Constraints
-MOI.supportsconstraint(b::AbstractBridgeOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet} = MOI.supportsconstraint(b.model, F, S)
-MOI.canaddconstraint(b::AbstractBridgeOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet} = MOI.canaddconstraint(b.model, F, S)
+MOI.supportsconstraint(b::AbstractBridgeOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet} = MOI.supportsconstraint(b.optimizer, F, S)
+MOI.canaddconstraint(b::AbstractBridgeOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet} = MOI.canaddconstraint(b.optimizer, F, S)
 function MOI.addconstraint!(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction, s::MOI.AbstractSet)
-    MOI.addconstraint!(b.model, f, s)
+    MOI.addconstraint!(b.optimizer, f, s)
 end
-MOI.canmodifyconstraint(b::AbstractBridgeOptimizer, ci::CI, change) = MOI.canmodifyconstraint(b.model, ci, change)
-MOI.modifyconstraint!(b::AbstractBridgeOptimizer, ci::CI, change) = MOI.modifyconstraint!(b.model, ci, change)
+MOI.canmodifyconstraint(b::AbstractBridgeOptimizer, ci::CI, change) = MOI.canmodifyconstraint(b.optimizer, ci, change)
+MOI.modifyconstraint!(b::AbstractBridgeOptimizer, ci::CI, change) = MOI.modifyconstraint!(b.optimizer, ci, change)
 
 # Objective
-MOI.canmodifyobjective(b::AbstractBridgeOptimizer, ::Type{M}) where M<:MOI.AbstractFunctionModification = MOI.canmodifyobjective(b.model, M)
-MOI.modifyobjective!(b::AbstractBridgeOptimizer, change::MOI.AbstractFunctionModification) = MOI.modifyobjective!(b.model, change)
+MOI.canmodifyobjective(b::AbstractBridgeOptimizer, ::Type{M}) where M<:MOI.AbstractFunctionModification = MOI.canmodifyobjective(b.optimizer, M)
+MOI.modifyobjective!(b::AbstractBridgeOptimizer, change::MOI.AbstractFunctionModification) = MOI.modifyobjective!(b.optimizer, change)
 
 # Variables
-MOI.canaddvariable(b::AbstractBridgeOptimizer) = MOI.canaddvariable(b.model)
-MOI.addvariable!(b::AbstractBridgeOptimizer) = MOI.addvariable!(b.model)
-MOI.addvariables!(b::AbstractBridgeOptimizer, n) = MOI.addvariables!(b.model, n)
+MOI.canaddvariable(b::AbstractBridgeOptimizer) = MOI.canaddvariable(b.optimizer)
+MOI.addvariable!(b::AbstractBridgeOptimizer) = MOI.addvariable!(b.optimizer)
+MOI.addvariables!(b::AbstractBridgeOptimizer, n) = MOI.addvariables!(b.optimizer, n)
 
 function _mois(t)
     MOIU._moi.(t.args)
 end
 
 """
-macro bridge(modelname, bridge, scalarsets, typedscalarsets, vectorsets, typedvectorsets, scalarfunctions, typedscalarfunctions, vectorfunctions, typedvectorfunctions)
+macro bridge(optimizername, bridge, scalarsets, typedscalarsets, vectorsets, typedvectorsets, scalarfunctions, typedscalarfunctions, vectorfunctions, typedvectorfunctions)
 
-Creates a type `modelname` implementing the MOI model interface and bridging the `scalarsets` scalar sets `typedscalarsets` typed scalar sets, `vectorsets` vector sets, `typedvectorsets` typed vector sets, `scalarfunctions` scalar functions, `typedscalarfunctions` typed scalar functions, `vectorfunctions` vector functions and `typedvectorfunctions` typed vector functions.
+Creates a type `optimizername` implementing the MOI optimizer interface and bridging the `scalarsets` scalar sets `typedscalarsets` typed scalar sets, `vectorsets` vector sets, `typedvectorsets` typed vector sets, `scalarfunctions` scalar functions, `typedscalarfunctions` typed scalar functions, `vectorfunctions` vector functions and `typedvectorfunctions` typed vector functions.
 To give no set/function, write `()`, to give one set `S`, write `(S,)`.
 
 ### Examples
@@ -149,12 +149,12 @@ The optimizer layer bridging the constraints `ScalarAffineFunction`-in-`Interval
 ```
 Given an optimizer `optimizer` implementing `ScalarAffineFunction`-in-`GreaterThan` and `ScalarAffineFunction`-in-`LessThan`, the optimizer
 ```
-bridgedmodel = SplitInterval(model)
+bridgedoptimizer = SplitInterval(optimizer)
 ```
 will additionally support `ScalarAffineFunction`-in-`Interval`.
 """
-macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
-    bridgedmodelname = Symbol(string(modelname) * "Instance")
+macro bridge(optimizername, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
+    bridgedoptimizername = Symbol(string(optimizername) * "Instance")
     bridgedfuns = :(Union{$(_mois(sf)...), $(_mois(sft)...), $(_mois(vf)...), $(_mois(vft)...)})
     bridgedsets = :(Union{$(_mois(ss)...), $(_mois(sst)...), $(_mois(vs)...), $(_mois(vst)...)})
 
@@ -165,7 +165,7 @@ macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
         attributescode = quote
             $attributescode
 
-            function $MOI.$f(b::$modelname, attr::Union{$MOI.ListOfConstraintIndices{<:$bridgedfuns, <:$bridgedsets}, $MOI.NumberOfConstraints{<:$bridgedfuns, <:$bridgedsets}})
+            function $MOI.$f(b::$optimizername, attr::Union{$MOI.ListOfConstraintIndices{<:$bridgedfuns, <:$bridgedsets}, $MOI.NumberOfConstraints{<:$bridgedfuns, <:$bridgedsets}})
                 $MOI.$f(b.bridged, attr)
             end
         end
@@ -175,11 +175,11 @@ macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
         attributescode = quote
             $attributescode
 
-            function $MOI.$f(b::$modelname, attr::$MOIB.InstanceConstraintAttribute, ci::Type{$CI{F, S}}) where {F<:$bridgedfuns, S<:$bridgedsets}
+            function $MOI.$f(b::$optimizername, attr::$MOIB.InstanceConstraintAttribute, ci::Type{$CI{F, S}}) where {F<:$bridgedfuns, S<:$bridgedsets}
                 $MOI.$f(b.bridged, attr, ci)
             end
-            function $MOI.$f(b::$modelname{T}, attr::$MOIB.SolverConstraintAttribute, ci::Type{$CI{F, S}}) where {T, F<:$bridgedfuns, S<:$bridgedsets}
-                $MOI.$f(b.model, attr, $bridge{T})
+            function $MOI.$f(b::$optimizername{T}, attr::$MOIB.SolverConstraintAttribute, ci::Type{$CI{F, S}}) where {T, F<:$bridgedfuns, S<:$bridgedsets}
+                $MOI.$f(b.optimizer, attr, $bridge{T})
             end
         end
     end
@@ -188,34 +188,34 @@ macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
         attributescode = quote
             $attributescode
 
-            function $MOI.$f(b::$modelname, attr::$MOIB.InstanceConstraintAttribute, ci::$CI{<:$bridgedfuns, <:$bridgedsets})
+            function $MOI.$f(b::$optimizername, attr::$MOIB.InstanceConstraintAttribute, ci::$CI{<:$bridgedfuns, <:$bridgedsets})
                 $MOI.$f(b.bridged, attr, ci)
             end
-            function $MOI.$f(b::$modelname, attr::$MOIB.SolverConstraintAttribute, ci::$CI{<:$bridgedfuns, <:$bridgedsets})
-                $MOI.$f(b.model, attr, $MOIB.bridge(b, ci))
+            function $MOI.$f(b::$optimizername, attr::$MOIB.SolverConstraintAttribute, ci::$CI{<:$bridgedfuns, <:$bridgedsets})
+                $MOI.$f(b.optimizer, attr, $MOIB.bridge(b, ci))
             end
         end
     end
 
     esc(quote
-        $MOIU.@model $bridgedmodelname $ss $sst $vs $vst $sf $sft $vf $vft
+        $MOIU.@model $bridgedoptimizername $ss $sst $vs $vst $sf $sft $vf $vft
 
-        struct $modelname{T, IT<:$MOI.ModelLike} <: $MOIB.AbstractBridgeOptimizer
-            model::IT
-            bridged::$bridgedmodelname{T}
+        struct $optimizername{T, IT<:$MOI.AbstractOptimizer} <: $MOIB.AbstractBridgeOptimizer
+            optimizer::IT
+            bridged::$bridgedoptimizername{T}
             bridges::Dict{Int64, $bridge{T}}
-            function $modelname{T}(model::IT) where {T, IT <: $MOI.ModelLike}
-                new{T, IT}(model, $bridgedmodelname{T}(), Dict{Int64, $bridge{T}}())
+            function $optimizername{T}(optimizer::IT) where {T, IT <: $MOI.AbstractOptimizer}
+                new{T, IT}(optimizer, $bridgedoptimizername{T}(), Dict{Int64, $bridge{T}}())
             end
         end
 
         # References
-        $MOI.candelete(b::$modelname{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T = $MOI.candelete(b.bridged, ci) && $MOI.candelete(b.model, $MOIB.bridge(b, ci))
+        $MOI.candelete(b::$optimizername{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T = $MOI.candelete(b.bridged, ci) && $MOI.candelete(b.optimizer, $MOIB.bridge(b, ci))
 
-        $MOI.isvalid(b::$modelname{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T = $MOI.isvalid(b.bridged, ci)
+        $MOI.isvalid(b::$optimizername{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T = $MOI.isvalid(b.bridged, ci)
 
-        function $MOI.delete!(b::$modelname{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T
-            $MOI.delete!(b.model, $MOIB.bridge(b, ci))
+        function $MOI.delete!(b::$optimizername{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T
+            $MOI.delete!(b.optimizer, $MOIB.bridge(b, ci))
             delete!(b.bridges, ci.value)
             $MOI.delete!(b.bridged, ci)
         end
@@ -223,19 +223,19 @@ macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
         $attributescode
 
         # Constraints
-        $MOI.supportsconstraint(b::$modelname, ::Type{F}, ::Type{S}) where {F<:$bridgedfuns, S<:$bridgedsets} = $MOI.supportsconstraint(b.bridged, F, S)
-        $MOI.canaddconstraint(b::$modelname, ::Type{F}, ::Type{S}) where {F<:$bridgedfuns, S<:$bridgedsets} = $MOI.canaddconstraint(b.bridged, F, S)
-        function $MOI.addconstraint!(b::$modelname{T}, f::$bridgedfuns, s::$bridgedsets) where T
+        $MOI.supportsconstraint(b::$optimizername, ::Type{F}, ::Type{S}) where {F<:$bridgedfuns, S<:$bridgedsets} = $MOI.supportsconstraint(b.bridged, F, S)
+        $MOI.canaddconstraint(b::$optimizername, ::Type{F}, ::Type{S}) where {F<:$bridgedfuns, S<:$bridgedsets} = $MOI.canaddconstraint(b.bridged, F, S)
+        function $MOI.addconstraint!(b::$optimizername{T}, f::$bridgedfuns, s::$bridgedsets) where T
             ci = $MOI.addconstraint!(b.bridged, f, s)
             @assert !haskey(b.bridges, ci.value)
-            b.bridges[ci.value] = $bridge{T}(b.model, f, s)
+            b.bridges[ci.value] = $bridge{T}(b.optimizer, f, s)
             ci
         end
-        function $MOI.canmodifyconstraint(b::$modelname, ci::$CI{<:$bridgedfuns, <:$bridgedsets}, change)
-            $MOI.canmodifyconstraint(b.bridged, ci, change) && $MOI.canmodifyconstraint(b.model, $MOIB.bridge(b, ci), change)
+        function $MOI.canmodifyconstraint(b::$optimizername, ci::$CI{<:$bridgedfuns, <:$bridgedsets}, change)
+            $MOI.canmodifyconstraint(b.bridged, ci, change) && $MOI.canmodifyconstraint(b.optimizer, $MOIB.bridge(b, ci), change)
         end
-        function $MOI.modifyconstraint!(b::$modelname, ci::$CI{<:$bridgedfuns, <:$bridgedsets}, change)
-            $MOI.modifyconstraint!(b.model, $MOIB.bridge(b, ci), change)
+        function $MOI.modifyconstraint!(b::$optimizername, ci::$CI{<:$bridgedfuns, <:$bridgedsets}, change)
+            $MOI.modifyconstraint!(b.optimizer, $MOIB.bridge(b, ci), change)
             $MOI.modifyconstraint!(b.bridged, ci, change)
         end
     end)

--- a/src/Bridges/intervalbridge.jl
+++ b/src/Bridges/intervalbridge.jl
@@ -7,38 +7,38 @@ struct SplitIntervalBridge{T} <: AbstractBridge
     lower::CI{MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}}
     upper::CI{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}}
 end
-function SplitIntervalBridge{T}(model, f::MOI.ScalarAffineFunction{T}, s::MOI.Interval{T}) where T
-    lower = MOI.addconstraint!(model, f, MOI.GreaterThan(s.lower))
-    upper = MOI.addconstraint!(model, f, MOI.LessThan(s.upper))
+function SplitIntervalBridge{T}(optimizer, f::MOI.ScalarAffineFunction{T}, s::MOI.Interval{T}) where T
+    lower = MOI.addconstraint!(optimizer, f, MOI.GreaterThan(s.lower))
+    upper = MOI.addconstraint!(optimizer, f, MOI.LessThan(s.upper))
     SplitIntervalBridge(lower, upper)
 end
-# Attributes, Bridge acting as an model
+# Attributes, Bridge acting as an optimizer
 MOI.get(b::SplitIntervalBridge{T}, ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}}) where T = 1
 MOI.get(b::SplitIntervalBridge{T}, ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}}) where T = 1
 MOI.get(b::SplitIntervalBridge{T}, ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}}) where {T} = [b.lower]
 MOI.get(b::SplitIntervalBridge{T}, ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}}) where {T} = [b.upper]
 
 # Indices
-function MOI.delete!(model::MOI.ModelLike, c::SplitIntervalBridge)
-    MOI.delete!(model, c.lower)
-    MOI.delete!(model, c.upper)
+function MOI.delete!(optimizer::MOI.AbstractOptimizer, c::SplitIntervalBridge)
+    MOI.delete!(optimizer, c.lower)
+    MOI.delete!(optimizer, c.upper)
 end
 
 # Attributes, Bridge acting as a constraint
-function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintPrimal, ::Type{SplitIntervalBridge{T}}) where T
-    MOI.canget(model, a, CI{MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}})
+function MOI.canget(optimizer::MOI.AbstractOptimizer, a::MOI.ConstraintPrimal, ::Type{SplitIntervalBridge{T}}) where T
+    MOI.canget(optimizer, a, CI{MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}})
 end
-function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintPrimal, c::SplitIntervalBridge)
+function MOI.get(optimizer::MOI.AbstractOptimizer, a::MOI.ConstraintPrimal, c::SplitIntervalBridge)
     # lower and upper should give the same value
-    MOI.get(model, MOI.ConstraintPrimal(), c.lower)
+    MOI.get(optimizer, MOI.ConstraintPrimal(), c.lower)
 end
-function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{SplitIntervalBridge{T}}) where T
-    MOI.canget(model, a, CI{MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}}) &&
-    MOI.canget(model, a, CI{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}})
+function MOI.canget(optimizer::MOI.AbstractOptimizer, a::MOI.ConstraintDual, ::Type{SplitIntervalBridge{T}}) where T
+    MOI.canget(optimizer, a, CI{MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}}) &&
+    MOI.canget(optimizer, a, CI{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}})
 end
-function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintDual, c::SplitIntervalBridge)
-    lowd = MOI.get(model, MOI.ConstraintDual(), c.lower) # Should be nonnegative
-    uppd = MOI.get(model, MOI.ConstraintDual(), c.upper) # Should be nonpositive
+function MOI.get(optimizer::MOI.AbstractOptimizer, a::MOI.ConstraintDual, c::SplitIntervalBridge)
+    lowd = MOI.get(optimizer, MOI.ConstraintDual(), c.lower) # Should be nonnegative
+    uppd = MOI.get(optimizer, MOI.ConstraintDual(), c.upper) # Should be nonpositive
     if lowd > -uppd
         lowd
     else
@@ -47,12 +47,12 @@ function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintDual, c::SplitIntervalBr
 end
 
 # Constraints
-MOI.canmodifyconstraint(model::MOI.ModelLike, c::SplitIntervalBridge, change) = true
-function MOI.modifyconstraint!(model::MOI.ModelLike, c::SplitIntervalBridge, change::Union{MOI.ScalarAffineFunction, MOI.AbstractFunctionModification})
-    MOI.modifyconstraint!(model, c.lower, change)
-    MOI.modifyconstraint!(model, c.upper, change)
+MOI.canmodifyconstraint(optimizer::MOI.AbstractOptimizer, c::SplitIntervalBridge, change) = true
+function MOI.modifyconstraint!(optimizer::MOI.AbstractOptimizer, c::SplitIntervalBridge, change::Union{MOI.ScalarAffineFunction, MOI.AbstractFunctionModification})
+    MOI.modifyconstraint!(optimizer, c.lower, change)
+    MOI.modifyconstraint!(optimizer, c.upper, change)
 end
-function MOI.modifyconstraint!(model::MOI.ModelLike, c::SplitIntervalBridge, change::MOI.Interval)
-    MOI.modifyconstraint!(model, c.lower, MOI.GreaterThan(change.lower))
-    MOI.modifyconstraint!(model, c.upper, MOI.LessThan(change.upper))
+function MOI.modifyconstraint!(optimizer::MOI.AbstractOptimizer, c::SplitIntervalBridge, change::MOI.Interval)
+    MOI.modifyconstraint!(optimizer, c.lower, MOI.GreaterThan(change.lower))
+    MOI.modifyconstraint!(optimizer, c.upper, MOI.LessThan(change.upper))
 end

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -1,16 +1,6 @@
 # Model not supporting Interval
 MOIU.@model SimpleModel () (EqualTo, GreaterThan, LessThan) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, PositiveSemidefiniteConeTriangle, ExponentialCone) () (SingleVariable,) (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
 
-@testset "Copy test" begin
-    mock = MOIU.MockOptimizer(SimpleModel{Float64}())
-    bridgedmock = MOIB.SplitInterval{Float64}(mock)
-    MOIT.failcopytestc(bridgedmock)
-    MOIT.failcopytestia(bridgedmock)
-    MOIT.failcopytestva(bridgedmock)
-    MOIT.failcopytestca(bridgedmock)
-    MOIT.copytest(bridgedmock, SimpleModel{Float64}())
-end
-
 function test_noc(bridgedmock, F, S, n)
     @test MOI.canget(bridgedmock, MOI.NumberOfConstraints{F, S}())
     @test MOI.get(bridgedmock, MOI.NumberOfConstraints{F, S}()) == n
@@ -19,53 +9,65 @@ function test_noc(bridgedmock, F, S, n)
 end
 
 @testset "BridgeOptimizer" begin
-    const model = MOIB.SplitInterval{Int}(SimpleModel{Int}())
+    mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+    bridgedmock = MOIB.SplitInterval{Float64}(mock)
 
-    @testset "Name test" begin
-        MOIT.nametest(MOIB.SplitInterval{Float64}(SimpleModel{Float64}()))
+    @testset "ModelLike" begin
+        @testset "Name test" begin
+            MOIT.nametest(bridgedmock)
+        end
+
+        @testset "Copy test" begin
+            MOIT.failcopytestc(bridgedmock)
+            MOIT.failcopytestia(bridgedmock)
+            MOIT.failcopytestva(bridgedmock)
+            MOIT.failcopytestca(bridgedmock)
+            MOIT.copytest(bridgedmock, SimpleModel{Float64}())
+        end
     end
 
     @testset "Custom test" begin
-        x, y = MOI.addvariables!(model, 2)
-        @test MOI.get(model, MOI.NumberOfVariables()) == 2
+        intmock = MOIU.MockOptimizer(SimpleModel{Int}())
+        bridgedintmock = MOIB.SplitInterval{Int}(intmock)
+
+        x, y = MOI.addvariables!(bridgedintmock, 2)
+        @test MOI.get(bridgedintmock, MOI.NumberOfVariables()) == 2
 
         f1 = MOI.ScalarAffineFunction([x], [3], 7)
-        c1 = MOI.addconstraint!(model, f1, MOI.Interval(-1, 1))
+        c1 = MOI.addconstraint!(bridgedintmock, f1, MOI.Interval(-1, 1))
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
-        @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
-        test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)
-        test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
-        @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
-        @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
+        @test MOI.canget(bridgedintmock, MOI.ListOfConstraints())
+        @test MOI.get(bridgedintmock, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
+        test_noc(bridgedintmock, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)
+        test_noc(bridgedintmock, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
+        @test MOI.canget(bridgedintmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
+        @test (@inferred MOI.get(bridgedintmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
 
         f2 = MOI.ScalarAffineFunction([x, y], [2, -1], 2)
-        c2 = MOI.addconstraint!(model, f1, MOI.GreaterThan(-2))
+        c2 = MOI.addconstraint!(bridgedintmock, f1, MOI.GreaterThan(-2))
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
-        @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}), (MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
-        test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 1)
-        test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
-        @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
-        @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
-        @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}}())) == [c2]
+        @test MOI.canget(bridgedintmock, MOI.ListOfConstraints())
+        @test MOI.get(bridgedintmock, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}), (MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
+        test_noc(bridgedintmock, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 1)
+        test_noc(bridgedintmock, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
+        @test MOI.canget(bridgedintmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
+        @test (@inferred MOI.get(bridgedintmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
+        @test (@inferred MOI.get(bridgedintmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}}())) == [c2]
 
-        @test MOI.isvalid(model, c2)
-        @test MOI.candelete(model, c2)
-        MOI.delete!(model, c2)
+        @test MOI.isvalid(bridgedintmock, c2)
+        @test MOI.candelete(bridgedintmock, c2)
+        MOI.delete!(bridgedintmock, c2)
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
-        @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
-        test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)
-        test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
-        @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
-        @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
+        @test MOI.canget(bridgedintmock, MOI.ListOfConstraints())
+        @test MOI.get(bridgedintmock, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
+        test_noc(bridgedintmock, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)
+        test_noc(bridgedintmock, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
+        @test MOI.canget(bridgedintmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
+        @test (@inferred MOI.get(bridgedintmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
     end
 
-    mock = MOIU.MockOptimizer(SimpleModel{Float64}())
-
     @testset "Continuous Linear" begin
-        MOIT.contlineartest(MOIB.SplitInterval{Float64}(mock), MOIT.TestConfig(solve=false))
+        MOIT.contlineartest(bridgedmock, MOIT.TestConfig(solve=false))
     end
 end
 


### PR DESCRIPTION
Since `AbstractBridgeOptimizer <: MOI.AbstractOptimizer`, the inner model should be an optimizer. Otherwise, `optimize!` will not work. It may seem restrictive to prevent models that are not optimizer to use bridges but they can always use a mockoptimizer to turn into an optimizer.