### PR TITLE
Add type parameter for CachingOptimizer

### DIFF
--- a/perf/cachingoptimizer.jl
+++ b/perf/cachingoptimizer.jl
@@ -1,4 +1,6 @@
-# See https://github.com/JuliaOpt/MathOptInterface.jl/issues/321 and https://github.com/JuliaOpt/MathOptInterface.jl/pull/323
+# See https://github.com/JuliaOpt/MathOptInterface.jl/issues/321,
+#     https://github.com/JuliaOpt/MathOptInterface.jl/pull/323 and
+#     https://github.com/JuliaOpt/MathOptInterface.jl/pull/390
 
 using BenchmarkTools
 using MathOptInterface
@@ -10,7 +12,7 @@ optimizer = MOIU.MockOptimizer(Model{Float64}())
 caching_optimizer = MOIU.CachingOptimizer(Model{Float64}(), optimizer)
 MOIU.resetoptimizer!(caching_optimizer) # detach optimizer
 v = MOI.addvariables!(caching_optimizer, 2)
-cf = MOI.ScalarAffineFunction(v, [0.0, 0.0], 0.0)
+cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0, 0.0], v), 0.0)
 c = MOI.addconstraint!(caching_optimizer, cf, MOI.Interval(-Inf, 1.0))
 @btime MOI.modifyconstraint!($caching_optimizer, $c, $(MOI.Interval(0.0, 2.0)))
 MOIU.attachoptimizer!(caching_optimizer)

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -22,9 +22,9 @@ A `CachingOptimizer` has two modes of operation (`CachingOptimizerMode`):
 - `Manual`: The only methods that change the state of the `CachingOptimizer` are [`resetoptimizer!`](@ref), [`dropoptimizer!`](@ref), and [`attachoptimizer!`](@ref). Attempting to perform an operation in the incorrect state results in an error.
 - `Automatic`: The `CachingOptimizer` changes its state when necessary. For example, `optimize!` will automatically call `attachoptimizer!` (an optimizer must have been previously set). Attempting to add a constraint or perform a modification not supported by the optimizer results in a drop to `EmptyOptimizer` mode.
 """
-mutable struct CachingOptimizer{OT, MT<:MOI.ModelLike} <: MOI.AbstractOptimizer
-    optimizer::OT
-    model_cache::MT
+mutable struct CachingOptimizer{OptimizerType, ModelType<:MOI.ModelLike} <: MOI.AbstractOptimizer
+    optimizer::OptimizerType
+    model_cache::ModelType
     state::CachingOptimizerState
     mode::CachingOptimizerMode
     model_to_optimizer_map::IndexMap

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -23,7 +23,7 @@ A `CachingOptimizer` has two modes of operation (`CachingOptimizerMode`):
 - `Automatic`: The `CachingOptimizer` changes its state when necessary. For example, `optimize!` will automatically call `attachoptimizer!` (an optimizer must have been previously set). Attempting to add a constraint or perform a modification not supported by the optimizer results in a drop to `EmptyOptimizer` mode.
 """
 mutable struct CachingOptimizer{OptimizerType, ModelType<:MOI.ModelLike} <: MOI.AbstractOptimizer
-    optimizer::OptimizerType
+    optimizer::Union{Nothing, OptimizerType}
     model_cache::ModelType
     state::CachingOptimizerState
     mode::CachingOptimizerMode
@@ -35,7 +35,7 @@ mutable struct CachingOptimizer{OptimizerType, ModelType<:MOI.ModelLike} <: MOI.
 end
 
 function CachingOptimizer(model_cache::MOI.ModelLike, mode::CachingOptimizerMode)
-    CachingOptimizer{Union{Nothing,MOI.AbstractOptimizer}, typeof(model_cache)}(nothing, model_cache, NoOptimizer, mode, IndexMap(), IndexMap())
+    CachingOptimizer{MOI.AbstractOptimizer, typeof(model_cache)}(nothing, model_cache, NoOptimizer, mode, IndexMap(), IndexMap())
 end
 
 """
@@ -76,7 +76,7 @@ mode(m::CachingOptimizer) = m.mode
 Sets or resets `m` to have the given empty optimizer. Can be called
 from any state. The `CachingOptimizer` will be in state `EmptyOptimizer` after the call.
 """
-function resetoptimizer!(m::CachingOptimizer{Union{Nothing,MOI.AbstractOptimizer}}, optimizer::MOI.AbstractOptimizer)
+function resetoptimizer!(m::CachingOptimizer, optimizer::MOI.AbstractOptimizer)
     @assert MOI.isempty(optimizer)
     m.optimizer = optimizer
     m.state = EmptyOptimizer
