### PR TITLE
Basic tests to catch edge cases

### DIFF
--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -149,20 +149,17 @@ function solve_qcp_edge_cases(model::MOI.ModelLike, config::TestConfig)
         MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
         MOI.set!(model,
             MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-            MOI.ScalarAffineFunction{Float64}(
-                MOI.ScalarAffineTerm{Float64}.([1.0, 2.0], x),
-                0.0
-            )
+            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0], x), 0.0)
         )
-        MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.GreaterThan{Float64}(0.5))
-        MOI.addconstraint!(model, MOI.SingleVariable(x[2]), MOI.GreaterThan{Float64}(0.5))
+        MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.GreaterThan(0.5))
+        MOI.addconstraint!(model, MOI.SingleVariable(x[2]), MOI.GreaterThan(0.5))
         MOI.addconstraint!(model,
-            MOI.ScalarQuadraticFunction{Float64}(
-                MOI.ScalarAffineTerm{Float64}.([1.0], [x[2]]),  # affine terms
-                MOI.ScalarQuadraticTerm{Float64}.([2.0, 2.0], [x[1], x[1]], [x[1], x[1]]),  # quad
+            MOI.ScalarQuadraticFunction(
+                MOI.ScalarAffineTerm.([1.0], [x[2]]),  # affine terms
+                MOI.ScalarQuadraticTerm.([2.0, 2.0], [x[1], x[1]], [x[1], x[1]]),  # quad
                 0.0  # constant
             ),
-            MOI.LessThan{Float64}(1.0)
+            MOI.LessThan(1.0)
         )
         test_model_solution(model, config;
             objective_value   = 1.5,
@@ -176,23 +173,20 @@ function solve_qcp_edge_cases(model::MOI.ModelLike, config::TestConfig)
         MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
         MOI.set!(model,
             MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-            MOI.ScalarAffineFunction{Float64}(
-                MOI.ScalarAffineTerm{Float64}.([1.0, 2.0], x),
-                0.0
-            )
+            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0], x), 0.0)
         )
         MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.GreaterThan{Float64}(0.5))
         MOI.addconstraint!(model, MOI.SingleVariable(x[2]), MOI.GreaterThan{Float64}(0.5))
         MOI.addconstraint!(model,
-            MOI.ScalarQuadraticFunction{Float64}(
+            MOI.ScalarQuadraticFunction(
                 MOI.ScalarAffineTerm{Float64}[],  # affine terms
-                MOI.ScalarQuadraticTerm{Float64}.(
+                MOI.ScalarQuadraticTerm.(
                     [ 2.0, 0.25, 0.25,  0.5,  2.0],
                     [x[1], x[1], x[2], x[1], x[2]],
                     [x[1], x[2], x[1], x[2], x[2]]),  # quad
                 0.0  # constant
             ),
-            MOI.LessThan{Float64}(1.0)
+            MOI.LessThan(1.0)
         )
         test_model_solution(model, config;
             objective_value   = 0.5 + (√13-1)/2,
@@ -205,7 +199,9 @@ unittests["solve_qcp_edge_cases"] = solve_qcp_edge_cases
 """
     solve_affine_deletion_edge_cases(model::MOI.ModelLike, config::TestConfig)
 
-Test various edge cases relating to deleting affine constraints.
+Test various edge cases relating to deleting affine constraints. This requires
+    + ScalarAffineFunction-in-LessThan; and
+    + VectorAffineFunction-in-Nonpositives.
 
 If `config.solve=true` confirm that it solves correctly.
 """

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -158,15 +158,15 @@ function solve_qp_edge_cases(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     x = MOI.addvariables!(model, 2)
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
-    MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.GreaterThan{Float64}(1.0))
-    MOI.addconstraint!(model, MOI.SingleVariable(x[2]), MOI.GreaterThan{Float64}(2.0))
+    MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.GreaterThan(1.0))
+    MOI.addconstraint!(model, MOI.SingleVariable(x[2]), MOI.GreaterThan(2.0))
 
     # min x^2 + y^2 | x>=1, y>=2
     MOI.set!(model,
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
-        MOI.ScalarQuadraticFunction{Float64}(
+        MOI.ScalarQuadraticFunction(
             MOI.ScalarAffineTerm{Float64}[],  # affine terms
-            MOI.ScalarQuadraticTerm{Float64}.([2.0, 2.0], x, x),  # quad
+            MOI.ScalarQuadraticTerm.([2.0, 2.0], x, x),  # quad
             0.0  # constant
         )
     )
@@ -179,9 +179,9 @@ function solve_qp_edge_cases(model::MOI.ModelLike, config::TestConfig)
     # min x^2 + x^2 | x>=1, y>=2
     MOI.set!(model,
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
-        MOI.ScalarQuadraticFunction{Float64}(
+        MOI.ScalarQuadraticFunction(
             MOI.ScalarAffineTerm{Float64}[],  # affine terms
-            MOI.ScalarQuadraticTerm{Float64}.([2.0, 2.0], [x[1], x[1]], [x[1], x[1]]),  # quad
+            MOI.ScalarQuadraticTerm.([2.0, 2.0], [x[1], x[1]], [x[1], x[1]]),  # quad
             0.0  # constant
         )
     )
@@ -194,9 +194,9 @@ function solve_qp_edge_cases(model::MOI.ModelLike, config::TestConfig)
     # min x^2 + 0.25x*y + 0.25y*x + 0.5x*y + y^2 | x>=1, y>=2
     MOI.set!(model,
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
-        MOI.ScalarQuadraticFunction{Float64}(
+        MOI.ScalarQuadraticFunction(
             MOI.ScalarAffineTerm{Float64}[],  # affine terms
-            MOI.ScalarQuadraticTerm{Float64}.(
+            MOI.ScalarQuadraticTerm.(
                 [ 2.0, 0.25, 0.25,  0.5,  2.0],
                 [x[1], x[1], x[2], x[1], x[2]],
                 [x[1], x[2], x[1], x[2], x[2]]),  # quad

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -145,3 +145,67 @@ function solve_singlevariable_obj(model::MOI.ModelLike, config::TestConfig)
     end
 end
 unittests["solve_singlevariable_obj"] = solve_singlevariable_obj
+
+"""
+    solve_qp_edge_cases(model::MOI.ModelLike, config::TestConfig)
+
+Test various edge cases relating to quadratic programs (i.e., with a quadratic
+objective function).
+
+If `config.solve=true` confirm that it solves correctly.
+"""
+function solve_qp_edge_cases(model::MOI.ModelLike, config::TestConfig)
+    MOI.empty!(model)
+    x = MOI.addvariables!(model, 2)
+    MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.GreaterThan{Float64}(1.0))
+    MOI.addconstraint!(model, MOI.SingleVariable(x[2]), MOI.GreaterThan{Float64}(2.0))
+
+    # min x^2 + y^2 | x>=1, y>=2
+    MOI.set!(model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[],  # affine terms
+            MOI.ScalarQuadraticTerm{Float64}.([2.0, 2.0], x, x),  # quad
+            0.0  # constant
+        )
+    )
+    test_model_solution(model, config;
+        objective_value   = 5.0,
+        variable_primal   = [(x[1], 1.0), (x[2], 2.0)]
+    )
+
+    # duplicate terms on diagonal
+    # min x^2 + x^2 | x>=1, y>=2
+    MOI.set!(model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[],  # affine terms
+            MOI.ScalarQuadraticTerm{Float64}.([2.0, 2.0], [x[1], x[1]], [x[1], x[1]]),  # quad
+            0.0  # constant
+        )
+    )
+    test_model_solution(model, config;
+        objective_value   = 2.0,
+        variable_primal   = [(x[1], 1.0)]
+    )
+
+    # duplicate terms on off-diagonal
+    # min x^2 + 0.25x*y + 0.25y*x + 0.5x*y + y^2 | x>=1, y>=2
+    MOI.set!(model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction{Float64}(
+            MOI.ScalarAffineTerm{Float64}[],  # affine terms
+            MOI.ScalarQuadraticTerm{Float64}.(
+                [ 2.0, 0.25, 0.25,  0.5,  2.0],
+                [x[1], x[1], x[2], x[1], x[2]],
+                [x[1], x[2], x[1], x[2], x[2]]),  # quad
+            0.0  # constant
+        )
+    )
+    test_model_solution(model, config;
+        objective_value   = 7.0,
+        variable_primal   = [(x[1], 1.0), (x[2], 2.0)]
+    )
+end
+unittests["solve_qp_edge_cases"] = solve_qp_edge_cases

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -192,18 +192,3 @@ function solve_with_lowerbound(model::MOI.ModelLike, config::TestConfig)
     end
 end
 unittests["solve_with_lowerbound"] = solve_with_lowerbound
-
-"""
-    multiple_variable_types(model::MOI.ModelLike, config::TestConfig)
-
-
-"""
-function multiple_variable_types(model::MOI.ModelLike, config::TestConfig)
-    MOI.empty!(model)
-    x = MOI.addvariable!(m)
-    MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.ZeroOne())
-    @test_throws Exception MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.Integer())
-    @test_throws Exception MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.Semiinteger(3.0,4.0))
-    @test_throws Exception MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.Semicontinuous(3.0,4.0))
-end
-unittests["multiple_variable_types"] = multiple_variable_types

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -192,3 +192,18 @@ function solve_with_lowerbound(model::MOI.ModelLike, config::TestConfig)
     end
 end
 unittests["solve_with_lowerbound"] = solve_with_lowerbound
+
+"""
+    multiple_variable_types(model::MOI.ModelLike, config::TestConfig)
+
+
+"""
+function multiple_variable_types(model::MOI.ModelLike, config::TestConfig)
+    MOI.empty!(model)
+    x = MOI.addvariable!(m)
+    MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.ZeroOne())
+    @test_throws Exception MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.Integer())
+    @test_throws Exception MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.Semiinteger(3.0,4.0))
+    @test_throws Exception MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.Semicontinuous(3.0,4.0))
+end
+unittests["multiple_variable_types"] = multiple_variable_types

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -16,7 +16,9 @@ end
         "solve_affine_lessthan",
         "solve_affine_greaterthan",
         "solve_affine_equalto",
