### PR TITLE
ListOfConstraints -> ListOfConstraintTypes

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -53,7 +53,7 @@ Name
 ObjectiveSense
 NumberOfVariables
 ListOfVariableIndices
-ListOfConstraints
+ListOfConstraintTypes
 NumberOfConstraints
 ListOfConstraintIndices
 ListOfModelAttributesSet

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -42,9 +42,9 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::Union{MOI.NumberOfConstraints
     end
     s
 end
-MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints) = MOI.canget(b.model, attr) && MOI.canget(b.bridged, attr)
+MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraintTypes) = MOI.canget(b.model, attr) && MOI.canget(b.bridged, attr)
 _noc(b, fs) = MOI.get(b, MOI.NumberOfConstraints{fs...}())
-function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints)
+function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraintTypes)
     loc = MOI.get(b.model, attr)
     rm = find(_noc.(b, loc) .== 0)
     deleteat!(loc, rm)

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -38,7 +38,7 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     c = MOI.addconstraint!(model, MOI.VectorAffineFunction([1,1,1,2,2], [v;v[2];v[3]], ones(5), [-3.0,-2.0]), MOI.Zeros(2))
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
-    loc = MOI.get(model, MOI.ListOfConstraints())
+    loc = MOI.get(model, MOI.ListOfConstraintTypes())
     @test length(loc) == 2
     @test (vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonnegatives) in loc
     @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
@@ -357,7 +357,7 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
-    loc = MOI.get(model, MOI.ListOfConstraints())
+    loc = MOI.get(model, MOI.ListOfConstraintTypes())
     @test length(loc) == 2
     @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
     @test (vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone) in loc

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -33,7 +33,7 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
-    loc = MOI.get(model, MOI.ListOfConstraints())
+    loc = MOI.get(model, MOI.ListOfConstraintTypes())
     @test length(loc) == 2
     @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
     @test (MOI.VectorOfVariables,MOI.SecondOrderCone) in loc

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -129,7 +129,7 @@ function emptytest(model::MOI.ModelLike)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 0
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 0
-    @test isempty(MOI.get(model, MOI.ListOfConstraints()))
+    @test isempty(MOI.get(model, MOI.ListOfConstraintTypes()))
 
     @test !MOI.isvalid(model, v[1])
     @test !MOI.isvalid(model, vc)
@@ -143,7 +143,7 @@ MOI.get(::BadModel, ::MOI.NumberOfVariables) = 1
 MOI.get(::BadModel, ::MOI.ListOfVariableIndices) = [MOI.VariableIndex(1)]
 MOI.canget(::BadModel, ::MOI.ListOfVariableAttributesSet) = true
 MOI.get(::BadModel, ::MOI.ListOfVariableAttributesSet) = MOI.AbstractVariableAttribute[]
-MOI.get(::BadModel, ::MOI.ListOfConstraints) = [(MOI.SingleVariable, MOI.EqualTo{Float64})]
+MOI.get(::BadModel, ::MOI.ListOfConstraintTypes) = [(MOI.SingleVariable, MOI.EqualTo{Float64})]
 MOI.get(::BadModel, ::MOI.ListOfConstraintIndices{F,S}) where {F,S} = [MOI.ConstraintIndex{F,S}(1)]
 MOI.get(::BadModel, ::MOI.ConstraintFunction, ::MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Float64}}) = MOI.SingleVariable(MOI.VariableIndex(1))
 MOI.get(::BadModel, ::MOI.ConstraintSet, ::MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Float64}}) = MOI.EqualTo(0.0)
@@ -151,7 +151,7 @@ MOI.canget(::BadModel, ::MOI.ListOfConstraintAttributesSet) = true
 MOI.get(::BadModel, ::MOI.ListOfConstraintAttributesSet) = MOI.AbstractConstraintAttribute[]
 
 struct BadConstraintModel <: BadModel end