@@ -104,7 +104,7 @@ end
 Drops the optimizer, if one is present. Can be called from any state.
 The `CachingOptimizer` will be in state `NoOptimizer` after the call.
 """
-function dropoptimizer!(m::CachingOptimizer{Union{Nothing,MOI.AbstractOptimizer}})
+function dropoptimizer!(m::CachingOptimizer)
     m.optimizer = nothing
     m.state = NoOptimizer
     return

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -45,8 +45,9 @@ Creates an `CachingOptimizer` in `Automatic` mode, with the optimizer `optimizer
 The model_cache manager returned behaves like an `AbstractOptimizer` as long as no
 `CachingOptimizer`-specific functions (e.g. `resetoptimizer!`) are called on it.
 The type of the optimizer returned is `CachingOptimizer{typeof(optimizer),
-typeof(model_cache)}` so it does not support the function `dropoptimizer!`
-nor the method `resetoptimizer!(::CachingOptimizer, optimizer)`.
+typeof(model_cache)}` so it does not support the function
+`resetoptimizer!(::CachingOptimizer, new_optimizer)` if the type of
+`new_optimizer` is different from the type of `optimizer`.
 """
 function CachingOptimizer(model_cache::MOI.ModelLike, optimizer::MOI.AbstractOptimizer)
     @assert MOI.isempty(model_cache)

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -171,8 +171,6 @@ end
         @test MOI.isempty(m)
         @test MOIU.state(m) == MOIU.AttachedOptimizer
         @test MOIU.mode(m) == MOIU.Automatic
-        @test_throws MethodError MOIU.dropoptimizer!(m)
-        @test_throws MethodError MOIU.resetoptimizer!(m, s)
     end
     @testset "Non-empty optimizer" begin
         s = MOIU.MockOptimizer(ModelForMock{Float64}())

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -167,9 +167,12 @@ end
         s = MOIU.MockOptimizer(ModelForMock{Float64}())
         model = ModelForCachingOptimizer{Float64}()
         m = MOIU.CachingOptimizer(model, s)
+        @test m isa MOIU.CachingOptimizer{typeof(s), typeof(model)}
         @test MOI.isempty(m)
         @test MOIU.state(m) == MOIU.AttachedOptimizer
         @test MOIU.mode(m) == MOIU.Automatic
+        @test_throws MethodError MOIU.dropoptimizer!(m)
+        @test_throws MethodError MOIU.resetoptimizer!(m, s)
     end
     @testset "Non-empty optimizer" begin
         s = MOIU.MockOptimizer(ModelForMock{Float64}())


### PR DESCRIPTION
This PR adds a type parameter for the optimizer of `CachingOptimizer`. It adds this type parameters in the first place as it will be more useful than the second one (see e.g. `dropoptimizer!`). It also changes the order of the cache and the optimizer fields for consistency.
Note that it does not implement the idea of https://github.com/JuliaOpt/MathOptInterface.jl/issues/321#issuecomment-382729573 of removing the possibility to have no optimizer or to change the optimizer.
Indeed, this would require JuMP to handle these cases and I initially thought that this was the solution because I didn't have the idea of simply using the non concrete type parameter `Union{Nothing, MOI.AbstractOptimizer}` in the case where we want to be able to drop the optimizer and to change it and use the concrete optimizer type when we don't want to change it and the type instability becomes the bottleneck (e.g. https://github.com/JuliaOpt/MathOptInterface.jl/issues/321).

We can now make a similar change in JuMP. Have a parameter for the `moibackend` type that the user can set it to the concrete type of the optimizer to have no overhead (but loosing the features of changing optimizer, droping it, ...)

## Benchmarks
See https://github.com/JuliaOpt/MathOptInterface.jl/pull/323 for benchmarks before this change

With a CachingOptimizer with concrete field type for the optimizer field (i.e. `MockOptimizer{Model{Float64}}`):
```
v0.6
 36.591 ns (4 allocations: 112 bytes)
148.012 ns (8 allocations: 224 bytes)
 24.322 ns (3 allocations: 96 bytes)
 24.871 ns (3 allocations: 96 bytes)
v0.7
 12.130 ns (1 allocation: 48 bytes)
103.417 ns (3 allocations: 112 bytes)
 13.545 ns (1 allocation: 48 bytes)
 11.785 ns
```
With a CachingOptimizer with `Union{Nothing, OptimizerType}` with concrete `OptimizerType` for the `optimizer field:
```
v0.6
 40.083 ns (4 allocations: 112 bytes)
177.939 ns (11 allocations: 288 bytes)
 29.122 ns (3 allocations: 96 bytes)
 25.401 ns (3 allocations: 96 bytes)
v0.7
 13.049 ns (1 allocation: 48 bytes)
109.670 ns (3 allocations: 112 bytes)
 11.501 ns (1 allocation: 48 bytes)
 12.421 ns (1 allocation: 48 bytes)
```

The overhead of the union with `Void` is negligible in v0.7 as suggested by https://github.com/JuliaOpt/MathOptInterface.jl/pull/390#discussion_r195424172 so it seems cleaner to use it

Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/321