### PR TITLE
Add in-place version of canonical() and more tests

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -201,13 +201,6 @@ Finds the coefficient associated with the term `t`.
 coefficient(t::MOI.ScalarAffineTerm) = t.coefficient
 coefficient(t::MOI.VectorAffineTerm) = t.scalar_term.coefficient
 
-"""
-    copy(f::Union{ScalarAffineFunction, VectorAffineFunction})
-
-Return a new affine function with a shallow copy of the terms and constant(s)
-from `f`.
-"""
-Base.copy(f::F) where {F <: Union{SAF, VAF}} = F(copy(f.terms), copy(_constant(f)))
 
 """
     iscanonical(f::Union{ScalarAffineFunction, VectorAffineFunction})

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -267,7 +267,6 @@ See [`canonical`](@ref).
 """
 function canonicalize!(f::Union{SAF, VAF})
     sort_and_compress!(f.terms, termindices, t -> !iszero(coefficient(t)), unsafe_add)
-    f
 end
 
 """
@@ -299,7 +298,7 @@ function sort_and_compress!(x::AbstractVector, by, keep, combine)
         end
         resize!(x, i1)
     end
-    x
+    return x
 end
 
 

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -216,20 +216,27 @@ Returns a Bool indicating whether the function is in canonical form.
 See [`canonical`](@ref).
 """
 function iscanonical(f::Union{SAF, VAF})
-    iscanonical(f.terms, termindices, t -> !iszero(coefficient(t)))
+    is_strictly_sorted(f.terms, termindices, t -> !iszero(coefficient(t)))
 end
-function iscanonical(x::AbstractVector, by, keep)
+
+"""
+    is_strictly_sorted(x::AbstractVector, by, filter)
+
+Returns `true` if `by(x[i]) < by(x[i + 1]` and `filter(x[i]) == true` for
+all indices i.
+"""
+function is_strictly_sorted(x::AbstractVector, by, filter)
     if isempty(x)
         return true
     end
-    if !keep(first(x))
+    if !filter(first(x))
         return false
     end
     for i in eachindex(x)[2:end]
         if by(x[i]) <= by(x[i - 1])
             return false
         end
