### PR TITLE
RFC: Comprehensive testing of basic constraint functionality

### DIFF
--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -1,5 +1,5 @@
 """
-    basic_constraint_tests(f::Function, model::MOI.ModelLike, config::TestConfig, set::MOI.AbstractSet, N::Int; delete::Bool=true)
+    test_basic_constraint_functionality(f::Function, model::MOI.ModelLike, config::TestConfig, set::MOI.AbstractSet, N::Int; delete::Bool=true)
 
 Test some basic constraint tests.
 
@@ -11,11 +11,11 @@ If `config.query=true`, test getting `ConstraintFunction` and `ConstraintSet`.
 
 ### Example
 
-    basic_constraint_tests(model, config, MOI.LessThan(1.0), 1; delete=false) do x
+    test_basic_constraint_functionality(model, config, MOI.LessThan(1.0), 1; delete=false) do x
         MOI.ScalarAffineFunction(model, [x], [1.0], 0.0)
     end
 """
-function basic_constraint_tests(f::Function, model::MOI.ModelLike, config::TestConfig, set::MOI.AbstractSet, N::Int=1; delete::Bool=true)
+function test_basic_constraint_functionality(f::Function, model::MOI.ModelLike, config::TestConfig, set::MOI.AbstractSet, N::Int=1; delete::Bool=true)
     MOI.empty!(model)
     x = MOI.addvariables!(model, N)
     constraint_function = f(x)
@@ -100,7 +100,7 @@ Basic tests for constraints of the form `ScalarAffineFunction{Float64}`-in-`Less
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_scalaraffine_in_lessthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.LessThan(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.LessThan(1.0); delete=delete) do x
         MOI.ScalarAffineFunction(x, [1.0], 0.0)
     end
 end
@@ -115,7 +115,7 @@ Basic tests for constraints of the form `ScalarAffineFunction{Float64}`-in-`Grea
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_scalaraffine_in_greaterthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.GreaterThan(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.GreaterThan(1.0); delete=delete) do x
         MOI.ScalarAffineFunction(x, [1.0], 0.0)
     end
 end