-MOI.get(::BadConstraintModel, ::MOI.ListOfConstraints) = [(MOI.SingleVariable, MOI.EqualTo{Float64}), (MOI.SingleVariable, UnknownSet)]
+MOI.get(::BadConstraintModel, ::MOI.ListOfConstraintTypes) = [(MOI.SingleVariable, MOI.EqualTo{Float64}), (MOI.SingleVariable, UnknownSet)]
 MOI.get(::BadModel, ::MOI.ConstraintFunction, ::MOI.ConstraintIndex{MOI.SingleVariable,UnknownSet}) = MOI.SingleVariable(MOI.VariableIndex(1))
 MOI.get(::BadModel, ::MOI.ConstraintSet, ::MOI.ConstraintIndex{MOI.SingleVariable,UnknownSet}) = UnknownSet()
 
@@ -235,7 +235,7 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
     @test MOI.get(dest, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == [dict[csa]]
     @test MOI.get(dest, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
     @test MOI.get(dest, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == [dict[cva]]
-    loc = MOI.get(dest, MOI.ListOfConstraints())
+    loc = MOI.get(dest, MOI.ListOfConstraintTypes())
     @test length(loc) == 4
     @test (MOI.SingleVariable,MOI.EqualTo{Float64}) in loc
     @test (MOI.VectorOfVariables,MOI.Nonnegatives) in loc

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -119,7 +119,7 @@ function defaultcopy!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
     res.status == MOI.CopySuccess || return res
 
     # Copy constraints
-    for (F, S) in MOI.get(src, MOI.ListOfConstraints())
+    for (F, S) in MOI.get(src, MOI.ListOfConstraintTypes())
         # do the rest in copyconstraints! which is type stable
         res = copyconstraints!(dest, src, copynames, idxmap, F, S)
         res.status == MOI.CopySuccess || return res
@@ -296,7 +296,7 @@ function allocateload!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
     res.status == MOI.CopySuccess || return res
 
     # Allocate constraints
-    for (F, S) in MOI.get(src, MOI.ListOfConstraints())
+    for (F, S) in MOI.get(src, MOI.ListOfConstraintTypes())
         # do the rest in copyconstraints! which is type stable
         res = allocateconstraints!(dest, src, copynames, idxmap, F, S)
         res.status == MOI.CopySuccess || return res
@@ -314,7 +314,7 @@ function allocateload!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
     res.status == MOI.CopySuccess || return res
 
     # Copy constraints
-    for (F, S) in MOI.get(src, MOI.ListOfConstraints())
+    for (F, S) in MOI.get(src, MOI.ListOfConstraintTypes())
         # do the rest in copyconstraints! which is type stable
         res = loadconstraints!(dest, src, copynames, idxmap, F, S)
         res.status == MOI.CopySuccess || return res

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -215,7 +215,7 @@ function test_variablenames_equal(model, variablenames)
 end
 function test_constraintnames_equal(model, constraintnames)
     seen_name = Dict(name => false for name in constraintnames)
-    for (F,S) in MOI.get(model, MOI.ListOfConstraints())
+    for (F,S) in MOI.get(model, MOI.ListOfConstraintTypes())
         for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
             cname = MOI.get(model, MOI.ConstraintName(), index)
             if !haskey(seen_name, cname)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -255,7 +255,7 @@ end
 
 MOI.get(model::AbstractModel, noc::MOI.NumberOfConstraints) = _getnoc(model, noc)
 
-function MOI.get(model::AbstractModel, loc::MOI.ListOfConstraints)
+function MOI.get(model::AbstractModel, loc::MOI.ListOfConstraintTypes)
     broadcastvcat(_getloc, model)
 end
 
@@ -266,7 +266,7 @@ end
 MOI.canget(model::AbstractModel, ::Union{MOI.NumberOfVariables,
                                          MOI.ListOfVariableIndices,
                                          MOI.NumberOfConstraints,
-                                         MOI.ListOfConstraints,
+                                         MOI.ListOfConstraintTypes,
                                          MOI.ListOfConstraintIndices,
                                          MOI.ObjectiveSense}) = true
 
@@ -329,7 +329,7 @@ function broadcastcall end
 """
 broadcastvcat(f::Function, model::AbstractModel)
 
-Calls `f(contrs)` for every vector `constrs::Vector{ConstraintIndex{F, S}, F, S}` of the model and concatenate the results with `vcat` (this is used internally for `ListOfConstraints`).
+Calls `f(contrs)` for every vector `constrs::Vector{ConstraintIndex{F, S}, F, S}` of the model and concatenate the results with `vcat` (this is used internally for `ListOfConstraintTypes`).
 
 # Examples
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -308,13 +308,13 @@ The number of constraints of the type `F`-in-`S` present in the model.
 struct NumberOfConstraints{F,S} <: AbstractModelAttribute end
 
 """
-    ListOfConstraints()
+    ListOfConstraintTypes()
 
 A list of tuples of the form `(F,S)`, where `F` is a function type
 and `S` is a set type indicating that the attribute `NumberOfConstraints{F,S}()`
 has value greater than zero.
 """
-struct ListOfConstraints <: AbstractModelAttribute end
+struct ListOfConstraintTypes <: AbstractModelAttribute end
 
 """
     ObjectiveFunction{F<:AbstractScalarFunction}()

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -33,8 +33,8 @@ end
         f1 = MOI.ScalarAffineFunction([x], [3], 7)
         c1 = MOI.addconstraint!(model, f1, MOI.Interval(-1, 1))
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
-        @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
+        @test MOI.canget(model, MOI.ListOfConstraintTypes())
+        @test MOI.get(model, MOI.ListOfConstraintTypes()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
         @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
@@ -43,8 +43,8 @@ end
         f2 = MOI.ScalarAffineFunction([x, y], [2, -1], 2)
         c2 = MOI.addconstraint!(model, f1, MOI.GreaterThan(-2))
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
-        @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}), (MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
+        @test MOI.canget(model, MOI.ListOfConstraintTypes())
+        @test MOI.get(model, MOI.ListOfConstraintTypes()) == [(MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}), (MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 1)
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
         @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
@@ -55,8 +55,8 @@ end
         @test MOI.candelete(model, c2)
         MOI.delete!(model, c2)
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
-        @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
+        @test MOI.canget(model, MOI.ListOfConstraintTypes())
+        @test MOI.get(model, MOI.ListOfConstraintTypes()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
         @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())

--- a/test/model.jl
+++ b/test/model.jl
@@ -52,8 +52,8 @@ end
     @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.VectorQuadraticFunction{Int},MOI.PositiveSemidefiniteConeTriangle}())
     @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.VectorQuadraticFunction{Int},MOI.PositiveSemidefiniteConeTriangle}())) == [c2]
 
