### PR TITLE
Fix names for CachingOptimizer

### DIFF
--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -41,14 +41,12 @@ function solve_affine_lessthan(model::MOI.ModelLike, config::TestConfig)
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.5,
-            variable_primal   = [(x, 0.5)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, -0.5)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.5,
+        variable_primal   = [(x, 0.5)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, -0.5)]
+    )
 end
 unittests["solve_affine_lessthan"] = solve_affine_lessthan
 
@@ -68,14 +66,12 @@ function solve_affine_greaterthan(model::MOI.ModelLike, config::TestConfig)
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.5,
-            variable_primal   = [(x, 0.5)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, 0.5)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.5,
+        variable_primal   = [(x, 0.5)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, 0.5)]
+    )
 end
 unittests["solve_affine_greaterthan"] = solve_affine_greaterthan
 
@@ -95,14 +91,12 @@ function solve_affine_equalto(model::MOI.ModelLike, config::TestConfig)
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.5,
-            variable_primal   = [(x, 0.5)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, 0.5)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.5,
+        variable_primal   = [(x, 0.5)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, 0.5)]
+    )
 end
 unittests["solve_affine_equalto"] = solve_affine_equalto
 
@@ -122,14 +116,12 @@ function solve_affine_interval(model::MOI.ModelLike, config::TestConfig)
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}}, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 6.0,
-            variable_primal   = [(x, 2.0)],
-            constraint_primal = [(c, 4.0)],
-            constraint_dual   = [(c, -1.5)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 6.0,
+        variable_primal   = [(x, 2.0)],
+        constraint_primal = [(c, 4.0)],
+        constraint_dual   = [(c, -1.5)]
+    )
 end
 unittests["solve_affine_interval"] = solve_affine_interval
 
@@ -218,7 +210,7 @@ function solve_affine_deletion_edge_cases(model::MOI.ModelLike, config::TestConf
     # test adding a VectorAffineFunction -in- LessThan
     c1 = MOI.addconstraint!(model, vaf, MOI.Nonpositives(1))
     test_model_solution(model, config; objective_value = 0.0,
-        constraint_primal = [(c1, [0.0])]
+                        constraint_primal = [(c1, [0.0])]
     )
     # test adding a ScalarAffineFunction -in- LessThan
     c2 = MOI.addconstraint!(model, saf, MOI.LessThan(1.0))

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -16,26 +16,22 @@ function solve_set_singlevariable_lessthan(model::MOI.ModelLike, config::TestCon
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 1.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, -1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 1.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, -1.0)]
+    )
     @test MOI.canset(model, MOI.ConstraintSet(), typeof(c))
     MOI.set!(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
     @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
     @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 2.0,
-            variable_primal   = [(x, 2.0)],
-            constraint_primal = [(c, 2.0)],
-            constraint_dual   = [(c, -1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 2.0,
+        variable_primal   = [(x, 2.0)],
+        constraint_primal = [(c, 2.0)],
+        constraint_dual   = [(c, -1.0)]
+    )
 end
 modificationtests["solve_set_singlevariable_lessthan"] = solve_set_singlevariable_lessthan
 
@@ -55,28 +51,24 @@ function solve_transform_singlevariable_lessthan(model::MOI.ModelLike, config::T
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 1.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, -1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 1.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, -1.0)]
+    )
     @test !MOI.cantransform(model, c, MOI.LessThan{Float64})
     @test MOI.cantransform(model, c, MOI.GreaterThan{Float64})
     c2 = MOI.transform!(model, c, MOI.GreaterThan(2.0))
     @test !MOI.isvalid(model, c)
     @test MOI.isvalid(model, c2)
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 2.0,
-            variable_primal   = [(x, 2.0)],
-            constraint_primal = [(c2, 2.0)],
-            constraint_dual   = [(c2, 1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 2.0,
+        variable_primal   = [(x, 2.0)],
+        constraint_primal = [(c2, 2.0)],
+        constraint_dual   = [(c2, 1.0)]
+    )
 end
 modificationtests["solve_transform_singlevariable_lessthan"] = solve_transform_singlevariable_lessthan
 
@@ -96,26 +88,22 @@ function solve_set_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConfi
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 1.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, -1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 1.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, -1.0)]
+    )
     @test MOI.canset(model, MOI.ConstraintSet(), typeof(c))
     MOI.set!(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
     @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
     @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 2.0,
-            variable_primal   = [(x, 2.0)],
-            constraint_primal = [(c, 2.0)],
-            constraint_dual   = [(c, -1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 2.0,
+        variable_primal   = [(x, 2.0)],
+        constraint_primal = [(c, 2.0)],
+        constraint_dual   = [(c, -1.0)]
+    )
 end
 modificationtests["solve_set_scalaraffine_lessthan"] = solve_set_scalaraffine_lessthan
 
@@ -135,24 +123,20 @@ function solve_coef_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConf
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 1.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, -1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 1.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, -1.0)]
+    )
     @test MOI.canmodify(model, typeof(c), MOI.ScalarCoefficientChange{Float64})
     MOI.modify!(model, c, MOI.ScalarCoefficientChange(x, 2.0))
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.5,
-            variable_primal   = [(x, 0.5)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, -0.5)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.5,
+        variable_primal   = [(x, 0.5)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, -0.5)]
+    )
 end
 modificationtests["solve_coef_scalaraffine_lessthan"] = solve_coef_scalaraffine_lessthan
 
