### PR TITLE
Add return type annotation to `get(::AbstractModel, ::ListOfConstraintIndices)`

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -268,7 +268,7 @@ function MOI.get(model::AbstractModel, loc::MOI.ListOfConstraints)
     broadcastvcat(_getloc, model)
 end
 
-function MOI.get(model::AbstractModel, loc::MOI.ListOfConstraintIndices)
+function (MOI.get(model::AbstractModel, loc::MOI.ListOfConstraintIndices{F, S})::Vector{CI{F, S}}) where {F, S}
     broadcastvcat(constrs -> _getlocr(constrs, loc), model)
 end
 


### PR DESCRIPTION
Fixes #426 

The actual root cause of #426 was that we were accidentally mis-using `MOI.@model`, and we had a model type that tried to support `ScalarQuadraticFunction` but didn't support any scalar sets at all. The result was that the model had a `.scalarquadraticfunction`, but that field itself was completely empty. So `vcat()` across the (empty set of) fields resulted in an un-inferable return type. 

The *correct* fix was to update our `@model` usage. But I still think a return type annotation is useful here, as `broadcastvcat` is doing some pretty complicated things and failing to infer this result type actually causes errors, not just slowness, in the downstream code. 