### PR TITLE
WIP: VectorAffineBridge

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -28,7 +28,7 @@ include("singlebridgeoptimizer.jl")
 include("lazybridgeoptimizer.jl")
 
 # This is used by JuMP and removes the need to update JuMP everytime a bridge is added
-MOIU.@model AllBridgedConstraints () (Interval,) (SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, LogDetConeTriangle, RootDetConeTriangle) () () (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
+MOIU.@model AllBridgedConstraints () (Interval,) (SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, LogDetConeTriangle, RootDetConeTriangle, Zeros, Nonnegatives, Nonpositives) () () (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
 """
     fullbridgeoptimizer(model::MOI.ModelLike, ::Type{T}) where T
 
@@ -43,6 +43,7 @@ function fullbridgeoptimizer(model::MOI.ModelLike, ::Type{T}) where T
     addbridge!(bridgedmodel, MOIB.RSOCBridge{T})
     addbridge!(bridgedmodel, MOIB.RSOCtoPSDCBridge{T})
     addbridge!(bridgedmodel, MOIB.SOCtoPSDCBridge{T})
+    addbridge!(bridgedmodel, MOIB.VectorToScalarBridge{T})
     bridgedmodel
 end
 
@@ -59,6 +60,6 @@ include("soctopsdbridge.jl")
 @bridge SOCtoPSD SOCtoPSDCBridge () () (SecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
 @bridge RSOCtoPSD RSOCtoPSDCBridge () () (RotatedSecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
 include("vaftosafbridge.jl")
-# @bridge VAFtoSAF VectorAffineBridge () () () (Zeros, Nonnegatives, Nonpositives) () () () (VectorAffineFunction,)
+@bridge VectorToScalar VectorToScalarBridge () () (Zeros, Nonnegatives, Nonpositives) () () () () (VectorAffineFunction,)
 
 end # module

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -58,5 +58,7 @@ include("detbridge.jl")
 include("soctopsdbridge.jl")
 @bridge SOCtoPSD SOCtoPSDCBridge () () (SecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
 @bridge RSOCtoPSD RSOCtoPSDCBridge () () (RotatedSecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
+include("vaftosafbrige.jl")
+@bridge VAFtoSAF VectorAffineBridge () () () (Zeros, Nonnegatives, Nonpositives) () () () (VectorAffineFunction,)
 
 end # module

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -58,7 +58,7 @@ include("detbridge.jl")
 include("soctopsdbridge.jl")
 @bridge SOCtoPSD SOCtoPSDCBridge () () (SecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
 @bridge RSOCtoPSD RSOCtoPSDCBridge () () (RotatedSecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
-include("vaftosafbrige.jl")
-@bridge VAFtoSAF VectorAffineBridge () () () (Zeros, Nonnegatives, Nonpositives) () () () (VectorAffineFunction,)
+include("vaftosafbridge.jl")
+# @bridge VAFtoSAF VectorAffineBridge () () () (Zeros, Nonnegatives, Nonpositives) () () () (VectorAffineFunction,)
 
 end # module

--- a/src/Bridges/vaftosafbridge.jl
+++ b/src/Bridges/vaftosafbridge.jl
@@ -5,6 +5,10 @@ get_scalar_set(T, ::Type{MOI.Zeros}) = MOI.EqualTo{T}
 get_scalar_set(T, ::Type{MOI.Nonpositives}) = MOI.LessThan{T}
 get_scalar_set(T, ::Type{MOI.Nonnegatives}) = MOI.GreaterThan{T}
 
+get_vector_set(::Type{MOI.EqualTo{T}}) where T = MOI.Zeros
+get_vector_set(::Type{MOI.LessThan{T}}) where T = MOI.Nonpositives
+get_vector_set(::Type{MOI.GreaterThan{T}}) where T = MOI.Nonnegatives
+
 """
     VectorToScalarBridge{S, T}
 
@@ -14,7 +18,8 @@ The `VectorToScalarBridge` splits an `VectorAffineFunction` into a series of
 struct VectorToScalarBridge{T, S<:VectorToScalarBridgeSets} <: AbstractBridge
     constraints::Vector{CI{MOI.ScalarAffineFunction{T}, S}}
 end
-function VectorToScalarBridge(model, func::MOI.VectorAffineFunction{T}, set::S) where {T, S}
+function VectorToScalarBridge(model, func::MOI.VectorAffineFunction{T},
+                              set::S) where {T, S}
     set_type = get_scalar_set(T, S)
     sets = [set_type(-constant) for constant in func.constants]
     functions = [MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}[], zero(T))
@@ -25,7 +30,7 @@ function VectorToScalarBridge(model, func::MOI.VectorAffineFunction{T}, set::S) 
         push!(scalar_function.terms, term.scalar_term)
     end
     constraint_indices = MOI.addconstraints!(model, functions, sets)
-    VectorToScalarBridge(constraint_indices)
+    return VectorToScalarBridge(constraint_indices)
 end
 
 function MOI.supportsconstraint(::Type{VectorToScalarBridge{T, S}},
@@ -46,22 +51,28 @@ function concrete_bridge_type(::Type{<:VectorToScalarBridge},
     return VectorToScalarBridge{T, S}
 end
 
-# Attributes, Bridge acting as an model
+
+function MOI.canget(bridge::VectorToScalarBridge{T, S},
+       ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T}, S}) where {T, S}
+    return true
+end
 function MOI.get(bridge::VectorToScalarBridge{T, S},
        ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T}, S}) where {T, S}
     return length(bridge.constraints)