@@ -172,14 +156,12 @@ function solve_func_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConf
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 1.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, -1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 1.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, -1.0)]
+    )
     @test MOI.canset(model, MOI.ConstraintFunction(), typeof(c))
     MOI.set!(model, MOI.ConstraintFunction(), c,
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(2.0, x)], 0.0)
@@ -187,14 +169,12 @@ function solve_func_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConf
     @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
     foo = MOI.get(model, MOI.ConstraintFunction(), c)
     @test foo ≈ MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(2.0, x)], 0.0)
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.5,
-            variable_primal   = [(x, 0.5)],
-            # constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, -0.5)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.5,
+        variable_primal   = [(x, 0.5)],
+        # constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, -0.5)]
+    )
 end
 modificationtests["solve_func_scalaraffine_lessthan"] = solve_func_scalaraffine_lessthan
 
@@ -222,22 +202,18 @@ function solve_const_vectoraffine_nonpos(model::MOI.ModelLike, config::TestConfi
             ),
             MOI.Nonpositives(2)
         )
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.0,
-            variable_primal   = [(x, 0.0), (y, 0.0)],
-            constraint_primal = [(c, [0.0, 0.0])]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.0,
+        variable_primal   = [(x, 0.0), (y, 0.0)],
+        constraint_primal = [(c, [0.0, 0.0])]
+    )
     @test MOI.canmodify(model, typeof(c), MOI.VectorConstantChange{Float64})
     MOI.modify!(model, c, MOI.VectorConstantChange([-1.0, -1.5]))
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 2.5,
-            variable_primal   = [(x, 1.0), (y, 0.75)],
-            constraint_primal = [(c, [0.0, 0.0])]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 2.5,
+        variable_primal   = [(x, 1.0), (y, 0.75)],
+        constraint_primal = [(c, [0.0, 0.0])]
+    )
 end
 modificationtests["solve_const_vectoraffine_nonpos"] = solve_const_vectoraffine_nonpos
 
@@ -264,22 +240,18 @@ function solve_multirow_vectoraffine_nonpos(model::MOI.ModelLike, config::TestCo
             ),
             MOI.Nonpositives(2)
         )
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.5,
-            variable_primal   = [(x, 0.5)],
-            constraint_primal = [(c, [-0.5, 0.0])]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.5,
+        variable_primal   = [(x, 0.5)],
+        constraint_primal = [(c, [-0.5, 0.0])]
+    )
     @test MOI.canmodify(model, typeof(c), MOI.MultirowChange{Float64})
     MOI.modify!(model, c, MOI.MultirowChange(x, [(1,4.0), (2,3.0)]))
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.25,
-            variable_primal   = [(x, 0.25)],
-            constraint_primal = [(c, [0.0, -0.25])]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.25,
+        variable_primal   = [(x, 0.25)],
+        constraint_primal = [(c, [0.0, -0.25])]
+    )
 end
 modificationtests["solve_multirow_vectoraffine_nonpos"] = solve_multirow_vectoraffine_nonpos
 
@@ -297,12 +269,10 @@ function solve_const_scalar_objective(model::MOI.ModelLike, config::TestConfig)
         c1: 1.0x <= 1.0
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 3.0,
-            variable_primal   = [(x, 1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 3.0,
+        variable_primal   = [(x, 1.0)]
+    )
     @test MOI.canmodify(model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarConstantChange{Float64}
@@ -311,12 +281,10 @@ function solve_const_scalar_objective(model::MOI.ModelLike, config::TestConfig)
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarConstantChange(3.0)
     )
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 4.0,
-            variable_primal   = [(x, 1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 4.0,
+        variable_primal   = [(x, 1.0)]
+    )
 end
 modificationtests["solve_const_scalar_objective"] = solve_const_scalar_objective
 
@@ -334,12 +302,10 @@ function solve_coef_scalar_objective(model::MOI.ModelLike, config::TestConfig)
         c1: 1.0x <= 1.0
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 1.0,
-            variable_primal   = [(x, 1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 1.0,
+        variable_primal   = [(x, 1.0)]
+    )
     @test MOI.canmodify(model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarCoefficientChange{Float64}
@@ -348,12 +314,10 @@ function solve_coef_scalar_objective(model::MOI.ModelLike, config::TestConfig)
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarCoefficientChange(x, 3.0)
     )
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 3.0,
-            variable_primal   = [(x, 1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 3.0,
+        variable_primal   = [(x, 1.0)]
+    )
 end
 modificationtests["solve_coef_scalar_objective"] = solve_coef_scalar_objective
 

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -77,14 +77,12 @@ function solve_constant_obj(model::MOI.ModelLike, config::TestConfig)
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 3.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, 2.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 3.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, 2.0)]
+    )
 end
 unittests["solve_constant_obj"] = solve_constant_obj
 
@@ -106,14 +104,12 @@ function solve_blank_obj(model::MOI.ModelLike, config::TestConfig)
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 0.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, 0.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 0.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, 0.0)]
+    )
 end
 unittests["solve_blank_obj"] = solve_blank_obj
 
