### PR TITLE
Refactor bridge optimizer

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -20,6 +20,8 @@ const CI = MOI.ConstraintIndex
 
 include("bridge.jl")
 include("bridgeoptimizer.jl")
+include("singlebridgeoptimizer.jl")
+
 include("intervalbridge.jl")
 @bridge SplitInterval SplitIntervalBridge () (Interval,) () () () (ScalarAffineFunction,) () ()
 include("rsocbridge.jl")

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -5,7 +5,36 @@ A bridge optimizer applies a given constraint bridge to a given optimizer.
 The attributes of the bridge optimizer are automatically computed to make the bridges transparent, e.g. the variables and constraints created by the bridges are hidden.
 """
 abstract type AbstractBridgeOptimizer <: MOI.AbstractOptimizer end
-bridge(b::AbstractBridgeOptimizer, ci::CI) = b.bridges[ci.value]
+
+# AbstractBridgeOptimizer interface
+
+"""
+    isbridged(b::AbstractBridgeOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})::Bool
+
+Return a `Bool` indicating whether `b` bridges `F`-in-`S` constraints.
+"""
+function isbridged end
+# Syntactic sugar
+isbridged(b::AbstractBridgeOptimizer, ::Type{CI{F, S}}) where {F, S} = isbridged(b, F, S)
+
+"""
+    bridgetype(b::AbstractBridgeOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})
+
+Return the `AbstractBridge` type to be used to bridge `F`-in-`S` constraints.
+This function should only be called if `isbridged(b, F, S)`.
+"""
+function bridgetype end
+
+"""
+    bridge(b::AbstractBridgeOptimizer, ci::CI)
+
+Return the `AbstractBridge` used to bridge the constraint with index `ci`.
+"""
+bridge(b::AbstractBridgeOptimizer, ci::CI) = b.bridges[ci]
+# By convention, they should be stored in a `bridges` field using a dictionary-like object.
+
+# Implementation of the MOI interface for AbstractBridgeOptimizer
+
 MOI.optimize!(b::AbstractBridgeOptimizer) = MOI.optimize!(b.model)
 
 MOI.isempty(b::AbstractBridgeOptimizer) = isempty(b.bridges) && MOI.isempty(b.model)
@@ -18,29 +47,75 @@ MOI.supports(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractModelAttribute,
 MOI.copy!(b::AbstractBridgeOptimizer, src::MOI.ModelLike; copynames=false) = MOIU.defaultcopy!(b, src, copynames)
 
 # References
-MOI.candelete(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.candelete(b.model, idx)
-MOI.isvalid(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.isvalid(b.model, idx)
-MOI.delete!(b::AbstractBridgeOptimizer, idx::MOI.Index) = MOI.delete!(b.model, idx)
+MOI.candelete(b::AbstractBridgeOptimizer, vi::VI) = MOI.candelete(b.model, vi)
+function MOI.candelete(b::AbstractBridgeOptimizer, ci::CI)
+    if isbridged(b, typeof(ci))
+        MOI.candelete(b.bridged, ci) && MOI.candelete(b.model, bridge(b, ci))
+    else
+        MOI.candelete(b.model, ci)
+    end
+end
+MOI.isvalid(b::AbstractBridgeOptimizer, vi::VI) = MOI.isvalid(b.model, vi)
+function MOI.isvalid(b::AbstractBridgeOptimizer, ci::CI)
+    if isbridged(b, typeof(ci))
+        MOI.isvalid(b.bridged, ci)
+    else
+        MOI.isvalid(b.model, ci)
+    end
+end
+MOI.delete!(b::AbstractBridgeOptimizer, vi::VI) = MOI.delete!(b.model, vi)
+function MOI.delete!(b::AbstractBridgeOptimizer, ci::CI)
+    if isbridged(b, typeof(ci))
+        MOI.delete!(b.model, bridge(b, ci))
+        delete!(b.bridges, ci)
+        MOI.delete!(b.bridged, ci)
+    else
+        MOI.delete!(b.model, ci)
+    end
+end
 
 # Attributes
-function MOI.get(b::AbstractBridgeOptimizer, loc::MOI.ListOfConstraintIndices)
-    locr = MOI.get(b.model, loc)
-    for bridge in values(b.bridges)
-        for c in MOI.get(bridge, loc)
-            i = findfirst(locr, c)
-            if (VERSION >= v"0.7.0-DEV.3395" && i !== nothing) || (VERSION < v"0.7.0-DEV.3395" && !iszero(i))
-                MOI.deleteat!(locr, i)
+function MOI.canget(b::AbstractBridgeOptimizer, attr::Union{MOI.NumberOfConstraints{F, S}, MOI.ListOfConstraintIndices{F, S}}) where {F, S}
+    if isbridged(b, F, S)
+        MOI.canget(b.bridged, attr)
+    else
+        MOI.canget(b.model, attr)
+    end
+end
+function MOI.get(b::AbstractBridgeOptimizer, loc::MOI.ListOfConstraintIndices{F, S}) where {F, S}
+    if isbridged(b, F, S)
+        MOI.get(b.bridged, loc)
+    else
+        locr = MOI.get(b.model, loc)
+        for bridge in values(b.bridges)
+            for c in MOI.get(bridge, loc)
+                i = findfirst(locr, c)
+                if (VERSION >= v"0.7.0-DEV.3395" && i !== nothing) || (VERSION < v"0.7.0-DEV.3395" && !iszero(i))
+                    MOI.deleteat!(locr, i)
+                end
             end
         end
+        locr
     end
-    locr
 end
-function MOI.get(b::AbstractBridgeOptimizer, attr::Union{MOI.NumberOfConstraints, MOI.NumberOfVariables})
+function _numberof(b::AbstractBridgeOptimizer, attr::Union{MOI.NumberOfConstraints, MOI.NumberOfVariables})
     s = MOI.get(b.model, attr)
     for v in values(b.bridges)
         s -= MOI.get(v, attr)
     end
     s
+end
+MOI.get(b::AbstractBridgeOptimizer, attr::MOI.NumberOfVariables) = _numberof(b, attr)
+function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.NumberOfConstraints{F, S}) where {F, S}
+    if isbridged(b, F, S)
+        MOI.get(b.bridged, attr)
+    else
+        s = MOI.get(b.model, attr)
+        for v in values(b.bridges)
+            s -= MOI.get(v, attr)
+        end
+        s
+    end
 end
 MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints) = MOI.canget(b.model, attr) && MOI.canget(b.bridged, attr)
 _noc(b, fs) = MOI.get(b, MOI.NumberOfConstraints{fs...}())
@@ -67,18 +142,81 @@ MOI.get(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, M
 MOI.set!(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, index::MOI.Index, value) = MOI.set!(b.model, attr, index, value)
 MOI.set!(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector{<:MOI.Index}, values::Vector) = MOI.set!(b.model, attr, indices, values)
 
+const InstanceConstraintAttribute = Union{MOI.ConstraintName, MOI.ConstraintFunction, MOI.ConstraintSet}
+const SolverConstraintAttribute = Union{MOI.ConstraintPrimalStart, MOI.ConstraintDualStart, MOI.ConstraintPrimal, MOI.ConstraintDual, MOI.ConstraintBasisStatus}
+function MOI.canget(b::AbstractBridgeOptimizer, attr::InstanceConstraintAttribute, ci::Type{CI{F, S}}) where {F, S}
+    if isbridged(b, F, S)
+        MOI.canget(b.bridged, attr, ci)
+    else
+        MOI.canget(b.model, attr, ci)
+    end
+end
+function MOI.canget(b::AbstractBridgeOptimizer, attr::SolverConstraintAttribute, ci::Type{CI{F, S}}) where {F, S}
+    if isbridged(b, F, S)
+        MOI.canget(b.model, attr, bridgetype(b, F, S))
+    else
+        MOI.canget(b.model, attr, ci)
+    end
+end
+function MOI.get(b::AbstractBridgeOptimizer, attr::InstanceConstraintAttribute, ci::CI)
+    if isbridged(b, typeof(ci))
+        MOI.get(b.bridged, attr, ci)
+    else
+        MOI.get(b.model, attr, ci)
+    end
+end
+function MOI.get(b::AbstractBridgeOptimizer, attr::SolverConstraintAttribute, ci::CI)
+    if isbridged(b, typeof(ci))
+        MOI.get(b.model, attr, bridge(b, ci))
+    else
+        MOI.get(b.model, attr, ci)
+    end
+end
+
 # Name
 MOI.canget(b::AbstractBridgeOptimizer, IdxT::Type{<:MOI.Index}, name::String) = MOI.canget(b.model, IdxT, name)
 MOI.get(b::AbstractBridgeOptimizer, IdxT::Type{<:MOI.Index}, name::String) = MOI.get(b.model, IdxT, name)
 
 # Constraints
-MOI.supportsconstraint(b::AbstractBridgeOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet} = MOI.supportsconstraint(b.model, F, S)
-MOI.canaddconstraint(b::AbstractBridgeOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet} = MOI.canaddconstraint(b.model, F, S)
-function MOI.addconstraint!(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction, s::MOI.AbstractSet)
-    MOI.addconstraint!(b.model, f, s)
+function MOI.supportsconstraint(b::AbstractBridgeOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})
+    if isbridged(b, F, S)
+        MOI.supportsconstraint(b.bridged, F, S)
+    else
+        MOI.supportsconstraint(b.model, F, S)
+    end
 end
-MOI.canmodifyconstraint(b::AbstractBridgeOptimizer, ci::CI, change) = MOI.canmodifyconstraint(b.model, ci, change)
-MOI.modifyconstraint!(b::AbstractBridgeOptimizer, ci::CI, change) = MOI.modifyconstraint!(b.model, ci, change)
+function MOI.canaddconstraint(b::AbstractBridgeOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})
+    if isbridged(b, F, S)
+        MOI.canaddconstraint(b.bridged, F, S)
+    else
+        MOI.canaddconstraint(b.model, F, S)
+    end
+end
+function MOI.addconstraint!(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction, s::MOI.AbstractSet)
+    if isbridged(b, typeof(f), typeof(s))
+        ci = MOI.addconstraint!(b.bridged, f, s)
+        @assert !haskey(b.bridges, ci)
+        b.bridges[ci] = bridgetype(b, typeof(f), typeof(s))(b.model, f, s)
+        ci
+    else
+        MOI.addconstraint!(b.model, f, s)
+    end
+end
+function MOI.canmodifyconstraint(b::AbstractBridgeOptimizer, ci::CI, change)
+    if isbridged(b, typeof(ci))
+       MOI.canmodifyconstraint(b.bridged, ci, change) && MOI.canmodifyconstraint(b.model, MOIB.bridge(b, ci), change)
+    else
+        MOI.canmodifyconstraint(b.model, ci, change)
+    end
+end
+function MOI.modifyconstraint!(b::AbstractBridgeOptimizer, ci::CI, change)
+    if isbridged(b, typeof(ci))
+        MOI.modifyconstraint!(b.model, bridge(b, ci), change)
+        MOI.modifyconstraint!(b.bridged, ci, change)
+    else
+        MOI.modifyconstraint!(b.model, ci, change)
+    end
+end
 
 # Objective
 MOI.canmodifyobjective(b::AbstractBridgeOptimizer, ::Type{M}) where M<:MOI.AbstractFunctionModification = MOI.canmodifyobjective(b.model, M)
@@ -88,116 +226,3 @@ MOI.modifyobjective!(b::AbstractBridgeOptimizer, change::MOI.AbstractFunctionMod
 MOI.canaddvariable(b::AbstractBridgeOptimizer) = MOI.canaddvariable(b.model)
 MOI.addvariable!(b::AbstractBridgeOptimizer) = MOI.addvariable!(b.model)
 MOI.addvariables!(b::AbstractBridgeOptimizer, n) = MOI.addvariables!(b.model, n)
-
-function _mois(t)
-    MOIU._moi.(t.args)
-end
-
-const InstanceConstraintAttribute = Union{MOI.ConstraintName, MOI.ConstraintFunction, MOI.ConstraintSet}
-const SolverConstraintAttribute = Union{MOI.ConstraintPrimalStart, MOI.ConstraintDualStart, MOI.ConstraintPrimal, MOI.ConstraintDual, MOI.ConstraintBasisStatus}
-
-"""
-macro bridge(modelname, bridge, scalarsets, typedscalarsets, vectorsets, typedvectorsets, scalarfunctions, typedscalarfunctions, vectorfunctions, typedvectorfunctions)
-
-Creates a type `modelname` implementing the MOI model interface and bridging the `scalarsets` scalar sets `typedscalarsets` typed scalar sets, `vectorsets` vector sets, `typedvectorsets` typed vector sets, `scalarfunctions` scalar functions, `typedscalarfunctions` typed scalar functions, `vectorfunctions` vector functions and `typedvectorfunctions` typed vector functions.
-To give no set/function, write `()`, to give one set `S`, write `(S,)`.
-
-### Examples
-
-The optimizer layer bridging the constraints `ScalarAffineFunction`-in-`Interval` is created as follows:
-```julia
-@bridge SplitInterval MOIB.SplitIntervalBridge () (Interval,) () () () (ScalarAffineFunction,) () ()
-```
-Given an optimizer `optimizer` implementing `ScalarAffineFunction`-in-`GreaterThan` and `ScalarAffineFunction`-in-`LessThan`, the optimizer
-```
-bridgedmodel = SplitInterval(model)
-```
-will additionally support `ScalarAffineFunction`-in-`Interval`.
-"""
-macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
-    bridgedmodelname = Symbol(string(modelname) * "Instance")
-    bridgedfuns = :(Union{$(_mois(sf)...), $(_mois(sft)...), $(_mois(vf)...), $(_mois(vft)...)})
-    bridgedsets = :(Union{$(_mois(ss)...), $(_mois(sst)...), $(_mois(vs)...), $(_mois(vst)...)})
-
-    # Attributes
-    attributescode = :()
-
-    for f in (:canget, :get)
-        attributescode = quote
-            $attributescode
-
-            function $MOI.$f(b::$modelname, attr::Union{$MOI.ListOfConstraintIndices{<:$bridgedfuns, <:$bridgedsets}, $MOI.NumberOfConstraints{<:$bridgedfuns, <:$bridgedsets}})
-                $MOI.$f(b.bridged, attr)
-            end
-        end
-    end
-
-    for f in (:canget, :canset)
-        attributescode = quote
-            $attributescode
-
-            function $MOI.$f(b::$modelname, attr::$MOIB.InstanceConstraintAttribute, ci::Type{$CI{F, S}}) where {F<:$bridgedfuns, S<:$bridgedsets}
-                $MOI.$f(b.bridged, attr, ci)
-            end
-            function $MOI.$f(b::$modelname{T}, attr::$MOIB.SolverConstraintAttribute, ci::Type{$CI{F, S}}) where {T, F<:$bridgedfuns, S<:$bridgedsets}
-                $MOI.$f(b.model, attr, $bridge{T})
-            end
-        end
-    end
-
-    for f in (:set!, :get, :get!)
-        attributescode = quote
-            $attributescode
-
-            function $MOI.$f(b::$modelname, attr::$MOIB.InstanceConstraintAttribute, ci::$CI{<:$bridgedfuns, <:$bridgedsets})
-                $MOI.$f(b.bridged, attr, ci)
-            end
-            function $MOI.$f(b::$modelname, attr::$MOIB.SolverConstraintAttribute, ci::$CI{<:$bridgedfuns, <:$bridgedsets})
-                $MOI.$f(b.model, attr, $MOIB.bridge(b, ci))
-            end
-        end
-    end
-
-    esc(quote
-        $MOIU.@model $bridgedmodelname $ss $sst $vs $vst $sf $sft $vf $vft
-
-        struct $modelname{T, IT<:$MOI.ModelLike} <: $MOIB.AbstractBridgeOptimizer
-            model::IT
-            bridged::$bridgedmodelname{T}
-            bridges::Dict{Int64, $bridge{T}}
-            function $modelname{T}(model::IT) where {T, IT <: $MOI.ModelLike}
-                new{T, IT}(model, $bridgedmodelname{T}(), Dict{Int64, $bridge{T}}())
-            end
-        end
-
-        # References
-        $MOI.candelete(b::$modelname{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T = $MOI.candelete(b.bridged, ci) && $MOI.candelete(b.model, $MOIB.bridge(b, ci))
-
-        $MOI.isvalid(b::$modelname{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T = $MOI.isvalid(b.bridged, ci)
-
-        function $MOI.delete!(b::$modelname{T}, ci::$CI{<:$bridgedfuns, <:$bridgedsets}) where T
-            $MOI.delete!(b.model, $MOIB.bridge(b, ci))
-            delete!(b.bridges, ci.value)
-            $MOI.delete!(b.bridged, ci)
-        end
-
-        $attributescode
-
-        # Constraints
-        $MOI.supportsconstraint(b::$modelname, ::Type{F}, ::Type{S}) where {F<:$bridgedfuns, S<:$bridgedsets} = $MOI.supportsconstraint(b.bridged, F, S)
-        $MOI.canaddconstraint(b::$modelname, ::Type{F}, ::Type{S}) where {F<:$bridgedfuns, S<:$bridgedsets} = $MOI.canaddconstraint(b.bridged, F, S)
-        function $MOI.addconstraint!(b::$modelname{T}, f::$bridgedfuns, s::$bridgedsets) where T
-            ci = $MOI.addconstraint!(b.bridged, f, s)
-            @assert !haskey(b.bridges, ci.value)
-            b.bridges[ci.value] = $bridge{T}(b.model, f, s)
-            ci
-        end
-        function $MOI.canmodifyconstraint(b::$modelname, ci::$CI{<:$bridgedfuns, <:$bridgedsets}, change)
-            $MOI.canmodifyconstraint(b.bridged, ci, change) && $MOI.canmodifyconstraint(b.model, $MOIB.bridge(b, ci), change)
-        end
-        function $MOI.modifyconstraint!(b::$modelname, ci::$CI{<:$bridgedfuns, <:$bridgedsets}, change)
-            $MOI.modifyconstraint!(b.model, $MOIB.bridge(b, ci), change)
-            $MOI.modifyconstraint!(b.bridged, ci, change)
-        end
-    end)
-end

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -110,11 +110,7 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.NumberOfConstraints{F, S}
     if isbridged(b, F, S)
         MOI.get(b.bridged, attr)
     else
-        s = MOI.get(b.model, attr)
-        for v in values(b.bridges)
-            s -= MOI.get(v, attr)
-        end
-        s
+        _numberof(b, attr)
     end
 end
 MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints) = MOI.canget(b.model, attr) && MOI.canget(b.bridged, attr)

--- a/src/Bridges/singlebridgeoptimizer.jl
+++ b/src/Bridges/singlebridgeoptimizer.jl
@@ -11,7 +11,8 @@ isbridged(b::SingleBridgeOptimizer, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI
 
 bridgetype(b::SingleBridgeOptimizer{BT}, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI.AbstractSet}) where BT = BT
 
-_mois(t) = MOIU._moi.(t.args)
+# :((Zeros, SecondOrderCone)) -> (:(MOI.Zeros), :(MOI.SecondOrderCone))
+_tuple_prefix_moi(t) = MOIU._moi.(t.args)
 
 """
 macro bridge(modelname, bridge, scalarsets, typedscalarsets, vectorsets, typedvectorsets, scalarfunctions, typedscalarfunctions, vectorfunctions, typedvectorfunctions)
