### PR TITLE
Add fullbridgeoptimizer function

### DIFF
--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -57,7 +57,7 @@ MOI.copy!(b::AbstractBridgeOptimizer, src::MOI.ModelLike; copynames=false) = MOI
 MOI.candelete(b::AbstractBridgeOptimizer, vi::VI) = MOI.candelete(b.model, vi)
 function MOI.candelete(b::AbstractBridgeOptimizer, ci::CI)
     if isbridged(b, typeof(ci))
-        MOI.candelete(b.bridged, ci) && MOI.candelete(b.model, bridge(b, ci))
+        MOI.candelete(b.bridged, ci) && MOI.candelete(b, bridge(b, ci))
     else
         MOI.candelete(b.model, ci)
     end
@@ -73,7 +73,7 @@ end
 MOI.delete!(b::AbstractBridgeOptimizer, vi::VI) = MOI.delete!(b.model, vi)
 function MOI.delete!(b::AbstractBridgeOptimizer, ci::CI)
     if isbridged(b, typeof(ci))
-        MOI.delete!(b.model, bridge(b, ci))
+        MOI.delete!(b, bridge(b, ci))
         delete!(b.bridges, ci)
         MOI.delete!(b.bridged, ci)
     else
@@ -156,7 +156,7 @@ function MOI.canget(b::AbstractBridgeOptimizer, attr::InstanceConstraintAttribut
 end
 function MOI.canget(b::AbstractBridgeOptimizer, attr::SolverConstraintAttribute, ci::Type{CI{F, S}}) where {F, S}
     if isbridged(b, F, S)
-        MOI.canget(b.model, attr, bridgetype(b, F, S))
+        MOI.canget(b, attr, bridgetype(b, F, S))
     else
         MOI.canget(b.model, attr, ci)
     end
@@ -170,7 +170,7 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::InstanceConstraintAttribute, 
 end
 function MOI.get(b::AbstractBridgeOptimizer, attr::SolverConstraintAttribute, ci::CI)
     if isbridged(b, typeof(ci))
-        MOI.get(b.model, attr, bridge(b, ci))
+        MOI.get(b, attr, bridge(b, ci))
     else
         MOI.get(b.model, attr, ci)
     end
@@ -199,7 +199,7 @@ function MOI.addconstraint!(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
     if isbridged(b, typeof(f), typeof(s))
         ci = MOI.addconstraint!(b.bridged, f, s)
         @assert !haskey(b.bridges, ci)
-        b.bridges[ci] = bridgetype(b, typeof(f), typeof(s))(b.model, f, s)
+        b.bridges[ci] = bridgetype(b, typeof(f), typeof(s))(b, f, s)
         ci
     else
         MOI.addconstraint!(b.model, f, s)
@@ -207,14 +207,14 @@ function MOI.addconstraint!(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
 end
 function MOI.canmodifyconstraint(b::AbstractBridgeOptimizer, ci::CI, change)
     if isbridged(b, typeof(ci))
-       MOI.canmodifyconstraint(b.bridged, ci, change) && MOI.canmodifyconstraint(b.model, MOIB.bridge(b, ci), change)
+       MOI.canmodifyconstraint(b.bridged, ci, change) && MOI.canmodifyconstraint(b, MOIB.bridge(b, ci), change)
     else
         MOI.canmodifyconstraint(b.model, ci, change)
     end
 end
 function MOI.modifyconstraint!(b::AbstractBridgeOptimizer, ci::CI, change)
     if isbridged(b, typeof(ci))
-        MOI.modifyconstraint!(b.model, bridge(b, ci), change)
+        MOI.modifyconstraint!(b, bridge(b, ci), change)
         MOI.modifyconstraint!(b.bridged, ci, change)
     else
         MOI.modifyconstraint!(b.model, ci, change)

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -124,6 +124,10 @@ end
 MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints) = MOI.canget(b.model, attr) && MOI.canget(b.bridged, attr)
 function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints)
     list_of_types = [MOI.get(b.model, attr); MOI.get(b.bridged, attr)]
+    # Some constraint types show up in `list_of_types` while all the constraints
+    # of that type have been created by bridges and not by the user.
+    # The code in `NumberOfConstraints` takes care of removing these constraints
+    # from the counter so we can rely on it to remove these constraint types.
     types_to_remove = find(iszero.(map(FS -> MOI.get(b, MOI.NumberOfConstraints{FS...}()), list_of_types)))
     deleteat!(list_of_types, types_to_remove)
     list_of_types

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -124,7 +124,7 @@ end
 MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints) = MOI.canget(b.model, attr) && MOI.canget(b.bridged, attr)
 function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints)
     list_of_types = [MOI.get(b.model, attr); MOI.get(b.bridged, attr)]
