### PR TITLE
[array_of_tuples] Fix parser

### DIFF
--- a/test/parser.jl
+++ b/test/parser.jl
@@ -4,13 +4,18 @@ structeq(a::T, b::T) where {T} = all(f->getfield(a, f) == getfield(b, f), fieldn
 @testset "parsefunction" begin
     @test structeq(MOIU.parsefunction(:x), MOIU.ParsedSingleVariable(:x))
     @test structeq(MOIU.parsefunction(:([x,y,z])), MOIU.ParsedVectorOfVariables([:x,:y,:z]))
-    @test structeq(MOIU.parsefunction(:(x + y + 2.0)), MOIU.ParsedScalarAffineFunction([:x,:y],[1.0,1.0],2.0))
-    @test structeq(MOIU.parsefunction(:(x + -3y + 2.0)), MOIU.ParsedScalarAffineFunction([:x,:y],[1.0,-3.0],2.0))
-    @test structeq(MOIU.parsefunction(:(2*x*y + y + 1.0)), MOIU.ParsedScalarQuadraticFunction([:y],[1.0],[:x],[:y],[2.0],1.0))
+    @test structeq(MOIU.parsefunction(:(x + y + 2.0)), MOIU.ParsedScalarAffineFunction(MOIU.ParsedScalarAffineTerm.([1.0,1.0],[:x,:y]), 2.0))
+    @test structeq(MOIU.parsefunction(:(x + -3y + 2.0)), MOIU.ParsedScalarAffineFunction(MOIU.ParsedScalarAffineTerm.([1.0,-3.0],[:x,:y]), 2.0))
+    @test structeq(MOIU.parsefunction(:(2*x*y + y + 1.0)), MOIU.ParsedScalarQuadraticFunction(MOIU.ParsedScalarAffineTerm.([1.0],[:y]),
+                                                                                              MOIU.ParsedScalarQuadraticTerm.([2.0],[:x],[:y]),
+                                                                                              1.0))
     @test_throws AssertionError MOIU.parsefunction(:(x - y))
 
-    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0])), MOIU.ParsedVectorAffineFunction([1,2,2],[:x,:x,:y],[1.0,2.0,1.0],[0.0,5.0]))
-    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0, 1*x*x])), MOIU.ParsedVectorQuadraticFunction([1,2,2],[:x,:x,:y],[1.0,2.0,1.0],[3],[:x],[:x],[2.0],[0.0,5.0,0.0]))
+    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0])), MOIU.ParsedVectorAffineFunction(MOIU.ParsedVectorAffineTerm.([1,2,2],MOIU.ParsedScalarAffineTerm.([1.0,2.0,1.0],[:x,:x,:y])),
+                                                                                         [0.0,5.0]))
+    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0, 1*x*x])), MOIU.ParsedVectorQuadraticFunction(MOIU.ParsedVectorAffineTerm.([1,2,2],MOIU.ParsedScalarAffineTerm.([1.0,2.0,1.0],[:x,:x,:y])),
+                                                                                                   MOIU.ParsedVectorQuadraticTerm.([3],MOIU.ParsedScalarQuadraticTerm.([2.0],[:x],[:x])),
+                                                                                                   [0.0,5.0,0.0]))
 
 end
 
@@ -75,7 +80,7 @@ end
         y = MOI.addvariable!(model)
         MOI.set!(model, MOI.VariableName(), x, "x")
         MOI.set!(model, MOI.VariableName(), y, "y")
-        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0], [x, y]), 1.0))
+        MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -2.0], [x, y]), 1.0))
         MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
         model2 = GeneralModel{Float64}()

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -2,20 +2,24 @@
 structeq(a::T, b::T) where {T} = all(f->getfield(a, f) == getfield(b, f), fieldnames(T))
 
 @testset "parsefunction" begin