@@ -33,8 +34,8 @@ will additionally support `ScalarAffineFunction`-in-`Interval`.
 """
 macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
     bridgedmodelname = Symbol(string(modelname) * "Instance")
-    bridgedfuns = :(Union{$(_mois(sf)...), $(_mois(sft)...), $(_mois(vf)...), $(_mois(vft)...)})
-    bridgedsets = :(Union{$(_mois(ss)...), $(_mois(sst)...), $(_mois(vs)...), $(_mois(vst)...)})
+    bridgedfuns = :(Union{$(_tuple_prefix_moi(sf)...), $(_tuple_prefix_moi(sft)...), $(_tuple_prefix_moi(vf)...), $(_tuple_prefix_moi(vft)...)})
+    bridgedsets = :(Union{$(_tuple_prefix_moi(ss)...), $(_tuple_prefix_moi(sst)...), $(_tuple_prefix_moi(vs)...), $(_tuple_prefix_moi(vst)...)})
 
     esc(quote
         $MOIU.@model $bridgedmodelname $ss $sst $vs $vst $sf $sft $vf $vft

--- a/src/Bridges/singlebridgeoptimizer.jl
+++ b/src/Bridges/singlebridgeoptimizer.jl
@@ -1,0 +1,44 @@
+struct SingleBridgeOptimizer{BT<:AbstractBridge, MT<:MOI.ModelLike, T, OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
+    model::OT
+    bridged::MT
+    bridges::Dict{CI, BT}
+end
+function SingleBridgeOptimizer{BT, MT, T}(model::OT) where {BT, MT, T, OT <: MOI.ModelLike}
+    SingleBridgeOptimizer{BT, MT, T, OT}(model, MT(), Dict{CI, BT}())
+end
+
+isbridged(b::SingleBridgeOptimizer, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI.AbstractSet}) = false
+
+bridgetype(b::SingleBridgeOptimizer{BT}, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI.AbstractSet}) where BT = BT
+
+_mois(t) = MOIU._moi.(t.args)
+
+"""
+macro bridge(modelname, bridge, scalarsets, typedscalarsets, vectorsets, typedvectorsets, scalarfunctions, typedscalarfunctions, vectorfunctions, typedvectorfunctions)
+
+Creates a type `modelname` implementing the MOI model interface and bridging the `scalarsets` scalar sets `typedscalarsets` typed scalar sets, `vectorsets` vector sets, `typedvectorsets` typed vector sets, `scalarfunctions` scalar functions, `typedscalarfunctions` typed scalar functions, `vectorfunctions` vector functions and `typedvectorfunctions` typed vector functions.
+To give no set/function, write `()`, to give one set `S`, write `(S,)`.
+
+### Examples
+
+The optimizer layer bridging the constraints `ScalarAffineFunction`-in-`Interval` is created as follows:
+```julia
+@bridge SplitInterval MOIB.SplitIntervalBridge () (Interval,) () () () (ScalarAffineFunction,) () ()
+```
+Given an optimizer `optimizer` implementing `ScalarAffineFunction`-in-`GreaterThan` and `ScalarAffineFunction`-in-`LessThan`, the optimizer
+```
+bridgedmodel = SplitInterval(model)
+```
+will additionally support `ScalarAffineFunction`-in-`Interval`.
+"""
+macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
+    bridgedmodelname = Symbol(string(modelname) * "Instance")
+    bridgedfuns = :(Union{$(_mois(sf)...), $(_mois(sft)...), $(_mois(vf)...), $(_mois(vft)...)})
+    bridgedsets = :(Union{$(_mois(ss)...), $(_mois(sst)...), $(_mois(vs)...), $(_mois(vst)...)})
+
+    esc(quote
+        $MOIU.@model $bridgedmodelname $ss $sst $vs $vst $sf $sft $vf $vft
+        const $modelname{T, OT<:MOI.ModelLike} = $MOIB.SingleBridgeOptimizer{$bridge{T}, $bridgedmodelname{T}, T, OT}
+        isbridged(b::$modelname, ::Type{<:$bridgedfuns}, ::Type{<:$bridgedsets}) = true
+    end)
+end


### PR DESCRIPTION
* Defines an documented interface for `AbstractBridgeOptimizer` and implements the MOI interface using this interface.
* Defines the `SingleBridgeOptimizer` concrete subtype of `AbstractBridgeOptimizer`.
* The `@bridge` macro now simply creates specifies a `SingleBridgeOptimizer` instead of creating a new concrete subtype of `AbstractBridgeOptimizer`.