-    # Some constraint types show up in `list_of_types` while all the constraints
+    # Some constraint types show up in `list_of_types` even when all the constraints
     # of that type have been created by bridges and not by the user.
     # The code in `NumberOfConstraints` takes care of removing these constraints
     # from the counter so we can rely on it to remove these constraint types.

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -122,11 +122,11 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.NumberOfConstraints{F, S}
     end
 end
 MOI.canget(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints) = MOI.canget(b.model, attr) && MOI.canget(b.bridged, attr)
-_noc(b, fs) = MOI.get(b, MOI.NumberOfConstraints{fs...}())
 function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ListOfConstraints)
-    loc = [MOI.get(b.model, attr); MOI.get(b.bridged, attr)]
-    rm = find(iszero.(_noc.(b, loc)))
-    deleteat!(loc, rm)
+    list_of_types = [MOI.get(b.model, attr); MOI.get(b.bridged, attr)]
+    types_to_remove = find(iszero.(map(FS -> MOI.get(b, MOI.NumberOfConstraints{FS...}()), list_of_types)))
+    deleteat!(list_of_types, types_to_remove)
+    list_of_types
 end
 for f in (:canget, :canset, :get, :get!)
     @eval begin

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -129,6 +129,7 @@ MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, No
         config = MOIT.TestConfig()
         MOIT.rootdett1vtest(fullbridgedmock, config)
         MOIT.rootdett1ftest(fullbridgedmock, config)
+        # Dual is not yet implemented for RootDet and GeoMean bridges
         @test !MOI.canget(fullbridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle})
         ci = first(MOI.get(fullbridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
         @test !MOI.canmodifyconstraint(fullbridgedmock, ci, MOI.VectorAffineFunction{Float64})
@@ -192,6 +193,7 @@ end
         bridgedmock = MOIB.GeoMean{Float64}(mock)
         MOIT.geomean1vtest(bridgedmock, config)
         MOIT.geomean1ftest(bridgedmock, config)
+        # Dual is not yet implemented for GeoMean bridge
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.GeometricMeanCone})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
         @test !MOI.canmodifyconstraint(bridgedmock, ci, MOI.VectorAffineFunction{Float64})
@@ -230,6 +232,7 @@ end
         mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [0, 1, 0, 1, 1, 0, 1, 0, 0])
         MOIT.logdett1vtest(bridgedmock, config)
         MOIT.logdett1ftest(bridgedmock, config)
+        # Dual is not yet implemented for LogDet bridge
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle}()))
         @test !MOI.canmodifyconstraint(bridgedmock, ci, MOI.VectorAffineFunction{Float64})
@@ -241,6 +244,7 @@ end
         mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1, 1, 0, 1, 1, 0, 1])
         MOIT.rootdett1vtest(bridgedmock, config)
         MOIT.rootdett1ftest(bridgedmock, config)
+        # Dual is not yet implemented for RootDet bridge
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
         @test !MOI.canmodifyconstraint(bridgedmock, ci, MOI.VectorAffineFunction{Float64})

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -70,7 +70,7 @@ end
 end
 
 # Model not supporting RotatedSecondOrderCone
-MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, PositiveSemidefiniteConeTriangle) () (SingleVariable,) (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
+MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, ExponentialCone, PositiveSemidefiniteConeTriangle) () (SingleVariable,) (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
 
 @testset "LazyBridgeOptimizer" begin
     const mock = MOIU.MockOptimizer(NoRSOCModel{Float64}())
@@ -103,6 +103,10 @@ MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, No
 
     @testset "Continuous Linear" begin
         MOIT.contlineartest(bridgedmock, MOIT.TestConfig(solve=false))
+    end
+
+    @testset "Continuous Conic" begin
+        MOIT.contconictest(MOIB.fullbridgeoptimizer(mock, Float64), MOIT.TestConfig(solve=false), ["logdets", "rootdets", "psds"])
     end
 end
 


### PR DESCRIPTION
This would allow JuMP to transform
https://github.com/JuliaOpt/JuMP.jl/blob/a59a431419f885a0e11c2838b50bea0e63061647/src/JuMP.jl#L164
into
```julia
m.moibackend = MOIB.fullbridgeoptimizer(MOIU.CachingOptimizer(MOIU.UniversalFallback(JuMPMOIModel{Float64}()), mode == Automatic ? MOIU.Automatic : MOIU.Manual), Float64)
```
and not have to explicitly add each MOI bridge.
It would be nice if this could also be part of MOI v0.3 :)