-        "solve_affine_interval"
+        "solve_affine_interval",
+        "solve_qp_edge_cases",
+        "solve_qcp_edge_cases"
         ])
 
     @testset "solve_blank_obj" begin
@@ -120,4 +122,37 @@ end
         )
         MOIT.solve_affine_interval(mock, config)
     end
+
+    @testset "solve_qcp_edge_cases" begin
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success,
+                (MOI.FeasiblePoint, [0.5, 0.5])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success,
+                (MOI.FeasiblePoint, [0.5, (√13 - 1)/4])
+            )
+        )
+        MOIT.solve_qcp_edge_cases(mock, config)
+    end
+
+    @testset "solve_qp_edge_cases" begin
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success,
+                (MOI.FeasiblePoint, [1.0, 2.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success,
+                (MOI.FeasiblePoint, [1.0, 2.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success,
+                (MOI.FeasiblePoint, [1.0, 2.0])
+            )
+        )
+        MOIT.solve_qp_edge_cases(mock, config)
+    end
+
 end

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -18,7 +18,8 @@ end
         "solve_affine_equalto",
         "solve_affine_interval",
         "solve_qp_edge_cases",
-        "solve_qcp_edge_cases"
+        "solve_qcp_edge_cases",
+        "solve_affine_deletion_edge_cases"
         ])
 
     @testset "solve_blank_obj" begin
@@ -155,4 +156,24 @@ end
         MOIT.solve_qp_edge_cases(mock, config)
     end
 
+    @testset "solve_affine_deletion_edge_cases" begin
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [0.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [0.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [1.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [1.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [2.0])
+            )
+        )
+        MOIT.solve_affine_deletion_edge_cases(mock, config)
+    end
 end


### PR DESCRIPTION
- Relating to ScalarQuadraticFunctions:
(1) duplicate terms on the diagonal; and
(2) duplicate terms on the off-diagonal, including duplicates of elements at locations (i,j) and (j,i).
- Deleting mixtures of scalaraffine and vectoraffine functions.