+end
+
+function MOI.canget(bridge::VectorToScalarBridge{T, S},
+       ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T}, S}) where {T, S}
+    return true
 end
 function MOI.get(bridge::VectorToScalarBridge{T, S},
        ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T}, S}) where {T, S}
     return bridge.constraints
 end
 
-# Indices
 function MOI.delete!(model::MOI.ModelLike, bridge::VectorToScalarBridge)
     MOI.delete!.(Ref(model), bridge.constraints)
 end
-
-# Attributes, Bridge acting as a constraint
 
 function MOI.canget(model::MOI.ModelLike, attribute::Union{MOI.ConstraintPrimal,
                                                            MOI.ConstraintDual},
@@ -72,24 +83,45 @@ end
 function MOI.get(model::MOI.ModelLike, attribute::Union{MOI.ConstraintPrimal,
                                                         MOI.ConstraintDual},
                  bridge::VectorToScalarBridge)
-    return [MOI.get(model, attribute, ci) for ci in bridge.constraints]
+    return MOI.get.(Ref(model), Ref(attribute), bridge.constraints)
 end
 
-# Constraints
-# MOI.canmodify(model::MOI.ModelLike, ::Type{<:VectorAffineBridge}, ::Type{<:MOI.AbstractFunctionModification}) = true
-# function MOI.modify!(model::MOI.ModelLike, c::VectorAffineBridge, change::MOI.AbstractFunctionModification)
-    # MOI.modify!(model, c.lower, change)
-    # MOI.modify!(model, c.upper, change)
-# end
-#
-# MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:VectorAffineBridge}) = true
-# function MOI.set!(model::MOI.ModelLike, ::MOI.ConstraintFunction, c::VectorAffineBridge, func::MOI.ScalarAffineFunction)
-#     MOI.set!(model, MOI.ConstraintFunction(), c.lower, func)
-#     MOI.set!(model, MOI.ConstraintFunction(), c.upper, func)
-# end
-#
-# MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:VectorAffineBridge}) = true
-# function MOI.set!(model::MOI.ModelLike, ::MOI.ConstraintSet, c::VectorAffineBridge, change::MOI.Interval)
-#     MOI.set!(model, MOI.ConstraintSet(), c.lower, MOI.GreaterThan(change.lower))
-#     MOI.set!(model, MOI.ConstraintSet(), c.upper, MOI.LessThan(change.upper))
-# end
+function MOI.modify!(model::MOI.ModelLike, bridge::VectorToScalarBridge,
+                     change::MOI.VectorConstantChange{Float64})
+    @assert length(bridge.constraints) == length(change.new_constant)
+    for (index, coef) in zip(bridge.constraints, change.new_constant)
+        MOI.modify!(model, index, MOI.ScalarConstantChange(coef))
+    end
+end
+
+function MOI.modify!(model::MOI.ModelLike, bridge::VectorToScalarBridge{T, S},
+                     change::MOI.MultirowChange{T}) where {T, S}
+    @assert length(bridge.constraints) == length(change.new_constant)
+    variable = change.variable
+    for (row, coef) in change.new_coefficients
+        index = bridge.constraints[row]
+        MOI.modify!(model, index, MOI.ScalarCoefficientChange(coef, variable))
+    end
+end
+
+MOI.canget(::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:VectorToScalarBridge}) = true
+function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintSet,
+                 bridge::VectorToScalarBridge{T, S}) where {T, S}
+    return get_vector_set(S)
+end
+
+MOI.canget(::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:VectorToScalarBridge}) = true
+function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintFunction,
+                 bridge::VectorToScalarBridge{T, S}) where {T, S}
+    terms = VectorAffineTerm{T}[]
+    constants = T[]
+    for (row, index) in enumerate(bridge.constraints)
+        foo = MOI.get(model, MOI.ConstraintFunction(), index)
+        for term in foo.terms
+            push!(terms, MOI.VectorAffineTerm(row, term))
+        end
+        scalar_set = MOI.get(model, MOI.ConstraintSet())
+        push!(constants, foo.constant + MOIU.getconstant(scalar_set))
+    end
+    return VectorAffineFunction(terms, constants)
+end