-    @test structeq(MOIU.parsefunction(:x), MOIU.ParsedSingleVariable(:x))
-    @test structeq(MOIU.parsefunction(:([x,y,z])), MOIU.ParsedVectorOfVariables([:x,:y,:z]))
-    @test structeq(MOIU.parsefunction(:(x + y + 2.0)), MOIU.ParsedScalarAffineFunction(MOIU.ParsedScalarAffineTerm.([1.0,1.0],[:x,:y]), 2.0))
-    @test structeq(MOIU.parsefunction(:(x + -3y + 2.0)), MOIU.ParsedScalarAffineFunction(MOIU.ParsedScalarAffineTerm.([1.0,-3.0],[:x,:y]), 2.0))
-    @test structeq(MOIU.parsefunction(:(2*x*y + y + 1.0)), MOIU.ParsedScalarQuadraticFunction(MOIU.ParsedScalarAffineTerm.([1.0],[:y]),
-                                                                                              MOIU.ParsedScalarQuadraticTerm.([2.0],[:x],[:y]),
-                                                                                              1.0))
+    @test structeq(MOIU.parsefunction(:x),
+                   MOIU.ParsedSingleVariable(:x))
+    @test structeq(MOIU.parsefunction(:([x,y,z])),
+                   MOIU.ParsedVectorOfVariables([:x,:y,:z]))
+
+    @test structeq(MOIU.parsefunction(:(x + y + 2.0)),
+                   MOIU.ParsedScalarAffineFunction(MOIU.ParsedScalarAffineTerm.([1.0,1.0],[:x,:y]), 2.0))
+    @test structeq(MOIU.parsefunction(:(x + -3y + 2.0)),
+                   MOIU.ParsedScalarAffineFunction(MOIU.ParsedScalarAffineTerm.([1.0,-3.0],[:x,:y]), 2.0))
+    @test structeq(MOIU.parsefunction(:(2*x*y + y + 1.0)),
+                   MOIU.ParsedScalarQuadraticFunction(MOIU.ParsedScalarAffineTerm.([1.0],[:y]), MOIU.ParsedScalarQuadraticTerm.([2.0],[:x],[:y]), 1.0))
+
     @test_throws AssertionError MOIU.parsefunction(:(x - y))
 
-    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0])), MOIU.ParsedVectorAffineFunction(MOIU.ParsedVectorAffineTerm.([1,2,2],MOIU.ParsedScalarAffineTerm.([1.0,2.0,1.0],[:x,:x,:y])),
-                                                                                         [0.0,5.0]))
-    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0, 1*x*x])), MOIU.ParsedVectorQuadraticFunction(MOIU.ParsedVectorAffineTerm.([1,2,2],MOIU.ParsedScalarAffineTerm.([1.0,2.0,1.0],[:x,:x,:y])),
-                                                                                                   MOIU.ParsedVectorQuadraticTerm.([3],MOIU.ParsedScalarQuadraticTerm.([2.0],[:x],[:x])),
-                                                                                                   [0.0,5.0,0.0]))
+    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0])),
+                   MOIU.ParsedVectorAffineFunction(MOIU.ParsedVectorAffineTerm.([1,2,2],MOIU.ParsedScalarAffineTerm.([1.0,2.0,1.0],[:x,:x,:y])), [0.0,5.0]))
+    @test structeq(MOIU.parsefunction(:([x, 2x+y+5.0, 1*x*x])),
+                   MOIU.ParsedVectorQuadraticFunction(MOIU.ParsedVectorAffineTerm.([1,2,2],MOIU.ParsedScalarAffineTerm.([1.0,2.0,1.0],[:x,:x,:y])), MOIU.ParsedVectorQuadraticTerm.([3],MOIU.ParsedScalarQuadraticTerm.([2.0],[:x],[:x])), [0.0,5.0,0.0]))
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ MOIU.@model(Model,
     include("sets.jl")
     include("model.jl")
     include("universalfallback.jl")
-#    include("parser.jl")
+    include("parser.jl")
     include("mockoptimizer.jl")
     include("cachingoptimizer.jl")
     include("copy.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
 # It tests that the ConstraintPrimal value requested in the tests is consistent with the VariablePrimal
 @testset "MOI.Test" begin
     include("Test/config.jl")
-#    include("Test/unit.jl")
+    include("Test/unit.jl")
     include("Test/contlinear.jl")
     include("Test/contconic.jl")
     include("Test/contquadratic.jl")


### PR DESCRIPTION
The `Parsed*` function have also been updated to match the MOI versions.
The `parsedtoMOI` strategy is now a bit different, it recursively call `parsedtoMOI` to its field instead of `variabletoindex` so that `Parsed*Term` also get called `parsedtoMOI`.