@@ -135,14 +131,12 @@ function solve_singlevariable_obj(model::MOI.ModelLike, config::TestConfig)
     """)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}, "c")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 1.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c, 1.0)],
-            constraint_dual   = [(c, 1.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 1.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c, 1.0)],
+        constraint_dual   = [(c, 1.0)]
+    )
 end
 unittests["solve_singlevariable_obj"] = solve_singlevariable_obj
 

--- a/src/Test/UnitTests/unit_tests.jl
+++ b/src/Test/UnitTests/unit_tests.jl
@@ -56,6 +56,7 @@ function test_model_solution(model, config;
         constraint_primal = nothing,
         constraint_dual   = nothing
     )
+    config.solve || return
     atol, rtol = config.atol, config.rtol
     MOI.optimize!(model)
     @test MOI.canget(model, MOI.TerminationStatus())

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -152,14 +152,12 @@ function solve_with_upperbound(model::MOI.ModelLike, config::TestConfig)
     x  = MOI.get(model, MOI.VariableIndex, "x")
     c1 = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}, "c1")
     c2 = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}, "c2")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 2.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c1, 1.0), (c2, 1.0)],
-            constraint_dual   = [(c1, -2.0), (c2, 0.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 2.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c1, 1.0), (c2, 1.0)],
+        constraint_dual   = [(c1, -2.0), (c2, 0.0)]
+    )
 end
 unittests["solve_with_upperbound"] = solve_with_upperbound
 
@@ -182,13 +180,11 @@ function solve_with_lowerbound(model::MOI.ModelLike, config::TestConfig)
     x = MOI.get(model, MOI.VariableIndex, "x")
     c1 = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}, "c1")
     c2 = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}, "c2")
-    if config.solve
-        test_model_solution(model, config;
-            objective_value   = 2.0,
-            variable_primal   = [(x, 1.0)],
-            constraint_primal = [(c1, 1.0), (c2, 1.0)],
-            constraint_dual   = [(c1, 2.0), (c2, 0.0)]
-        )
-    end
+    test_model_solution(model, config;
+        objective_value   = 2.0,
+        variable_primal   = [(x, 1.0)],
+        constraint_primal = [(c1, 1.0), (c2, 1.0)],
+        constraint_dual   = [(c1, 2.0), (c2, 0.0)]
+    )
 end
 unittests["solve_with_lowerbound"] = solve_with_lowerbound

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -438,6 +438,10 @@ function MOI.canget(m::CachingOptimizer, attr::Union{MOI.AbstractVariableAttribu
     return false
 end
 
+# Name
+MOI.canget(m::CachingOptimizer, IdxT::Type{<:MOI.Index}, name::String) = MOI.canget(m.model_cache, IdxT, name)
+MOI.get(m::CachingOptimizer, IdxT::Type{<:MOI.Index}, name::String) = MOI.get(m.model_cache, IdxT, name)
+
 # Force users to specify whether the attribute should be queried from the
 # model_cache or the optimizer. Maybe we could consider a small whitelist of
 # attributes to handle automatically.

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -203,6 +203,11 @@ for state in (MOIU.NoOptimizer, MOIU.EmptyOptimizer, MOIU.AttachedOptimizer)
         @test MOIU.state(m) == state
         @test MOIU.mode(m) == mode
         config = MOIT.TestConfig(solve=false)
-        MOIT.contlineartest(m, config)
+        @testset "Unit" begin
+            MOIT.unittest(m, config)
+        end
+        @testset "Continuous Linear" begin
+            MOIT.contlineartest(m, config)
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ MOIU.@model(Model,
                (VectorOfVariables,),
                (VectorAffineFunction, VectorQuadraticFunction))
 # Model supporting only SecondOrderCone as non-LP cone.
-@MOIU.model ModelForMock (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone) () (SingleVariable,) (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
+@MOIU.model ModelForMock (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone) () (SingleVariable,) (ScalarAffineFunction, ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
 
 # Utilities submodule tests
 @testset "MOI.Utilities" begin


### PR DESCRIPTION
Trying to run unit tests on the caching optimizer showed that there was method missing in the name implementation.
There was also some unit tests that didn't check `config.solve`. I move this check to the subfunction to be sure it is always checked