--- a/src/Bridges/vaftosafbridge.jl
+++ b/src/Bridges/vaftosafbridge.jl
@@ -1,0 +1,86 @@
+"""
+    VectorAffineBridge{T}
+
+The `VectorAffineBridge` splits a `VectorAffineFunction` into a series of
+`ScalarAffineFunction`s.
+"""
+struct VectorAffineBridge{S,T} <: AbstractBridge
+    constraints::Vector{CI{MOI.ScalarAffineFunction{T}, S}}
+end
+const VectorAffineBridgeSets = Union{MOI.Zeros, MOI.Nonpositives, MOI.Nonnegatives}
+function VectorAffineBridge{T}(model, f::MOI.VectorAffineFunction{T}, s::VectorAffineBridgeSets) where T
+    set_type = getscalarset(T, typeof(s))
+    sets      = [ set_type(-constant) for constant in f.constants ]
+    functions = [ MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}[], zero(T)) for term in f.terms ]
+    @assert dimension(s) == length(sets) == length(functions)
+    for term in f.terms
+        saf = functions[term.output_index]
+        push!(saf.terms, term.scalar_term)
+    end
+    ci = CI{MOI.ScalarAffineFunction{T}, S}[]
+    for (func, set) in zip(functions, sets)
+        push!(ci, MOI.addconstraint!(model, func, set))
+    end
+    VectorAffineBridge(ci)
+end
+getscalarset(T, ::Type{MOI.Zeros})        = MOI.EqualTo{T}
+getscalarset(T, ::Type{MOI.Nonpositives}) = MOI.LessThan{T}
+getscalarset(T, ::Type{MOI.Nonnegatives}) = MOI.GreaterThan{T}
+
+
+MOI.supportsconstraint(::Type{VectorAffineBridge{T,S}}, ::Type{MOI.VectorAffineFunction{T}}, ::Type{S}) where {T,S<:VectorAffineBridgeSets} = true
+function addedconstrainttypes(::Type{VectorAffineBridge{T,S}}, ::Type{MOI.VectorAffineFunction{T}}, ::Type{S}) where {T,S<:VectorAffineBridgeSets}
+    [(MOI.ScalarAffineFunction{T}, getscalarset(T,S))]
+ end
+
+# Attributes, Bridge acting as an model
+function MOI.get(b::VectorAffineBridge{T,S}, ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T}, S2}) where {T,S,S2}
+    if getscalarset(T, S) == S2
+        return length(b.constraints)
+    else
+        return 0
+    end
+end
+function MOI.get(b::VectorAffineBridge{T,S}, ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T}, S2}) where {T,S,S2}
+    b.constraints
+end
+
+# Indices
+function MOI.delete!(model::MOI.ModelLike, c::VectorAffineBridge)
+    for ci in c.constraints
+        MOI.delete!(model, ci)
+    end
+end
+
+# Attributes, Bridge acting as a constraint
+function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintPrimal, ::Type{VectorAffineBridge{T,S}}) where {T,S}
+    MOI.canget(model, a, CI{MOI.ScalarAffineFunction{T}, getscalarset(T, S)})
+end
+function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintPrimal, c::VectorAffineBridge)
+    [ MOI.get(model, MOI.ConstraintPrimal(), ci) for ci in c.constraints ]
+end
+function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{VectorAffineBridge{T,S}}) where {T,S}
+    MOI.canget(model, a, CI{MOI.ScalarAffineFunction{T}, getscalarset(T, S))
+end
+function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintDual, c::VectorAffineBridge)
+    [ MOI.get(model, MOI.ConstraintDual(), ci) for ci in c.constraints ]
+end
+
+# Constraints
+# MOI.canmodify(model::MOI.ModelLike, ::Type{<:VectorAffineBridge}, ::Type{<:MOI.AbstractFunctionModification}) = true
+# function MOI.modify!(model::MOI.ModelLike, c::VectorAffineBridge, change::MOI.AbstractFunctionModification)
+    # MOI.modify!(model, c.lower, change)
+    # MOI.modify!(model, c.upper, change)
+# end
+#
+# MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:VectorAffineBridge}) = true
+# function MOI.set!(model::MOI.ModelLike, ::MOI.ConstraintFunction, c::VectorAffineBridge, func::MOI.ScalarAffineFunction)
+#     MOI.set!(model, MOI.ConstraintFunction(), c.lower, func)
+#     MOI.set!(model, MOI.ConstraintFunction(), c.upper, func)
+# end
+#
+# MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:VectorAffineBridge}) = true
+# function MOI.set!(model::MOI.ModelLike, ::MOI.ConstraintSet, c::VectorAffineBridge, change::MOI.Interval)
+#     MOI.set!(model, MOI.ConstraintSet(), c.lower, MOI.GreaterThan(change.lower))
+#     MOI.set!(model, MOI.ConstraintSet(), c.upper, MOI.LessThan(change.upper))
+# end

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -292,4 +292,5 @@ end
                                                 (MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone, 0),
                                                 (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0)))
     end
+
 end


### PR DESCRIPTION
This PR adds a bridge between `VectorAffineFunction`-in-`{Zeros, Nonnegatives, Nonpositives}` and multiple `ScalarAffineFunction`-in-`{EqualTo, LessThan, GreaterThan}`.

The biggest target for this is LQOI. We should be able to remove a large chunk of code which effectively implements this bridge anyway. I commented out all of the `VectorAffineFunction` code in LQOI, and then ran the GLPK tests with `MOIB.VectorToScalar{Float64}(GLPK.Optimizer())` and everything passed!

- [ ] I'm not sure what the best way to test this is. @blegat?

<s>Just playing around trying to understand the bridge code.

Untested atm.

@blegat is this how it should be?</s>