@@ -129,7 +129,7 @@ Basic tests for constraints of the form `ScalarAffineFunction{Float64}`-in-`Equa
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_scalaraffine_in_equalto(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.EqualTo(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.EqualTo(1.0); delete=delete) do x
         MOI.ScalarAffineFunction(x, [1.0], 0.0)
     end
 end
@@ -143,7 +143,7 @@ Basic tests for constraints of the form `ScalarAffineFunction{Float64}`-in-`Inte
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_scalaraffine_in_interval(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.Interval(0.0, 1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.Interval(0.0, 1.0); delete=delete) do x
         MOI.ScalarAffineFunction(x, [1.0], 0.0)
     end
 end
@@ -157,7 +157,7 @@ Basic tests for constraints of the form `ScalarQuadraticFunction{Float64}`-in-`L
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_scalarquadratic_in_lessthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.LessThan(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.LessThan(1.0); delete=delete) do x
         MOI.ScalarQuadraticFunction(x, [1.0], x, x, [1.0], 0.0)
     end
 end
@@ -172,7 +172,7 @@ Basic tests for constraints of the form `ScalarQuadraticFunction{Float64}`-in-`G
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_scalarquadratic_in_greaterthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.GreaterThan(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.GreaterThan(1.0); delete=delete) do x
         MOI.ScalarQuadraticFunction(x, [1.0], x, x, [1.0], 0.0)
     end
 end
@@ -186,7 +186,7 @@ Basic tests for constraints of the form `ScalarQuadraticFunction{Float64}`-in-`E
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_scalarquadratic_in_equalto(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.EqualTo(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.EqualTo(1.0); delete=delete) do x
         MOI.ScalarQuadraticFunction(x, [1.0], x, x, [1.0], 0.0)
     end
 end
@@ -200,7 +200,7 @@ Basic tests for constraints of the form `ScalarQuadraticFunction{Float64}`-in-`I
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_scalarquadratic_in_interval(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.Interval(0.0, 1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.Interval(0.0, 1.0); delete=delete) do x
         MOI.ScalarQuadraticFunction(x, [1.0], x, x, [1.0], 0.0)
     end
 end
@@ -214,7 +214,7 @@ Basic tests for constraints of the form `SingleVariable`-in-`LessThan{Float64}`.
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_singlevariable_in_lessthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.LessThan(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.LessThan(1.0); delete=delete) do x
         MOI.SingleVariable(x[1])
     end
 end
@@ -229,7 +229,7 @@ Basic tests for constraints of the form `SingleVariable`-in-`GreaterThan{Float64
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_singlevariable_in_greaterthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.GreaterThan(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.GreaterThan(1.0); delete=delete) do x
         MOI.SingleVariable(x[1])
     end
 end
@@ -243,7 +243,7 @@ Basic tests for constraints of the form `SingleVariable`-in-`EqualTo{Float64}`.
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_singlevariable_in_equalto(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.EqualTo(1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.EqualTo(1.0); delete=delete) do x
         MOI.SingleVariable(x[1])
     end
 end
@@ -257,7 +257,7 @@ Basic tests for constraints of the form `SingleVariable`-in-`Interval{Float64}`.
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_singlevariable_in_interval(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.Interval(0.0, 1.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.Interval(0.0, 1.0); delete=delete) do x
         MOI.SingleVariable(x[1])
     end
 end
@@ -271,7 +271,7 @@ Basic tests for constraints of the form `SingleVariable`-in-`ZeroOne`.
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_singlevariable_in_zeroone(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.ZeroOne(); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.ZeroOne(); delete=delete) do x
         MOI.SingleVariable(x[1])
     end
 end
@@ -285,7 +285,7 @@ Basic tests for constraints of the form `SingleVariable`-in-`Integer`.
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_singlevariable_in_integer(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.Integer(); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.Integer(); delete=delete) do x
         MOI.SingleVariable(x[1])
     end
 end
@@ -299,7 +299,7 @@ Basic tests for constraints of the form `SingleVariable`-in-`Semicontinuous`.
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_singlevariable_in_semicontinuous(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.Semicontinuous(1.0, 2.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.Semicontinuous(1.0, 2.0); delete=delete) do x
         MOI.SingleVariable(x[1])
     end
 end
@@ -313,8 +313,36 @@ Basic tests for constraints of the form `SingleVariable`-in-`Semiinteger`.
 If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
 """
 function test_singlevariable_in_semiinteger(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
-    basic_constraint_tests(model, config, MOI.Semiinteger(1.0, 2.0); delete=delete) do x
+    test_basic_constraint_functionality(model, config, MOI.Semiinteger(1.0, 2.0); delete=delete) do x
         MOI.SingleVariable(x[1])
     end
 end
 unittests["test_singlevariable_in_semiinteger"] = test_singlevariable_in_semiinteger
+
+"""
+    test_vectorofvariables_in_sos1(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorOfVariables`-in-`SOS1`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectorofvariables_in_sos1(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.SOS1([1.0, 2.0, 3.0]), 3; delete=delete) do x
+        MOI.VectorOfVariables(x)
+    end
+end
+unittests["test_vectorofvariables_in_sos1"] = test_vectorofvariables_in_sos1
+
+"""
+    test_vectorofvariables_in_sos2(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorOfVariables`-in-`SOS2`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectorofvariables_in_sos2(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.SOS2([1.0, 2.0, 3.0]), 3; delete=delete) do x
+        MOI.VectorOfVariables(x)
+    end
+end
+unittests["test_vectorofvariables_in_sos2"] = test_vectorofvariables_in_sos2

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -102,19 +102,19 @@ function test_basic_constraint_functionality(f::Function, model::MOI.ModelLike, 
 end
 
 # x
-const dummy_single_variable   = (x) -> MOI.SingleVariable(x[1])
+const dummy_single_variable   = (x::Vector{MOI.VariableIndex}) -> MOI.SingleVariable(x[1])
 # x₁, x₂
-const dummy_vectorofvariables = (x) -> MOI.VectorOfVariables(x)
+const dummy_vectorofvariables = (x::Vector{MOI.VariableIndex}) -> MOI.VectorOfVariables(x)
 # 1.0 * x
-const dummy_scalar_affine     = (x) -> MOI.ScalarAffineFunction(x, [1.0], 0.0)
+const dummy_scalar_affine     = (x::Vector{MOI.VariableIndex}) -> MOI.ScalarAffineFunction(x, [1.0], 0.0)
 # 1.0 * x + 1.0 * x^2
-const dummy_scalar_quadratic  = (x) -> MOI.ScalarQuadraticFunction(x, [1.0], x, x, [1.0], 0.0)
+const dummy_scalar_quadratic  = (x::Vector{MOI.VariableIndex}) -> MOI.ScalarQuadraticFunction(x, [1.0], x, x, [1.0], 0.0)
 # x₁ +    - 1
 #    + x₂ + 1
-const dummy_vector_affine     = (x) -> MOI.VectorAffineFunction([1, 2], x, [1.0, 1.0], [-1.0, 1.0])
+const dummy_vector_affine     = (x::Vector{MOI.VariableIndex}) -> MOI.VectorAffineFunction([1, 2], x, [1.0, 1.0], [-1.0, 1.0])
 # x₁ +    + x₁^2
 #    + x₂ +      + x₂^2
-const dummy_vector_quadratic  = (x) -> MOI.VectorQuadraticFunction(
+const dummy_vector_quadratic  = (x::Vector{MOI.VariableIndex}) -> MOI.VectorQuadraticFunction(
     [1,2], x, [1.0, 1.0],       # affine component
     [1,2], x, x, [1.0, 1.0],    # quadratic component
     [0.0, 0.0]                  # constant term
@@ -137,6 +137,12 @@ const BasicConstraintTests = Dict(
     (MOI.VectorOfVariables, MOI.Zeros)         => ( dummy_vectorofvariables, 2, MOI.Zeros(2) ),
     (MOI.VectorOfVariables, MOI.Nonpositives)  => ( dummy_vectorofvariables, 2, MOI.Nonpositives(2) ),
     (MOI.VectorOfVariables, MOI.Nonnegatives)  => ( dummy_vectorofvariables, 2, MOI.Nonnegatives(2) ),
+
+    (MOI.VectorOfVariables, MOI.SecondOrderCone)        => ( dummy_vectorofvariables, 3, MOI.SecondOrderCone(3) ),
+    (MOI.VectorOfVariables, MOI.RotatedSecondOrderCone) => ( dummy_vectorofvariables, 3, MOI.RotatedSecondOrderCone(3) ),
+    (MOI.VectorOfVariables, MOI.GeometricMeanCone)      => ( dummy_vectorofvariables, 3, MOI.GeometricMeanCone(3) ),
+    (MOI.VectorOfVariables, MOI.ExponentialCone)        => ( dummy_vectorofvariables, 3, MOI.ExponentialCone() ),
+    (MOI.VectorOfVariables, MOI.DualExponentialCone)    => ( dummy_vectorofvariables, 3, MOI.DualExponentialCone() ),
 
     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})    => ( dummy_scalar_affine, 1, MOI.LessThan(1.0) ),
     (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => ( dummy_scalar_affine, 1, MOI.GreaterThan(1.0) ),

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -22,13 +22,10 @@ function test_basic_constraint_functionality(f::Function, model::MOI.ModelLike, 
     F, S = typeof(constraint_function), typeof(set)
 
     @test MOI.supportsconstraint(model, F, S)
+    @test MOI.canaddconstraint(model, F, S)
 
     @testset "NumberOfConstraints" begin
         @test MOI.canget(model, MOI.NumberOfConstraints{F,S}())
-    end
-
-    @testset "canaddconstraint" begin
-        @test MOI.canaddconstraint(model, F, S)
     end
 
     @testset "addconstraint!" begin
@@ -79,13 +76,11 @@ function test_basic_constraint_functionality(f::Function, model::MOI.ModelLike, 
     end
 
     if delete
-        @testset "candelete" begin
+        @testset "delete!" begin
             c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
             @test length(c_indices) == 3  # check that we've added a constraint
             @test MOI.candelete(model, c_indices[1])
-        end
-        @testset "delete!" begin
-            c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+
             @test length(c_indices) == 3  # check that we've added a constraint
             MOI.delete!(model, c_indices[1])
             @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == length(c_indices)-1 == 2

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -78,22 +78,23 @@ function test_basic_constraint_functionality(f::Function, model::MOI.ModelLike, 
     @testset "ListOfConstraintIndices" begin
         @test MOI.canget(model, MOI.ListOfConstraintIndices{F,S}())
         c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+        # for sanity, check that we've added 3 constraints as expected.
         @test length(c_indices) == MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 3
     end
 
     @testset "isvalid" begin
         c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-        @test length(c_indices) == 3  # check that we've added a constraint
+        # for sanity, check that we've added 3 constraints as expected.
+        @test length(c_indices) == 3
         @test all(MOI.isvalid.(model, c_indices))
     end
 
     if delete
         @testset "delete!" begin
             c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-            @test length(c_indices) == 3  # check that we've added a constraint
+            # for sanity, check that we've added 3 constraints as expected.
+            @test length(c_indices) == 3
             @test MOI.candelete(model, c_indices[1])
-
-            @test length(c_indices) == 3  # check that we've added a constraint
             MOI.delete!(model, c_indices[1])
             @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == length(c_indices)-1 == 2
             @test !MOI.isvalid(model, c_indices[1])

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -1,0 +1,184 @@
+"""
+    basic_constraint_tests(f::Function, model::MOI.ModelLike, config::TestConfig, set::MOI.AbstractSet, N::Int; delete::Bool=true)
+
+Test some basic constraint tests. `f` is a function that takes a vector of `N`
+variables and returns a constraint function.
+
+If `delete=true`, test `candelete` and `delete!`.
+
+### Example
+
+    basic_constraint_tests(model, config, MOI.LessThan(1.0), 1; delete=false) do x
+        MOI.ScalarAffineFunction(model, [x], [1.0], 0.0)
+    end
+"""
+function basic_constraint_tests(f::Function, model::MOI.ModelLike, config::TestConfig, set::MOI.AbstractSet, N::Int=1; delete::Bool=true)
+    MOI.empty!(model)
+    x = MOI.addvariables!(model, N)
+    constraint_function = f(x)
+    F, S = typeof(constraint_function), typeof(set)
+
+    @testset "NumberOfConstraints" begin
+        @test MOI.canget(model, MOI.NumberOfConstraints{F,S}())
+    end
+
+    @testset "canaddconstraint" begin
+        @test MOI.canaddconstraint(model, F, S)
+    end
+
+    @testset "addconstraint!" begin
+        n = MOI.get(model, MOI.NumberOfConstraints{F,S}())
+        c = MOI.addconstraint!(model, constraint_function, set)
+        @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == n + 1
+    end
+
+    @testset "addconstraints!" begin
+        n = MOI.get(model, MOI.NumberOfConstraints{F,S}())
+        cc = MOI.addconstraints!(model,
+            [constraint_function, constraint_function],
+            [set, set]
+        )
+        @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == n + 2
+    end
+
+    @testset "ListOfConstraintIndices" begin
+        @test MOI.canget(model, MOI.ListOfConstraintIndices{F,S}())
+        c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+        @test length(c_indices) == MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 3
+    end
+
+    @testset "isvalid" begin
+        c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+        @test length(c_indices) == 3  # check that we've added a constraint
+        @test all(MOI.isvalid.(model, c_indices))
+    end
+
+    if delete
+        @testset "candelete" begin
+            c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+            @test length(c_indices) == 3  # check that we've added a constraint
+            @test MOI.candelete(model, c_indices[1])
+        end
+        @testset "delete!" begin
+            c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+            @test length(c_indices) == 3  # check that we've added a constraint
+            MOI.delete!(model, c_indices[1])
+            @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == length(c_indices)-1 == 2
+            @test !MOI.isvalid(model, c_indices[1])
+        end
+    end
+end
+
+"""
+    test_scalaraffine_in_lessthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `ScalarAffineFunction{Float64}`-in-`LessThan{Float64}`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_scalaraffine_in_lessthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    basic_constraint_tests(model, config, MOI.LessThan(1.0)) do x
+        MOI.ScalarAffineFunction(x, [1.0], 0.0)
+    end
+end
+unittests["test_scalaraffine_in_lessthan"] = test_scalaraffine_in_lessthan
+
+
+"""
+    test_scalaraffine_in_greaterthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `ScalarAffineFunction{Float64}`-in-`GreaterThan{Float64}`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_scalaraffine_in_greaterthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    basic_constraint_tests(model, config, MOI.GreaterThan(1.0)) do x
+        MOI.ScalarAffineFunction(x, [1.0], 0.0)
+    end
+end
+unittests["test_scalaraffine_in_greaterthan"] = test_scalaraffine_in_greaterthan
+
+"""
+    test_scalaraffine_in_equalto(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `ScalarAffineFunction{Float64}`-in-`EqualTo{Float64}`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_scalaraffine_in_equalto(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    basic_constraint_tests(model, config, MOI.EqualTo(1.0)) do x
+        MOI.ScalarAffineFunction(x, [1.0], 0.0)
+    end
+end
+unittests["test_scalaraffine_in_equalto"] = test_scalaraffine_in_equalto
+
+"""
+    test_scalaraffine_in_interval(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `ScalarAffineFunction{Float64}`-in-`Interval{Float64}`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_scalaraffine_in_interval(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    basic_constraint_tests(model, config, MOI.Interval(0.0, 1.0)) do x
+        MOI.ScalarAffineFunction(x, [1.0], 0.0)
+    end
+end
+unittests["test_scalaraffine_in_interval"] = test_scalaraffine_in_interval
+
+"""
+    test_singlevariable_in_lessthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `SingleVariable`-in-`LessThan{Float64}`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_singlevariable_in_lessthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    basic_constraint_tests(model, config, MOI.LessThan(1.0)) do x
+        MOI.SingleVariable(x[1])
+    end
+end
+unittests["test_singlevariable_in_lessthan"] = test_singlevariable_in_lessthan
+
+
+"""
+    test_singlevariable_in_greaterthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `SingleVariable`-in-`GreaterThan{Float64}`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_singlevariable_in_greaterthan(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    basic_constraint_tests(model, config, MOI.GreaterThan(1.0)) do x
+        MOI.SingleVariable(x[1])
+    end
+end
+unittests["test_singlevariable_in_greaterthan"] = test_singlevariable_in_greaterthan
+
+"""
+    test_singlevariable_in_equalto(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `SingleVariable`-in-`EqualTo{Float64}`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_singlevariable_in_equalto(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    basic_constraint_tests(model, config, MOI.EqualTo(1.0)) do x
+        MOI.SingleVariable(x[1])
+    end
+end
+unittests["test_singlevariable_in_equalto"] = test_singlevariable_in_equalto
+
+"""
+    test_singlevariable_in_interval(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `SingleVariable`-in-`Interval{Float64}`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_singlevariable_in_interval(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    basic_constraint_tests(model, config, MOI.Interval(0.0, 1.0)) do x
+        MOI.SingleVariable(x[1])
+    end
+end
+unittests["test_singlevariable_in_interval"] = test_singlevariable_in_interval

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -101,11 +101,24 @@ function test_basic_constraint_functionality(f::Function, model::MOI.ModelLike, 
     end
 end
 
+# x
 const dummy_single_variable   = (x) -> MOI.SingleVariable(x[1])
+# x₁, x₂
 const dummy_vectorofvariables = (x) -> MOI.VectorOfVariables(x)
+# 1.0 * x
 const dummy_scalar_affine     = (x) -> MOI.ScalarAffineFunction(x, [1.0], 0.0)
+# 1.0 * x + 1.0 * x^2
 const dummy_scalar_quadratic  = (x) -> MOI.ScalarQuadraticFunction(x, [1.0], x, x, [1.0], 0.0)
+# x₁ +    - 1
+#    + x₂ + 1
 const dummy_vector_affine     = (x) -> MOI.VectorAffineFunction([1, 2], x, [1.0, 1.0], [-1.0, 1.0])
+# x₁ +    + x₁^2
+#    + x₂ +      + x₂^2
+const dummy_vector_quadratic  = (x) -> MOI.VectorQuadraticFunction(
+    [1,2], x, [1.0, 1.0],       # affine component
+    [1,2], x, x, [1.0, 1.0],    # quadratic component
+    [0.0, 0.0]                  # constant term
+)
 
 const BasicConstraintTests = Dict(
     (MOI.SingleVariable, MOI.LessThan{Float64})    => ( dummy_single_variable, 1, MOI.LessThan(1.0) ),
@@ -138,7 +151,12 @@ const BasicConstraintTests = Dict(
     (MOI.VectorAffineFunction{Float64}, MOI.Reals)        => ( dummy_vector_affine, 2, MOI.Reals(2) ),
     (MOI.VectorAffineFunction{Float64}, MOI.Zeros)        => ( dummy_vector_affine, 2, MOI.Zeros(2) ),
     (MOI.VectorAffineFunction{Float64}, MOI.Nonpositives) => ( dummy_vector_affine, 2, MOI.Nonpositives(2) ),
-    (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives) => ( dummy_vector_affine, 2, MOI.Nonnegatives(2) )
+    (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives) => ( dummy_vector_affine, 2, MOI.Nonnegatives(2) ),
+
+    (MOI.VectorQuadraticFunction{Float64}, MOI.Reals)        => ( dummy_vector_quadratic, 2, MOI.Reals(2) ),
+    (MOI.VectorQuadraticFunction{Float64}, MOI.Zeros)        => ( dummy_vector_quadratic, 2, MOI.Zeros(2) ),
+    (MOI.VectorQuadraticFunction{Float64}, MOI.Nonpositives) => ( dummy_vector_quadratic, 2, MOI.Nonpositives(2) ),
+    (MOI.VectorQuadraticFunction{Float64}, MOI.Nonnegatives) => ( dummy_vector_quadratic, 2, MOI.Nonnegatives(2) )
 )
 """
     basic_constraint_tests(model::MOI.ModelLike, config::TestConfig;

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -143,6 +143,15 @@ const BasicConstraintTests = Dict(
     (MOI.VectorOfVariables, MOI.GeometricMeanCone)      => ( dummy_vectorofvariables, 3, MOI.GeometricMeanCone(3) ),
     (MOI.VectorOfVariables, MOI.ExponentialCone)        => ( dummy_vectorofvariables, 3, MOI.ExponentialCone() ),
     (MOI.VectorOfVariables, MOI.DualExponentialCone)    => ( dummy_vectorofvariables, 3, MOI.DualExponentialCone() ),
+    (MOI.VectorOfVariables, MOI.PowerCone)              => ( dummy_vectorofvariables, 3, MOI.PowerCone(2.0) ),
+    (MOI.VectorOfVariables, MOI.DualPowerCone)          => ( dummy_vectorofvariables, 3, MOI.DualPowerCone(2.0) ),
+
+    (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle) => ( dummy_vectorofvariables, 6, MOI.PositiveSemidefiniteConeTriangle(3) ),
+    (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeSquare)   => ( dummy_vectorofvariables, 9, MOI.PositiveSemidefiniteConeSquare(3) ),
+    (MOI.VectorOfVariables, MOI.LogDetConeTriangle)               => ( dummy_vectorofvariables, 6, MOI.LogDetConeTriangle(3) ),
+    (MOI.VectorOfVariables, MOI.LogDetConeSquare)                 => ( dummy_vectorofvariables, 9, MOI.LogDetConeSquare(3) ),
+    (MOI.VectorOfVariables, MOI.RootDetConeTriangle)              => ( dummy_vectorofvariables, 6, MOI.RootDetConeTriangle(3) ),
+    (MOI.VectorOfVariables, MOI.RootDetConeSquare)                => ( dummy_vectorofvariables, 9, MOI.RootDetConeSquare(3) ),
 
     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})    => ( dummy_scalar_affine, 1, MOI.LessThan(1.0) ),
     (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => ( dummy_scalar_affine, 1, MOI.GreaterThan(1.0) ),

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -348,3 +348,59 @@ function test_vectorofvariables_in_sos2(model::MOI.ModelLike, config::TestConfig
     end
 end
 unittests["test_vectorofvariables_in_sos2"] = test_vectorofvariables_in_sos2
+
+"""
+    test_vectorofvariables_in_reals(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorOfVariables`-in-`Reals`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectorofvariables_in_reals(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.Reals(3), 3; delete=delete) do x
+        MOI.VectorOfVariables(x)
+    end
+end
+unittests["test_vectorofvariables_in_reals"] = test_vectorofvariables_in_reals
+
+"""
+    test_vectorofvariables_in_nonnegatives(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorOfVariables`-in-`Nonnegatives`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectorofvariables_in_nonnegatives(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.Nonnegatives(3), 3; delete=delete) do x
+        MOI.VectorOfVariables(x)
+    end
+end
+unittests["test_vectorofvariables_in_nonnegatives"] = test_vectorofvariables_in_nonnegatives
+
+"""
+    test_vectorofvariables_in_nonpositives(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorOfVariables`-in-`Nonpositives`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectorofvariables_in_nonpositives(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.Nonpositives(3), 3; delete=delete) do x
+        MOI.VectorOfVariables(x)
+    end
+end
+unittests["test_vectorofvariables_in_nonpositives"] = test_vectorofvariables_in_nonpositives
+
+"""
+    test_vectorofvariables_in_zeros(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorOfVariables`-in-`Zeros`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectorofvariables_in_zeros(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.Zeros(3), 3; delete=delete) do x
+        MOI.VectorOfVariables(x)
+    end
+end
+unittests["test_vectorofvariables_in_zeros"] = test_vectorofvariables_in_zeros

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -146,12 +146,12 @@ const BasicConstraintTests = Dict(
     (MOI.VectorOfVariables, MOI.PowerCone)              => ( dummy_vectorofvariables, 3, MOI.PowerCone(2.0) ),
     (MOI.VectorOfVariables, MOI.DualPowerCone)          => ( dummy_vectorofvariables, 3, MOI.DualPowerCone(2.0) ),
 
-    (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle) => ( dummy_vectorofvariables, 6, MOI.PositiveSemidefiniteConeTriangle(3) ),
-    (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeSquare)   => ( dummy_vectorofvariables, 9, MOI.PositiveSemidefiniteConeSquare(3) ),
-    (MOI.VectorOfVariables, MOI.LogDetConeTriangle)               => ( dummy_vectorofvariables, 6, MOI.LogDetConeTriangle(3) ),
-    (MOI.VectorOfVariables, MOI.LogDetConeSquare)                 => ( dummy_vectorofvariables, 9, MOI.LogDetConeSquare(3) ),
-    (MOI.VectorOfVariables, MOI.RootDetConeTriangle)              => ( dummy_vectorofvariables, 6, MOI.RootDetConeTriangle(3) ),
-    (MOI.VectorOfVariables, MOI.RootDetConeSquare)                => ( dummy_vectorofvariables, 9, MOI.RootDetConeSquare(3) ),
+    (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle) => ( dummy_vectorofvariables,  7, MOI.PositiveSemidefiniteConeTriangle(3) ),
+    (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeSquare)   => ( dummy_vectorofvariables, 10, MOI.PositiveSemidefiniteConeSquare(3) ),
+    (MOI.VectorOfVariables, MOI.LogDetConeTriangle)               => ( dummy_vectorofvariables,  7, MOI.LogDetConeTriangle(3) ),
+    (MOI.VectorOfVariables, MOI.LogDetConeSquare)                 => ( dummy_vectorofvariables, 10, MOI.LogDetConeSquare(3) ),
+    (MOI.VectorOfVariables, MOI.RootDetConeTriangle)              => ( dummy_vectorofvariables,  7, MOI.RootDetConeTriangle(3) ),
+    (MOI.VectorOfVariables, MOI.RootDetConeSquare)                => ( dummy_vectorofvariables, 10, MOI.RootDetConeSquare(3) ),
 
     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})    => ( dummy_scalar_affine, 1, MOI.LessThan(1.0) ),
     (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => ( dummy_scalar_affine, 1, MOI.GreaterThan(1.0) ),

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -21,6 +21,8 @@ function test_basic_constraint_functionality(f::Function, model::MOI.ModelLike, 
     constraint_function = f(x)
     F, S = typeof(constraint_function), typeof(set)
 
+    @test MOI.supportsconstraint(model, F, S)
+
     @testset "NumberOfConstraints" begin
         @test MOI.canget(model, MOI.NumberOfConstraints{F,S}())
     end

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -106,19 +106,19 @@ end
 const dummy_single_variable   = (x::Vector{MOI.VariableIndex}) -> MOI.SingleVariable(x[1])
 # x₁, x₂
 const dummy_vectorofvariables = (x::Vector{MOI.VariableIndex}) -> MOI.VectorOfVariables(x)
-# 1.0 * x
-const dummy_scalar_affine     = (x::Vector{MOI.VariableIndex}) -> MOI.ScalarAffineFunction(x, [1.0], 0.0)
-# 1.0 * x + 1.0 * x^2
-const dummy_scalar_quadratic  = (x::Vector{MOI.VariableIndex}) -> MOI.ScalarQuadraticFunction(x, [1.0], x, x, [1.0], 0.0)
-# x₁ +    - 1
-#    + x₂ + 1
-const dummy_vector_affine     = (x::Vector{MOI.VariableIndex}) -> MOI.VectorAffineFunction([1, 2], x, [1.0, 1.0], [-1.0, 1.0])
-# x₁ +    + x₁^2
-#    + x₂ +      + x₂^2
+# 1.0 * x + 0.0
+const dummy_scalar_affine     = (x::Vector{MOI.VariableIndex}) -> MOI.ScalarAffineFunction(x, ones(Float64, length(x)), 0.0)
+# 1.0 * x + 1.0 * x^2 + 0.0
+const dummy_scalar_quadratic  = (x::Vector{MOI.VariableIndex}) -> MOI.ScalarQuadraticFunction(x, ones(Float64, length(x)), x, x, ones(Float64, length(x)), 0.0)
+# x₁ +    + 0.0
+#    + x₂ + 0.0
+const dummy_vector_affine     = (x::Vector{MOI.VariableIndex}) -> MOI.VectorAffineFunction(collect(1:length(x)), x, ones(Float64, length(x)), zeros(Float64, length(x)))
+# x₁ +    + x₁^2        + 0.0
+#    + x₂ +      + x₂^2 + 0.0
 const dummy_vector_quadratic  = (x::Vector{MOI.VariableIndex}) -> MOI.VectorQuadraticFunction(
-    [1,2], x, [1.0, 1.0],       # affine component
-    [1,2], x, x, [1.0, 1.0],    # quadratic component
-    [0.0, 0.0]                  # constant term
+    collect(1:length(x)), x, ones(Float64, length(x)),     # affine component
+    collect(1:length(x)), x, x, ones(Float64, length(x)),  # quadratic component
+    zeros(Float64, length(x))                              # constant term
 )
 
 const BasicConstraintTests = Dict(

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -404,3 +404,46 @@ function test_vectorofvariables_in_zeros(model::MOI.ModelLike, config::TestConfi
     end
 end
 unittests["test_vectorofvariables_in_zeros"] = test_vectorofvariables_in_zeros
+
+
+"""
+    test_vectoraffinefunction_in_zeros(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorAffine`-in-`Zeros`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectoraffinefunction_in_zeros(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.Zeros(2), 2; delete=delete) do x
+        MOI.VectorAffineFunction([1, 2], x, [1.0, 1.0], [-1.0, 1.0])
+    end
+end
+unittests["test_vectoraffinefunction_in_zeros"] = test_vectoraffinefunction_in_zeros
+
+"""
+    test_vectoraffinefunction_in_nonnegatives(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorAffine`-in-`Nonnegatives`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectoraffinefunction_in_nonnegatives(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.Nonnegatives(2), 2; delete=delete) do x
+        MOI.VectorAffineFunction([1, 2], x, [1.0, 1.0], [-1.0, 1.0])
+    end
+end
+unittests["test_vectoraffinefunction_in_nonnegatives"] = test_vectoraffinefunction_in_nonnegatives
+
+"""
+    test_vectoraffinefunction_in_nonpositives(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+
+Basic tests for constraints of the form `VectorAffine`-in-`Nonpositives`.
+
+If `delete=true`, test `MOI.candelete` and `MOI.delete!`.
+"""
+function test_vectoraffinefunction_in_nonpositives(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
+    test_basic_constraint_functionality(model, config, MOI.Nonpositives(2), 2; delete=delete) do x
+        MOI.VectorAffineFunction([1, 2], x, [1.0, 1.0], [-1.0, 1.0])
+    end
+end
+unittests["test_vectoraffinefunction_in_nonpositives"] = test_vectoraffinefunction_in_nonpositives

--- a/src/Test/UnitTests/unit_tests.jl
+++ b/src/Test/UnitTests/unit_tests.jl
@@ -95,5 +95,7 @@ end
 include("variables.jl")
 include("objectives.jl")
 include("constraints.jl")
+include("basic_constraint_tests.jl")
+
 
 @moitestset unit

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -379,6 +379,9 @@ struct SOS1{T <: Real} <: AbstractVectorSet
     weights::Vector{T}
 end
 
+Base.:(==)(a::SOS1{T}, b::SOS1{T}) where T = a.weights == b.weights
+Base.isapprox(a::SOS1{T}, b::SOS1{T}; kwargs...) where T = isapprox(a.weights, b.weights; kwargs...)
+
 """
     SOS2{T <: Real}(weights::Vector{T})
 
@@ -391,5 +394,8 @@ See [here](http://lpsolve.sourceforge.net/5.5/SOS.htm) for a description of SOS 
 struct SOS2{T <: Real} <: AbstractVectorSet
     weights::Vector{T}
 end
+
+Base.:(==)(a::SOS2{T}, b::SOS2{T}) where T = a.weights == b.weights
+Base.isapprox(a::SOS2{T}, b::SOS2{T}; kwargs...) where T = isapprox(a.weights, b.weights; kwargs...)
 
 dimension(s::Union{SOS1, SOS2}) = length(s.weights)

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -1,3 +1,9 @@
+@testset "Basic Constraint Tests" begin
+    mock   = MOIU.MockOptimizer(Model{Float64}())
+    config = MOIT.TestConfig()
+    MOIT.basic_constraint_tests(mock, config)
+end
+
 @testset "Unit Tests" begin
     mock = MOIU.MockOptimizer(Model{Float64}())
     config = MOIT.TestConfig()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ end
 # Model supporting every MOI functions and sets
 MOIU.@model(Model,
                (ZeroOne, Integer),
-               (EqualTo, GreaterThan, LessThan, Interval),
+               (EqualTo, GreaterThan, LessThan, Interval, Semicontinuous, Semiinteger),
                (Reals, Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, ExponentialCone, DualExponentialCone, PositiveSemidefiniteConeTriangle, PositiveSemidefiniteConeSquare, RootDetConeTriangle, RootDetConeSquare, LogDetConeTriangle, LogDetConeSquare),
                (PowerCone, DualPowerCone, SOS1, SOS2),
                (SingleVariable,),


### PR DESCRIPTION
### Background

At the moment it is pretty hard from the solver's point-of-view to check that they are implementing the full MOI API correctly (e.g., LQOI). This PR attempts to test this.

For every constraint type supported by the solver, it tests the basic usage of the MOI API. It does not test corner cases. That can come later. In most cases, checking that the solver implemented something correctly will involve forming the problem, modifying, solving, and then checking the solution. This PR just tries to ensure that the methods are implemented.

It has exposed a number of bugs an un-implemented stuff in LQOI (ref https://github.com/JuliaOpt/LinQuadOptInterface.jl/pull/10).

See [the tests in Gurobi.jl](https://github.com/JuliaOpt/Gurobi.jl/blob/2033629e3a67d72cbfb99ac68fbc417f9c7d2b8e/test/MOIWrapper.jl#L10-L26) for an example of how it can be called.

### What this does

N.B. some unchecked things still todo.

In particular, it adds tests for basic usage of:
- [x] supportsconstraint
- [x] canget/get `NumberOfConstraints{F,S}()`
- [x] canaddconstraint
- [x] addconstraint!
- [x] addconstraints!
- [x] canget/get `ListOfConstraintIndices{F,S}()`
- [x] isvalid
- [x] candelete/delete!
- [x] get `ConstraintFunction`
- [x] get `ConstraintSet`
- [ ] canmodify/modify
  - [ ] modify set
  - [ ] modify function
  - [ ] [scalarconstant](http://www.juliaopt.org/MathOptInterface.jl/latest/apireference.html#MathOptInterface.ScalarConstantChange)
  - [ ] [vectorconstant](http://www.juliaopt.org/MathOptInterface.jl/latest/apireference.html#MathOptInterface.VectorConstantChange)
  - [ ] [scalarcoefficient](http://www.juliaopt.org/MathOptInterface.jl/latest/apireference.html#MathOptInterface.ScalarCoefficientChange)
  - [ ] [multirow](http://www.juliaopt.org/MathOptInterface.jl/latest/apireference.html#MathOptInterface.MultirowChange)
- [ ] cantransform/transform
- [x] `ConstraintName`
- [ ] `ConstraintPrimalStart`
- [ ] `ConstraintDualStart`
- [ ] `ConstraintBasisStatus`
- [ ] `ConstraintDual`
- [ ] `ConstraintPrimal`

for the function-set combinations
- [x] `ScalarAffineFunction{Float64}`-in-{`LessThan, GreaterThan, EqualTo, Interval`}
- [x] `ScalarQuadraticFunction{Float64}`-in-{`LessThan, GreaterThan, EqualTo, Interval`}
- [x] `VectorAffineFunction{Float64}`-in-{`Zeros,Nonnegatives,Nonpositives,Reals`}
- [x] `VectorQuadraticFunction{Float64}`-in-{`Zeros,Nonnegatives,Nonpositives,Reals`}
- [x] `SingleVariable`-in-{`LessThan, GreaterThan, EqualTo, Interval`}
- [x] `SingleVariable`-in-{`ZeroOne, Integer, Semicontinuous, Semiinteger`}
- [x] `VectorOfVariables`-in-{`SOS1, SOS2, Zeros,Nonnegatives,Nonpositives,Reals`}
- [x] conic stuff
  - [x] `VectorOfVariables`-in-`SecondOrderCone`
  - [x] `VectorOfVariables`-in-`RotatedSecondOrderCone`
  - [x] `VectorOfVariables`-in-`GeometricMeanCone`
  - [x] `VectorOfVariables`-in-`ExponentialCone`
  - [x] `VectorOfVariables`-in-`DualExponentialCone`
  - [x] PowerCone
  - [x] DualPowerCone
  - [x] PositiveSemidefiniteConeTriangle
  - [x] PositiveSemidefiniteConeSquare
  - [x] LogDetConeTriangle
  - [x] LogDetConeSquare
  - [x] RootDetConeTriangle
  - [x] RootDetConeSquare

<s>Considering doing something like
```julia
const BasicConstraintTests = Dict(
    (MOI.SingleVariable, MOI.ZeroOne)        => test_singlevariable_in_zeroone
)

function basic_constraint_tests(model::MOI.ModelLike, config::TestConfig; delete::Bool=true)
    for ( (F,S), func ) in BasicConstraintTests
        if MOI.supportsconstraint(model, F, S)
            @testset "$(string(func))" begin
                func(model, config; delete=delete)
            end
        end
    end
end
unittests["basic_constraint_tests"] = basic_constraint_tests
```
But, we probably need a way for solvers to specify if they don't support deleting or querying a subset of constraint types.</s> I did something like this.