-    @test MOI.canget(model, MOI.ListOfConstraints())
-    loc = MOI.get(model, MOI.ListOfConstraints())
+    @test MOI.canget(model, MOI.ListOfConstraintTypes())
+    loc = MOI.get(model, MOI.ListOfConstraintTypes())
     @test length(loc) == 2
     @test (MOI.VectorQuadraticFunction{Int},MOI.PositiveSemidefiniteConeTriangle) in loc
     @test (MOI.VectorQuadraticFunction{Int},MOI.PositiveSemidefiniteConeTriangle) in loc
@@ -81,7 +81,7 @@ end
     c7 = MOI.addconstraint!(model, f7, MOI.Nonpositives(2))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
 
-    loc1 = MOI.get(model, MOI.ListOfConstraints())
+    loc1 = MOI.get(model, MOI.ListOfConstraintTypes())
     loc2 = Vector{Tuple{DataType, DataType}}()
     function _pushloc(constrs::Vector{MOIU.C{F, S}}) where {F, S}
         if !isempty(constrs)


### PR DESCRIPTION
Closes #214 

I also propose changing
```
 A list of tuples of the form `(F,S)`, where `F` is a function type
 and `S` is a set type indicating that the attribute `NumberOfConstraints{F,S}()`
 has value greater than zero.
```
to 
```
 A list of tuples of the form `(F,S)`, where `F` is a function type
 and `S` is a set type indicating that `supportsconstraint(model, F, S)` is `true`.
```

Updated: changed `cansupport` to `supportsconstraint`.