-        if !keep(x[i])
+        if !filter(x[i])
             return false
         end
     end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -133,12 +133,12 @@ iscanonical(f::MOI.VectorAffineFunction) = iscanonical(f.terms,
 iscanonical(f::MOI.ScalarAffineFunction) = iscanonical(f.terms,
                                                        t -> t.variable_index.value,
                                                        t -> !iszero(t.coefficient))
-function iscanonical(x::AbstractVector, key, keep)
+function iscanonical(x::AbstractVector, by, keep)
     if isempty(x)
         return true
     end
     @inbounds for i in 1:(length(x) - 1)
-        if key(x[i + 1]) <= key(x[i])
+        if by(x[i + 1]) <= by(x[i])
             return false
         end
         if !keep(x[i])

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -260,6 +260,7 @@ See [`canonical`](@ref).
 """
 function canonicalize!(f::Union{SAF, VAF})
     sort_and_compress!(f.terms, termindices, t -> !iszero(coefficient(t)), unsafe_add)
+    return f
 end
 
 """

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -204,7 +204,7 @@ coefficient(t::MOI.VectorAffineTerm) = t.scalar_term.coefficient
 """
     copy(f::Union{ScalarAffineFunction, VectorAffineFunction})
 
-Return a new affine function with a shallow copy of the terms vector and constant(s)
+Return a new affine function with a shallow copy of the terms and constant(s)
 from `f`.
 """
 Base.copy(f::F) where {F <: Union{SAF, VAF}} = F(copy(f.terms), copy(_constant(f)))

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -207,18 +207,18 @@ function canonical!(f::MOI.VectorAffineFunction)
     f
 end
 
-function merge_duplicates!(x::AbstractVector, key, keep, reduction, alg = QuickSort)
+function merge_duplicates!(x::AbstractVector, by, keep, combine)
     if length(x) == 1
         if !keep(first(x))
             empty!(x)
         end
     elseif length(x) > 1
-        sort!(x, by = key, alg = alg)
+        sort!(x, QuickSort, Base.Order.ord(isless, by, false, Base.Sort.Forward))
         i1 = 1
         i2 = 2
         @inbounds while i2 <= length(x)
-            if key(x[i1]) == key(x[i2])
-                x[i1] = reduction(x[i1], x[i2])
+            if by(x[i1]) == by(x[i2])
+                x[i1] = combine(x[i1], x[i2])
                 i2 += 1
             else
                 if !keep(x[i1])

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -311,3 +311,11 @@ function Base.isapprox(f::F, g::G; kwargs...) where {F<:Union{ScalarAffineFuncti
                                                      G<:Union{ScalarAffineFunction, ScalarQuadraticFunction, VectorAffineFunction, VectorQuadraticFunction}}
     isapprox(_constant(f), _constant(g); kwargs...) && all(dict_isapprox.(_dicts(f), _dicts(g); kwargs...))
 end
+
+"""
+    copy(func::Union{ScalarAffineFunction, VectorAffineFunction})
+
+Return a new affine function with a shallow copy of the terms and constant(s)
+from `func`.
+"""
+Base.copy(func::F) where {F <: Union{SAF, VAF}} = F(copy(func.terms), copy(_constant(func)))

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -318,4 +318,4 @@ end
 Return a new affine function with a shallow copy of the terms and constant(s)
 from `func`.
 """
-Base.copy(func::F) where {F <: Union{SAF, VAF}} = F(copy(func.terms), copy(_constant(func)))
+Base.copy(func::F) where {F <: Union{ScalarAffineFunction, VectorAffineFunction}} = F(copy(func.terms), copy(_constant(func)))

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -285,7 +285,7 @@
                 # test allocations inside a function scope to avoid
                 # issues with global variables
                 allocations_wrapper(f) = @allocated(MOI.Utilities.canonical!(f))
-                @test allocations_wrapper(f) <= 200
+                @test allocations_wrapper(f) == 0
             end
         end
         @testset "VectorAffineFunction" begin
@@ -299,7 +299,7 @@
                 # test allocations inside a function scope to avoid
                 # issues with global variables
                 allocations_wrapper(f) = @allocated(MOI.Utilities.canonical!(f))
-                @test allocations_wrapper(f) <= 200
+                @test allocations_wrapper(f) == 0
             end
         end
     end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -222,6 +222,11 @@
             @test @allocated(MOIU.canonicalize!(f)) == 0
         end
         @testset "ScalarAffine" begin
+            @test MOIU.iscanonical(MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(Float64[], MOI.VariableIndex.(Int[])), 1.0))
+            @test !MOIU.iscanonical(MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0], MOI.VariableIndex.([1])), 1.0))
+            @test !MOIU.iscanonical(MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0], MOI.VariableIndex.([2, 1])), 2.0))
+            @test !MOIU.iscanonical(MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.0], MOI.VariableIndex.([1, 2])), 2.0))
+
             test_canonicalization(
                 MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(Float64[], MOI.VariableIndex[]), 1.5),
                 MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(Float64[], MOI.VariableIndex[]), 1.5),
@@ -282,6 +287,13 @@
             end
         end
         @testset "VectorAffine" begin
+            @test MOIU.iscanonical(MOI.VectorAffineFunction(MOI.VectorAffineTerm.(Int[], MOI.ScalarAffineTerm.(Float64[], MOI.VariableIndex.(Int[]))), Float64[]))
+            @test !MOIU.iscanonical(MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1], MOI.ScalarAffineTerm.([0.0], MOI.VariableIndex.([1]))), [1.0]))
+            @test !MOIU.iscanonical(MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 2], MOI.ScalarAffineTerm.([0.0, 1.0], MOI.VariableIndex.([1, 2]))), [1.0]))
+            @test !MOIU.iscanonical(MOI.VectorAffineFunction(MOI.VectorAffineTerm.([2, 1], MOI.ScalarAffineTerm.([1.0, 1.0], MOI.VariableIndex.([1, 2]))), [1.0]))
+            @test !MOIU.iscanonical(MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 1], MOI.ScalarAffineTerm.([1.0, -1.0], MOI.VariableIndex.([1, 1]))), [1.0]))
+            @test !MOIU.iscanonical(MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 1], MOI.ScalarAffineTerm.([1.0, 1.0], MOI.VariableIndex.([1, 1]))), [1.0]))
+
             test_canonicalization(
                 MOI.VectorAffineFunction(MOI.VectorAffineTerm.(Int[], MOI.ScalarAffineTerm.(Float64[], MOI.VariableIndex.(Int[]))), Float64[]),
                 MOI.VectorAffineFunction(MOI.VectorAffineTerm.(Int[], MOI.ScalarAffineTerm.(Float64[], MOI.VariableIndex.(Int[]))), Float64[])

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -280,7 +280,7 @@
                 g = @inferred(MOI.Utilities.canonical(f))
                 @test _isapprox(g, _canonical_reference(f))
                 @test MOI.Utilities.iscanonical(g)
-                @test MOI.Utilities.canonical(g) === g
+                @test MOI.Utilities.canonical(g) !== g
 
                 # test allocations inside a function scope to avoid
                 # issues with global variables
@@ -294,7 +294,7 @@
                 g = @inferred(MOI.Utilities.canonical(f))
                 @test _isapprox(g, _canonical_reference(f))
                 @test MOI.Utilities.iscanonical(g)
-                @test MOI.Utilities.canonical(g) === g
+                @test MOI.Utilities.canonical(g) !== g
 
                 # test allocations inside a function scope to avoid
                 # issues with global variables

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -281,7 +281,11 @@
                 @test _isapprox(g, _canonical_reference(f))
                 @test MOI.Utilities.iscanonical(g)
                 @test MOI.Utilities.canonical(g) === g
-                @test @allocated(MOI.Utilities.canonical!(f)) <= 200
+
+                # test allocations inside a function scope to avoid
+                # issues with global variables
+                allocations_wrapper(f) = @allocated(MOI.Utilities.canonical!(f))
+                @test allocations_wrapper(f) <= 200
             end
         end
         @testset "VectorAffineFunction" begin
@@ -291,7 +295,11 @@
                 @test _isapprox(g, _canonical_reference(f))
                 @test MOI.Utilities.iscanonical(g)
                 @test MOI.Utilities.canonical(g) === g
-                @test @allocated(MOI.Utilities.canonical!(f)) <= 200
+
+                # test allocations inside a function scope to avoid
+                # issues with global variables
+                allocations_wrapper(f) = @allocated(MOI.Utilities.canonical!(f))
+                @test allocations_wrapper(f) <= 200
             end
         end
     end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -270,6 +270,16 @@
                 MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -0.5, 0.5, -0.5], MOI.VariableIndex.([7, 7, 2, 7])), 5.0),
                 MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.5], MOI.VariableIndex.([2])), 5.0),
                 )
+            function random_scalar_affine_function(n)
+                indices = MOI.VariableIndex.([rand(1:n) for i in 1:n])
+                coefficients = randn(n)
+                coefficients[rand(Float64, size(coefficients)) .<= 0.2] .= 0
+                MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(coefficients, indices), randn())
+            end
+            srand(1)
+            for i in 1:1000
+                @test MOIU.iscanonical(MOIU.canonical(random_scalar_affine_function(rand(1:100))))
+            end
         end
         @testset "VectorAffine" begin
             test_canonicalization(
@@ -288,102 +298,43 @@
                 MOI.VectorAffineFunction(MOI.VectorAffineTerm.([3, 3], MOI.ScalarAffineTerm.([1.0, 2.0], MOI.VariableIndex.([6, 5]))), [1.0, 2.0, 3.0]),
                 MOI.VectorAffineFunction(MOI.VectorAffineTerm.([3, 3], MOI.ScalarAffineTerm.([2.0, 1.0], MOI.VariableIndex.([5, 6]))), [1.0, 2.0, 3.0])
                 )
-        end
-
-        # Previous implementations of `MOI.Utilities.canonical`, now kept as reference
-        # implementations to compare against
-        function _canonical_reference(f::MOI.ScalarAffineFunction{T}) where T
-            sorted_terms = sort(f.terms, by = t -> t.variable_index.value)
-            terms = MOI.ScalarAffineTerm{T}[]
-            for t in sorted_terms
-                if !isempty(terms) && t.variable_index == last(terms).variable_index
-                    terms[end] = MOI.ScalarAffineTerm(terms[end].coefficient + t.coefficient, t.variable_index)
-                elseif !iszero(t.coefficient)
-                    if !isempty(terms) && iszero(last(terms).coefficient)
-                        terms[end] = t
-                    else
-                        push!(terms, t)
-                    end
-                end
+            test_canonicalization(
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([3, 3], MOI.ScalarAffineTerm.([1.0, 2.0], MOI.VariableIndex.([1, 1]))), [1.0, 2.0, 3.0]),
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([3], MOI.ScalarAffineTerm.([3.0], MOI.VariableIndex.([1]))), [1.0, 2.0, 3.0])
+                )
+            test_canonicalization(
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 1, 1], MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], MOI.VariableIndex.([1, 2, 1]))), [4.0, 5.0, 6.0]),
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 1], MOI.ScalarAffineTerm.([4.0, 2.0], MOI.VariableIndex.([1, 2]))), [4.0, 5.0, 6.0]),
+                )
+            test_canonicalization(
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 1, 1], MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], MOI.VariableIndex.([2, 1, 1]))), [4.0, 5.0, 6.0]),
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 1], MOI.ScalarAffineTerm.([5.0, 1.0], MOI.VariableIndex.([1, 2]))), [4.0, 5.0, 6.0]),
+                )
+            test_canonicalization(
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([2, 3, 3], MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], MOI.VariableIndex.([1, 1, 1]))), [4.0, 5.0, 6.0]),
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([2, 3], MOI.ScalarAffineTerm.([1.0, 5.0], MOI.VariableIndex.([1, 1]))), [4.0, 5.0, 6.0]),
+                )
+            test_canonicalization(
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([2, 3, 3], MOI.ScalarAffineTerm.([1.0, -3.0, 3.0], MOI.VariableIndex.([1, 1, 1]))), [4.0, 5.0, 6.0]),
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([2], MOI.ScalarAffineTerm.([1.0], MOI.VariableIndex.([1]))), [4.0, 5.0, 6.0]),
+                )
+            test_canonicalization(
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([2, 3, 3, 3], MOI.ScalarAffineTerm.([1.0, 3.0, -1.0, -2.0], MOI.VariableIndex.([1, 1, 1, 1]))), [4.0, 5.0, 6.0]),
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.([2], MOI.ScalarAffineTerm.([1.0], MOI.VariableIndex.([1]))), [4.0, 5.0, 6.0]),
+                )
+            srand(2)
+            function random_vector_affine_function(n)
+                indices = MOI.VariableIndex.([rand(1:n) for i in 1:n])
+                coefficients = randn(n)
+                coefficients[rand(Float64, size(coefficients)) .<= 0.2] .= 0
+                constants = randn(n)
+                constants[rand(Float64, size(constants)) .<= 0.2] .= 0
+                output_indices = [rand(1:n) for i in 1:n]
+                MOI.VectorAffineFunction(MOI.VectorAffineTerm.(output_indices, MOI.ScalarAffineTerm.(coefficients, indices)),
+                                         constants)
             end
-            if !isempty(terms) && iszero(last(terms).coefficient)
-                pop!(terms)
-            end
-            MOI.ScalarAffineFunction{T}(terms, f.constant)
-        end
-        function _canonical_reference(f::MOI.VectorAffineFunction{T}) where T
-            sorted_terms = sort(f.terms, by = t -> (t.output_index, t.scalar_term.variable_index.value))
-            terms = MOI.VectorAffineTerm{T}[]
-            for t in sorted_terms
-                if !isempty(terms) && t.output_index == last(terms).output_index && t.scalar_term.variable_index == last(terms).scalar_term.variable_index
-                    terms[end] = MOI.VectorAffineTerm(t.output_index, MOI.ScalarAffineTerm(terms[end].scalar_term.coefficient + t.scalar_term.coefficient, t.scalar_term.variable_index))
-                elseif !iszero(t.scalar_term.coefficient)
-                    if !isempty(terms) && iszero(last(terms).scalar_term.coefficient)
-                        terms[end] = t
-                    else
-                        push!(terms, t)
-                    end
-                end
-            end
-            if !isempty(terms) && iszero(last(terms).scalar_term.coefficient)
-                pop!(terms)
-            end
-            MOI.VectorAffineFunction{T}(terms, f.constants)
-        end
-
-        function random_scalar_affine_function(n)
-            indices = MOI.VariableIndex.([rand(1:n) for i in 1:n])
-            coefficients = randn(n)
-            coefficients[rand(Float64, size(coefficients)) .<= 0.2] .= 0
-            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(coefficients, indices), randn())
-        end
-
-        function random_vector_affine_function(n)
-            indices = MOI.VariableIndex.([rand(1:n) for i in 1:n])
-            coefficients = randn(n)
-            coefficients[rand(Float64, size(coefficients)) .<= 0.2] .= 0
-            constants = randn(n)
-            constants[rand(Float64, size(constants)) .<= 0.2] .= 0
-            output_indices = [rand(1:n) for i in 1:n]
-            MOI.VectorAffineFunction(MOI.VectorAffineTerm.(output_indices, MOI.ScalarAffineTerm.(coefficients, indices)),
-                                     constants)
-        end
-
-        _var_idx(f::MOI.ScalarAffineTerm) = f.variable_index
-        _coeff(f::MOI.ScalarAffineTerm) = f.coefficient
-        _isapprox(f1::MOI.ScalarAffineFunction, f2::MOI.ScalarAffineFunction) = _var_idx.(f1.terms) == _var_idx.(f2.terms) && _coeff.(f1.terms) ≈ _coeff.(f2.terms) && f1.constant ≈ f2.constant
-        _var_idx(f::MOI.VectorAffineTerm) = f.scalar_term.variable_index
-        _coeff(f::MOI.VectorAffineTerm) = f.scalar_term.coefficient
-        _output_idx(f::MOI.VectorAffineTerm) = f.output_index
-        _isapprox(f1::MOI.VectorAffineFunction, f2::MOI.VectorAffineFunction) = _var_idx.(f1.terms) == _var_idx.(f2.terms) && _output_idx.(f1.terms) == _output_idx.(f2.terms) && _coeff.(f1.terms) ≈ _coeff.(f2.terms) && f1.constants ≈ f2.constants
-
-        srand(1)
-        @testset "ScalarAffineFunction" begin
             for i in 1:1000
-                f = random_scalar_affine_function(rand(1:1000))
-                g = @inferred(MOI.Utilities.canonical(f))
-                @test _isapprox(g, _canonical_reference(f))
-                @test MOI.Utilities.iscanonical(g)
-                @test MOI.Utilities.canonical(g) !== g
-
-                # test allocations inside a function scope to avoid
-                # issues with global variables
-                allocations_wrapper(f) = @allocated(MOI.Utilities.canonicalize!(f))
-                @test allocations_wrapper(f) == 0
-            end
-        end
-        @testset "VectorAffineFunction" begin
-            for i in 1:1000
-                f = random_vector_affine_function(rand(1:1000))
-                g = @inferred(MOI.Utilities.canonical(f))
-                @test _isapprox(g, _canonical_reference(f))
-                @test MOI.Utilities.iscanonical(g)
-                @test MOI.Utilities.canonical(g) !== g
-
-                # test allocations inside a function scope to avoid
-                # issues with global variables
-                allocations_wrapper(f) = @allocated(MOI.Utilities.canonicalize!(f))
-                @test allocations_wrapper(f) == 0
+                @test MOIU.iscanonical(MOIU.canonical(random_vector_affine_function(rand(1:100))))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ const MOIB = MathOptInterface.Bridges
 
 using Compat
 using Compat.Test
+using Compat.Random
 
 # Tests for solvers are located in MOI.Test.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,6 @@ const MOIB = MathOptInterface.Bridges
 
 using Compat
 using Compat.Test
-using Compat.Random
 
 # Tests for solvers are located in MOI.Test.
 


### PR DESCRIPTION
Fixes #429 

This implements the in-place canonicalization I suggested over in #429 with some cleanup to make it a bit more readable. It adds two new functions: `iscanonical()` which tests if an AffineFunction is canonical and `canonical!` which converts an AffineFunction to canonical form in-place. ~~In Julia v0.7 and above, the in-place `canonical!` should allocate zero memory (on v0.6, it allocates a tiny amount for keyword arguments).~~ Edit: the in-place version now has zero allocations on 0.6 and 0.7 (thanks @tkoolen!) 

Another significant change is that if a function is already in canonical form, it is not copied or modified. This should make things a bit faster for modeling layers like JuMP that already provide canonical functions. 