### PR TITLE
Replace can... functions by errors

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -120,7 +120,7 @@ set!(model, VariablePrimalStart(), v2, [1.3,6.8,-4.6])
 ```
 
 A variable can be deleted from a model with [`delete!(::ModelLike, ::VariableIndex)`](@ref MathOptInterface.delete!(::MathOptInterface.ModelLike, ::MathOptInterface.Index)).
-Not all models support deleting variables; a [`UnsupportedDeletion`](@ref MathOptInterface.UnsupportedDeletion)
+Not all models support deleting variables; an [`UnsupportedDeletion`](@ref MathOptInterface.UnsupportedDeletion)
 error is thrown if this is not supported.
 
 ## Functions

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -119,7 +119,9 @@ v2 = addvariables!(model, 3)
 set!(model, VariablePrimalStart(), v2, [1.3,6.8,-4.6])
 ```
 
-A variable can be deleted from a model with [`delete!(::ModelLike, ::VariableIndex)`](@ref MathOptInterface.delete!(::MathOptInterface.ModelLike, ::MathOptInterface.Index)). Not all models support deleting variables; the [`candelete`](@ref MathOptInterface.candelete) method is used to check if this is supported.
+A variable can be deleted from a model with [`delete!(::ModelLike, ::VariableIndex)`](@ref MathOptInterface.delete!(::MathOptInterface.ModelLike, ::MathOptInterface.Index)).
+Not all models support deleting variables; a [`UnsupportedDeletion`](@ref MathOptInterface.UnsupportedDeletion)
+error is thrown if this is not supported.
 
 ## Functions
 

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -286,9 +286,11 @@ constraint_expr
 ## Errors
 
 When an MOI call fails on a model, precise errors should be thrown when possible
-instead of simply calling `error` with a message. This allows for instance to
-the CachingOptimizer to automatically detach the optimizer when an
-incremental update of the model is not supported.
+instead of simply calling `error` with a message. The docstrings for the
+respective methods describe the errors that the implementation should thrown in
+certain situations. This error-reporting system allows code to distinguish
+between internal errors (that should be shown to the user) and unsupported
+operations which may have automatic workarounds.
 
 When an invalid index is used in an MOI call, an [`InvalidIndex`](@ref) should
 be thrown:

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -160,7 +160,6 @@ Functions for adding and modifying constraints.
 
 ```@docs
 isvalid(::ModelLike,::ConstraintIndex)
-canaddconstraint
 addconstraint!
 addconstraints!
 transform!

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -23,7 +23,6 @@ Functions for getting and setting attributes.
 canget
 get
 get!
-canset
 set!
 supports
 ```
@@ -42,8 +41,6 @@ Copying
 
 ```@docs
 copy!
-CopyResult
-CopyStatusCode
 ```
 
 List of model attributes
@@ -129,7 +126,6 @@ BasisStatusCode
 ```@docs
 VariableIndex
 ConstraintIndex
-candelete
 isvalid
 delete!(::ModelLike,::Index)
 ```
@@ -139,7 +135,6 @@ delete!(::ModelLike,::Index)
 Functions for adding variables. For deleting, see index types section.
 
 ```@docs
-canaddvariable
 addvariables!
 addvariable!
 ```
@@ -250,7 +245,6 @@ Functions for modifying objective and constraint functions.
 
 ```@docs
 modify!
-canmodify
 AbstractFunctionModification
 ScalarConstantChange
 VectorConstantChange
@@ -287,6 +281,39 @@ eval_hessian_lagrangian
 eval_hessian_lagrangian_product
 objective_expr
 constraint_expr
+```
+
+## Errors
+
+When an MOI call fails on a model, precise errors should be thrown when possible
+instead of simply calling `error` with a message. This allows for instance to
+the CachingOptimizer to automatically detach the optimizer when an
+incremental update of the model is not supported.
+
+When an invalid index is used in an MOI call, an [`InvalidIndex`](@ref) should
+be thrown:
+```@docs
+InvalidIndex
+```
+
+The rest of the errors defined in MOI fall in two categories represented by the
+following two abstract types:
+```@docs
+UnsupportedError
+CannotError
+```
+
+The different [`UnsupportedError`](@ref) and [`CannotError`](@ref) are the
+following errors:
+```@docs
+UnsupportedAttribute
+CannotSetAttribute
+CannotAddVariable
+UnsupportedConstraint
+CannotAddConstraint
+UnsupportedConstraintModification
+UnsupportedObjectiveModification
+UnsupportedDeletion
 ```
 
 ## Bridges

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -164,7 +164,6 @@ canaddconstraint
 addconstraint!
 addconstraints!
 transform!
-cantransform
 supportsconstraint
 ```
 

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -43,10 +43,3 @@ MOI.supportsconstraint(::Type{<:AbstractBridge}, ::Type{<:MOI.AbstractFunction},
 Return a list of the types of constraints that bridges of type `BT` add for bridging an `F`-in-`S` constraints.
 """
 function addedconstrainttypes end
-
-"""
-    MOI.candelete(model::MOI.ModelLike, b::AbstractBridge)
-
-Return a `Bool` indicating whether the bridge `b` can be removed from the model `model`.
-"""
-MOI.candelete(model::MOI.ModelLike, c::AbstractBridge) = true

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -249,6 +249,5 @@ MOI.canmodify(b::AbstractBridgeOptimizer, obj::MOI.ObjectiveFunction, ::Type{M})
 MOI.modify!(b::AbstractBridgeOptimizer, obj::MOI.ObjectiveFunction, change::MOI.AbstractFunctionModification) = MOI.modify!(b.model, obj, change)
 
 # Variables
-MOI.canaddvariable(b::AbstractBridgeOptimizer) = MOI.canaddvariable(b.model)
 MOI.addvariable!(b::AbstractBridgeOptimizer) = MOI.addvariable!(b.model)
 MOI.addvariables!(b::AbstractBridgeOptimizer, n) = MOI.addvariables!(b.model, n)

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -204,14 +204,7 @@ function MOI.addconstraint!(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
         MOI.addconstraint!(b.model, f, s)
     end
 end
-function MOI.canmodify(b::AbstractBridgeOptimizer, ::Type{CI{F, S}}, ::Type{Chg}) where {F, S, Chg<:MOI.AbstractFunctionModification}
-    if isbridged(b, CI{F, S})
-        MOI.canmodify(b.bridged, CI{F, S}, Chg) && MOI.canmodify(b, MOIB.bridgetype(b, F, S), Chg)
-    else
-        MOI.canmodify(b.model, CI{F, S}, Chg)
-    end
-end
-function MOI.modify!(b::AbstractBridgeOptimizer, ci::CI, change)
+function MOI.modify!(b::AbstractBridgeOptimizer, ci::CI, change::MOI.AbstractFunctionModification)
     if isbridged(b, typeof(ci))
         MOI.modify!(b, bridge(b, ci), change)
         MOI.modify!(b.bridged, ci, change)
@@ -247,7 +240,6 @@ function MOI.set!(b::AbstractBridgeOptimizer, ::MOI.ConstraintFunction, constrai
 end
 
 # Objective
-MOI.canmodify(b::AbstractBridgeOptimizer, obj::MOI.ObjectiveFunction, ::Type{M}) where M<:MOI.AbstractFunctionModification = MOI.canmodify(b.model, obj, M)
 MOI.modify!(b::AbstractBridgeOptimizer, obj::MOI.ObjectiveFunction, change::MOI.AbstractFunctionModification) = MOI.modify!(b.model, obj, change)
 
 # Variables

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -54,14 +54,6 @@ MOI.supports(b::AbstractBridgeOptimizer, attr::Union{MOI.AbstractModelAttribute,
 MOI.copy!(b::AbstractBridgeOptimizer, src::MOI.ModelLike; copynames=false) = MOIU.defaultcopy!(b, src, copynames)
 
 # References
-MOI.candelete(b::AbstractBridgeOptimizer, vi::VI) = MOI.candelete(b.model, vi)
-function MOI.candelete(b::AbstractBridgeOptimizer, ci::CI)
-    if isbridged(b, typeof(ci))
-        MOI.candelete(b.bridged, ci) && MOI.candelete(b, bridge(b, ci))
-    else
-        MOI.candelete(b.model, ci)
-    end
-end
 MOI.isvalid(b::AbstractBridgeOptimizer, vi::VI) = MOI.isvalid(b.model, vi)
 function MOI.isvalid(b::AbstractBridgeOptimizer, ci::CI)
     if isbridged(b, typeof(ci))
@@ -73,6 +65,9 @@ end
 MOI.delete!(b::AbstractBridgeOptimizer, vi::VI) = MOI.delete!(b.model, vi)
 function MOI.delete!(b::AbstractBridgeOptimizer, ci::CI)
     if isbridged(b, typeof(ci))
+        if !MOI.isvalid(b, ci)
+            throw(MOI.InvalidIndex(ci))
+        end
         MOI.delete!(b, bridge(b, ci))
         delete!(b.bridges, ci)
         MOI.delete!(b.bridged, ci)

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -192,13 +192,6 @@ function MOI.supportsconstraint(b::AbstractBridgeOptimizer, F::Type{<:MOI.Abstra
         MOI.supportsconstraint(b.model, F, S)
     end
 end
-function MOI.canaddconstraint(b::AbstractBridgeOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})
-    if isbridged(b, F, S)
-        supportsbridgingconstraint(b, F, S) && MOI.canaddconstraint(b.bridged, F, S) && all(C -> MOI.canaddconstraint(b, C...), addedconstrainttypes(bridgetype(b, F, S), F, S))
-    else
-        MOI.canaddconstraint(b.model, F, S)
-    end
-end
 function MOI.addconstraint!(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction, s::MOI.AbstractSet)
     if isbridged(b, typeof(f), typeof(s))
         ci = MOI.addconstraint!(b.bridged, f, s)

--- a/src/Bridges/detbridge.jl
+++ b/src/Bridges/detbridge.jl
@@ -141,7 +141,6 @@ end
 MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{<:LogDetBridge}) = false
 
 # Constraints
-MOI.canmodify(model::MOI.ModelLike, ::Type{<:LogDetBridge}, change) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:LogDetBridge}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:LogDetBridge}) = false
 
@@ -209,6 +208,5 @@ end
 MOI.canget(model::MOI.ModelLike, ::MOI.ConstraintDual, ::Type{<:RootDetBridge}) = false
 
 # Constraints
-MOI.canmodify(model::MOI.ModelLike, ::Type{<:RootDetBridge}, ::Type{<:MOI.AbstractFunctionModification}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RootDetBridge}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RootDetBridge}) = false

--- a/src/Bridges/detbridge.jl
+++ b/src/Bridges/detbridge.jl
@@ -142,8 +142,8 @@ MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{<:LogDetBridge}) 
 
 # Constraints
 MOI.canmodify(model::MOI.ModelLike, ::Type{<:LogDetBridge}, change) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:LogDetBridge}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:LogDetBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:LogDetBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:LogDetBridge}) = false
 
 """
     RootDetBridge{T}
@@ -210,5 +210,5 @@ MOI.canget(model::MOI.ModelLike, ::MOI.ConstraintDual, ::Type{<:RootDetBridge}) 
 
 # Constraints
 MOI.canmodify(model::MOI.ModelLike, ::Type{<:RootDetBridge}, ::Type{<:MOI.AbstractFunctionModification}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RootDetBridge}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RootDetBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RootDetBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RootDetBridge}) = false

--- a/src/Bridges/geomeanbridge.jl
+++ b/src/Bridges/geomeanbridge.jl
@@ -139,5 +139,5 @@ MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{<:GeoMeanBridge})
 
 # Constraints
 MOI.canmodify(model::MOI.ModelLike, ::Type{<:GeoMeanBridge}, ::Type{<:MOI.AbstractFunctionModification}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:GeoMeanBridge}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:GeoMeanBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:GeoMeanBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:GeoMeanBridge}) = false

--- a/src/Bridges/geomeanbridge.jl
+++ b/src/Bridges/geomeanbridge.jl
@@ -138,6 +138,5 @@ MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{<:GeoMeanBridge})
 #end
 
 # Constraints
-MOI.canmodify(model::MOI.ModelLike, ::Type{<:GeoMeanBridge}, ::Type{<:MOI.AbstractFunctionModification}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:GeoMeanBridge}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:GeoMeanBridge}) = false

--- a/src/Bridges/intervalbridge.jl
+++ b/src/Bridges/intervalbridge.jl
@@ -57,13 +57,13 @@ function MOI.modify!(model::MOI.ModelLike, c::SplitIntervalBridge, change::MOI.A
     MOI.modify!(model, c.upper, change)
 end
 
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:SplitIntervalBridge}) = true
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:SplitIntervalBridge}) = true
 function MOI.set!(model::MOI.ModelLike, ::MOI.ConstraintFunction, c::SplitIntervalBridge, func::MOI.ScalarAffineFunction)
     MOI.set!(model, MOI.ConstraintFunction(), c.lower, func)
     MOI.set!(model, MOI.ConstraintFunction(), c.upper, func)
 end
 
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:SplitIntervalBridge}) = true
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:SplitIntervalBridge}) = true
 function MOI.set!(model::MOI.ModelLike, ::MOI.ConstraintSet, c::SplitIntervalBridge, change::MOI.Interval)
     MOI.set!(model, MOI.ConstraintSet(), c.lower, MOI.GreaterThan(change.lower))
     MOI.set!(model, MOI.ConstraintSet(), c.upper, MOI.LessThan(change.upper))

--- a/src/Bridges/intervalbridge.jl
+++ b/src/Bridges/intervalbridge.jl
@@ -51,7 +51,6 @@ function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintDual, c::SplitIntervalBr
 end
 
 # Constraints
-MOI.canmodify(model::MOI.ModelLike, ::Type{<:SplitIntervalBridge}, ::Type{<:MOI.AbstractFunctionModification}) = true
 function MOI.modify!(model::MOI.ModelLike, c::SplitIntervalBridge, change::MOI.AbstractFunctionModification)
     MOI.modify!(model, c.lower, change)
     MOI.modify!(model, c.upper, change)

--- a/src/Bridges/rsocbridge.jl
+++ b/src/Bridges/rsocbridge.jl
@@ -66,5 +66,5 @@ end
 MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintDual, c::RSOCBridge) = _get(model, attr, c)
 
 MOI.canmodify(model::MOI.ModelLike, ::Type{<:RSOCBridge}, ::Type{<:MOI.AbstractFunctionModification}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCBridge}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RSOCBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RSOCBridge}) = false

--- a/src/Bridges/rsocbridge.jl
+++ b/src/Bridges/rsocbridge.jl
@@ -65,6 +65,5 @@ function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{RSOCBrid
 end
 MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintDual, c::RSOCBridge) = _get(model, attr, c)
 
-MOI.canmodify(model::MOI.ModelLike, ::Type{<:RSOCBridge}, ::Type{<:MOI.AbstractFunctionModification}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCBridge}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RSOCBridge}) = false

--- a/src/Bridges/soctopsdbridge.jl
+++ b/src/Bridges/soctopsdbridge.jl
@@ -86,7 +86,6 @@ function MOI.delete!(instance::MOI.AbstractOptimizer, c::SOCtoPSDCBridge)
     MOI.delete!(instance, c.cr)
 end
 
-MOI.canmodify(::MOI.AbstractOptimizer, ::Type{<:SOCtoPSDCBridge}, ::Type{<:MOI.AbstractFunctionModification}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:SOCtoPSDCBridge}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:SOCtoPSDCBridge}) = false
 
@@ -153,6 +152,5 @@ function MOI.delete!(instance::MOI.AbstractOptimizer, c::RSOCtoPSDCBridge)
     MOI.delete!(instance, c.cr)
 end
 
-MOI.canmodify(::MOI.AbstractOptimizer, ::Type{<:RSOCtoPSDCBridge}, change) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCtoPSDCBridge}) = false
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RSOCtoPSDCBridge}) = false

--- a/src/Bridges/soctopsdbridge.jl
+++ b/src/Bridges/soctopsdbridge.jl
@@ -87,8 +87,8 @@ function MOI.delete!(instance::MOI.AbstractOptimizer, c::SOCtoPSDCBridge)
 end
 
 MOI.canmodify(::MOI.AbstractOptimizer, ::Type{<:SOCtoPSDCBridge}, ::Type{<:MOI.AbstractFunctionModification}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:SOCtoPSDCBridge}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:SOCtoPSDCBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:SOCtoPSDCBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:SOCtoPSDCBridge}) = false
 
 """
 The `RSOCtoPSDCBridge` transforms the second order cone constraint ``\\lVert x \\rVert \\le 2tu`` with ``u \\ge 0`` into the semidefinite cone constraints
@@ -154,5 +154,5 @@ function MOI.delete!(instance::MOI.AbstractOptimizer, c::RSOCtoPSDCBridge)
 end
 
 MOI.canmodify(::MOI.AbstractOptimizer, ::Type{<:RSOCtoPSDCBridge}, change) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCtoPSDCBridge}) = false
-MOI.canset(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RSOCtoPSDCBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCtoPSDCBridge}) = false
+MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RSOCtoPSDCBridge}) = false

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -78,48 +78,17 @@ Empty the model, that is, remove all variables, constraints and model attributes
 function empty! end
 
 """
-    CopyStatusCode
-
-An Enum of possible statuses returned by a `copy!` operation through the `CopyResult` struct.
-
-* `CopySuccess`: The copy was successful.
-* `CopyUnsupportedAttribute`: The copy failed because the destination does not support an attribute present in the source.
-* `CopyUnsupportedConstraint`: The copy failed because the destination does not support a constraint present in the source.
-* `CopyOtherError`: The copy failed for a different reason.
-
-In the failure cases:
-
-- See the corresponding `message` field of the `CopyResult` for an explanation of the failure.
-- The state of the destination model is undefined.
-"""
-@enum CopyStatusCode CopySuccess CopyUnsupportedAttribute CopyUnsupportedConstraint CopyOtherError
-
-"""
-    struct CopyResult{T}
-        status::CopyStatusCode
-        message::String # Human-friendly explanation why the copy failed
-        indexmap::T     # Only valid if status is CopySuccess
-    end
-
-A struct returned by `copy!` to indicate success or failure. If success, also exposes a map between the variable and constraint indices of the two models.
-"""
-struct CopyResult{T}
-    status::CopyStatusCode
-    message::String # Human-friendly explanation why the copy failed
-    indexmap::T     # Only valid if status is CopySuccess
-end
-
-"""
-    copy!(dest::ModelLike, src::ModelLike; copynames=true, warnattributes=true)::CopyResult
+    copy!(dest::ModelLike, src::ModelLike; copynames=true, warnattributes=true)
 
 Copy the model from `src` into `dest`. The target `dest` is emptied, and all
 previous indices to variables or constraints in `dest` are invalidated. Returns
-a `CopyResult` object. If the copy is successful, the `CopyResult` contains a
-dictionary-like object that translates variable and constraint indices from the
-`src` model to the corresponding indices in the `dest` model.
+a dictionary-like object that translates variable and constraint indices from
+the `src` model to the corresponding indices in the `dest` model.
 
-If `copynames` is `false`, the `Name`, `VariableName` and `ConstraintName` attributes are not copied even if they are set in `src`.
-If an attribute `attr` cannot be copied from `src` to `dest` then an error is thrown. If an optimizer attribute cannot be copied then:
+If `copynames` is `false`, the `Name`, `VariableName` and `ConstraintName`
+attributes are not copied even if they are set in `src`. If an attribute `attr`
+cannot be copied from `src` to `dest` then an error is thrown. If an optimizer
+attribute cannot be copied then:
 
 * If `warnattributes` is `true`, a warning is displayed, otherwise,
 * The attribute is silently ignored.
@@ -134,15 +103,9 @@ x = addvariable!(src)
 isvalid(src, x)   # true
 isvalid(dest, x)  # false (`dest` has no variables)
 
-copy_result = copy!(dest, src)
-if copy_result.status == CopySuccess
-    index_map = copy_result.indexmap
-    isvalid(dest, x) # false (unless index_map[x] == x)
-    isvalid(dest, index_map[x]) # true
-else
-    println("Copy failed with status ", copy_result.status)
-    println("Failure message: ", copy_result.message)
-end
+index_map = copy!(dest, src)
+isvalid(dest, x) # false (unless index_map[x] == x)
+isvalid(dest, index_map[x]) # true
 ```
 """
 function copy! end

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -86,12 +86,15 @@ a dictionary-like object that translates variable and constraint indices from
 the `src` model to the corresponding indices in the `dest` model.
 
 If `copynames` is `false`, the `Name`, `VariableName` and `ConstraintName`
-attributes are not copied even if they are set in `src`. If an attribute `attr`
-cannot be copied from `src` to `dest` then an error is thrown. If an optimizer
-attribute cannot be copied then:
+attributes are not copied even if they are set in `src`. If a constraint that
+is copied from `src` is not supported by `dest` then an
+[`UnsupportedConstraint`](@ref) error is thrown. Similarly, if a model, variable
+or constraint attribute that is copied from `src` is not supported by `dest`
+then an [`UnsupportedAttribute`](@ref) error is thrown. Unsupported *optimizer*
+attributes are treated differently:
 
 * If `warnattributes` is `true`, a warning is displayed, otherwise,
-* The attribute is silently ignored.
+* the attribute is silently ignored.
 
 ### Example
 

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -147,6 +147,7 @@ end
 """
 function copy! end
 
+include("error.jl")
 include("indextypes.jl")
 include("functions.jl")
 include("sets.jl")

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -227,7 +227,6 @@ function basic_constraint_test_helper(model::MOI.ModelLike, config::TestConfig, 
     if delete
         @testset "delete!" begin
             c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-            @test MOI.candelete(model, c_indices[1])
             MOI.delete!(model, c_indices[1])
             @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == length(c_indices)-1
             @test !MOI.isvalid(model, c_indices[1])

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -180,7 +180,7 @@ function basic_constraint_test_helper(model::MOI.ModelLike, config::TestConfig, 
         @testset "ConstraintName" begin
             @test MOI.canget(model, MOI.ConstraintName(), typeof(c))
             @test MOI.get(model, MOI.ConstraintName(), c) == ""
-            @test MOI.canset(model, MOI.ConstraintName(), typeof(c))
+            @test MOI.supports(model, MOI.ConstraintName(), typeof(c))
             MOI.set!(model, MOI.ConstraintName(), c, "c")
             @test MOI.get(model, MOI.ConstraintName(), c) == "c"
         end

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -167,7 +167,6 @@ function basic_constraint_test_helper(model::MOI.ModelLike, config::TestConfig, 
     F, S = typeof(constraint_function), typeof(set)
 
     @test MOI.supportsconstraint(model, F, S)
-    @test MOI.canaddconstraint(model, F, S)
 
     @testset "NumberOfConstraints" begin
         @test MOI.canget(model, MOI.NumberOfConstraints{F,S}())

--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -218,8 +218,13 @@ function solve_affine_deletion_edge_cases(model::MOI.ModelLike, config::TestConf
         constraint_primal = [(c1, [0.0]), (c2, 0.0)]
     )
     # now delete the VectorAffineFunction
-    @test MOI.candelete(model, c1)
     MOI.delete!(model, c1)
+    @test_throws MOI.InvalidIndex{typeof(c1)} MOI.delete!(model, c1)
+    try
+        MOI.delete!(model, c1)
+    catch err
+        @test err.index == c1
+    end
     test_model_solution(model, config; objective_value = 1.0,
         constraint_primal = [(c2, 1.0)]
     )
@@ -229,7 +234,6 @@ function solve_affine_deletion_edge_cases(model::MOI.ModelLike, config::TestConf
         constraint_primal = [(c2, 1.0), (c3, [-1.0])]
     )
     # delete the ScalarAffineFunction
-    @test MOI.candelete(model, c2)
     MOI.delete!(model, c2)
     test_model_solution(model, config; objective_value = 2.0,
         constraint_primal = [(c3, [0.0])]

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -22,7 +22,7 @@ function solve_set_singlevariable_lessthan(model::MOI.ModelLike, config::TestCon
         constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, -1.0)]
     )
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(c))
+    @test MOI.supports(model, MOI.ConstraintSet(), typeof(c))
     MOI.set!(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
     @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
     @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
@@ -92,7 +92,7 @@ function solve_set_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConfi
         constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, -1.0)]
     )
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(c))
+    @test MOI.supports(model, MOI.ConstraintSet(), typeof(c))
     MOI.set!(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
     @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
     @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
@@ -160,7 +160,7 @@ function solve_func_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConf
         constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, -1.0)]
     )
-    @test MOI.canset(model, MOI.ConstraintFunction(), typeof(c))
+    @test MOI.supports(model, MOI.ConstraintFunction(), typeof(c))
     MOI.set!(model, MOI.ConstraintFunction(), c,
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(2.0, x)], 0.0)
     )

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -127,7 +127,6 @@ function solve_coef_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConf
         constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, -1.0)]
     )
-    @test MOI.canmodify(model, typeof(c), MOI.ScalarCoefficientChange{Float64})
     MOI.modify!(model, c, MOI.ScalarCoefficientChange(x, 2.0))
     test_model_solution(model, config;
         objective_value   = 0.5,
@@ -205,7 +204,6 @@ function solve_const_vectoraffine_nonpos(model::MOI.ModelLike, config::TestConfi
         variable_primal   = [(x, 0.0), (y, 0.0)],
         constraint_primal = [(c, [0.0, 0.0])]
     )
-    @test MOI.canmodify(model, typeof(c), MOI.VectorConstantChange{Float64})
     MOI.modify!(model, c, MOI.VectorConstantChange([-1.0, -1.5]))
     test_model_solution(model, config;
         objective_value   = 2.5,
@@ -243,7 +241,6 @@ function solve_multirow_vectoraffine_nonpos(model::MOI.ModelLike, config::TestCo
         variable_primal   = [(x, 0.5)],
         constraint_primal = [(c, [-0.5, 0.0])]
     )
-    @test MOI.canmodify(model, typeof(c), MOI.MultirowChange{Float64})
     MOI.modify!(model, c, MOI.MultirowChange(x, [(1,4.0), (2,3.0)]))
     test_model_solution(model, config;
         objective_value   = 0.25,
@@ -270,10 +267,6 @@ function solve_const_scalar_objective(model::MOI.ModelLike, config::TestConfig)
     test_model_solution(model, config;
         objective_value   = 3.0,
         variable_primal   = [(x, 1.0)]
-    )
-    @test MOI.canmodify(model,
-        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-        MOI.ScalarConstantChange{Float64}
     )
     MOI.modify!(model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -303,10 +296,6 @@ function solve_coef_scalar_objective(model::MOI.ModelLike, config::TestConfig)
     test_model_solution(model, config;
         objective_value   = 1.0,
         variable_primal   = [(x, 1.0)]
-    )
-    @test MOI.canmodify(model,
-        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-        MOI.ScalarCoefficientChange{Float64}
     )
     MOI.modify!(model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -57,8 +57,6 @@ function solve_transform_singlevariable_lessthan(model::MOI.ModelLike, config::T
         constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, -1.0)]
     )
-    @test !MOI.cantransform(model, c, MOI.LessThan{Float64})
-    @test MOI.cantransform(model, c, MOI.GreaterThan{Float64})
     c2 = MOI.transform!(model, c, MOI.GreaterThan(2.0))
     @test !MOI.isvalid(model, c)
     @test MOI.isvalid(model, c2)

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -22,7 +22,7 @@ Test setting objective sense to MaxSense.
 function max_sense(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
-    @test MOI.canset(model, MOI.ObjectiveSense())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
     @test MOI.canget(model, MOI.ObjectiveSense())
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
@@ -37,7 +37,7 @@ Test setting objective sense to MinSense.
 function min_sense(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
-    @test MOI.canset(model, MOI.ObjectiveSense())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
     @test MOI.canget(model, MOI.ObjectiveSense())
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
@@ -52,7 +52,7 @@ Test setting objective sense to FeasibilitySense.
 function feasibility_sense(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
-    @test MOI.canset(model, MOI.ObjectiveSense())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
     @test MOI.canget(model, MOI.ObjectiveSense())
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FeasibilitySense

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -2,7 +2,6 @@
     Functions in this file test functionality relating to variables in MOI.
 
 ### Functionality currently tested
-    - canaddvariable
     - addvariables!
     - addvariable!
     - deleting variables
@@ -26,7 +25,6 @@ Test adding a single variable.
 function add_variable(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
-    @test MOI.canaddvariable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
@@ -41,7 +39,6 @@ Test adding multiple variables.
 function add_variables(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
-    @test MOI.canaddvariable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.addvariables!(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -56,7 +53,6 @@ Tess adding, and then deleting, a single variable.
 function delete_variable(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
-    @test MOI.canaddvariable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
@@ -74,7 +70,6 @@ Test adding, and then deleting, multiple variables.
 function delete_variables(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
-    @test MOI.canaddvariable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.addvariables!(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -117,7 +117,7 @@ function variablenames(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     v = MOI.addvariable!(model)
     @test MOI.get(model, MOI.VariableName(), v) == ""
-    @test MOI.canset(model, MOI.VariableName(), typeof(v))
+    @test MOI.supports(model, MOI.VariableName(), typeof(v))
     MOI.set!(model, MOI.VariableName(), v, "x")
     @test MOI.get(model, MOI.VariableName(), v) == "x"
     MOI.set!(model, MOI.VariableName(), v, "y")

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -56,7 +56,6 @@ function delete_variable(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-    @test MOI.candelete(model, v)
     MOI.delete!(model, v)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
 end
@@ -73,16 +72,18 @@ function delete_variables(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.addvariables!(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-    @test MOI.candelete(model, v)
     MOI.delete!(model, v)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.addvariables!(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-    @test MOI.candelete(model, v[1])
     MOI.delete!(model, v[1])
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-    @test !MOI.candelete(model, v[1])
-    @test MOI.candelete(model, v[2])
+    @test_throws MOI.InvalidIndex{MOI.VariableIndex} MOI.delete!(model, v[1])
+    try
+        MOI.delete!(model, v[1])
+    catch err
+        @test err.index == v[1]
+    end
     @test !MOI.isvalid(model, v[1])
     @test MOI.isvalid(model, v[2])
 end

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -28,14 +28,11 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
 
     vov = MOI.VectorOfVariables(v)
     if vecofvars
-        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
         vc = MOI.addconstraint!(model, vov, MOI.Nonnegatives(3))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
         vc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.Nonnegatives(3))
     end
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     c = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,1,1,2,2], MOI.ScalarAffineTerm.(1.0, [v;v[2];v[3]])), [-3.0,-2.0]), MOI.Zeros(2))
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
@@ -129,31 +126,24 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     c = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,1,2,3,3], MOI.ScalarAffineTerm.([1.0,-1.0,1.0,1.0,1.0], [x,s,y,x,z])), [4.0,3.0,-12.0]), MOI.Zeros(3))
 
     vov = MOI.VectorOfVariables([y])
     if vecofvars
-        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonpositives)
         vc = MOI.addconstraint!(model, vov, MOI.Nonpositives(1))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
         vc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.Nonpositives(1))
     end
     if vecofvars
         # test fallback
-        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
         vz = MOI.addconstraint!(model, [z], MOI.Nonnegatives(1))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
         vz = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, z))], [0.]), MOI.Nonnegatives(1))
     end
     vov = MOI.VectorOfVariables([s])
     if vecofvars
-        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Zeros)
         vs = MOI.addconstraint!(model, vov, MOI.Zeros(1))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
         vs = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.Zeros(1))
     end
 
@@ -230,9 +220,7 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
     MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))],[-1.0]), MOI.Nonnegatives(1))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
     MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [1.0]), MOI.Nonpositives(1))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
@@ -280,9 +268,7 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
     MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Nonnegatives(1))
-    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonpositives)
     MOI.addconstraint!(model, MOI.VectorOfVariables([x]), MOI.Nonpositives(1))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
@@ -345,14 +331,11 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     ceq = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Zeros(1))
     vov = MOI.VectorOfVariables([x,y,z])
     if vecofvars
-        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
         csoc = MOI.addconstraint!(model, vov, MOI.SecondOrderCone(3))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)
         csoc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.SecondOrderCone(3))
     end
 
@@ -437,15 +420,11 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if nonneg
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
         cnon = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [-1/√2]), MOI.Nonnegatives(1))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
         cnon = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(-1.0, y))], [1/√2]), MOI.Nonpositives(1))
     end
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     ceq = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(-1.0, t))], [1.0]), MOI.Zeros(1))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)
     csoc = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,2,3], MOI.ScalarAffineTerm.(1.0, [t,x,y])), zeros(3)), MOI.SecondOrderCone(3))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},nonneg ? MOI.Nonnegatives : MOI.Nonpositives}()) == 1
@@ -518,11 +497,8 @@ function soc3test(model::MOI.ModelLike, config::TestConfig)
     MOI.canaddvariable(model)
     x,y = MOI.addvariables!(model, 2)
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [-2.0]), MOI.Nonnegatives(1))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
     MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Nonpositives(1))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)
     MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,2], MOI.ScalarAffineTerm.(1.0, [x,y])), zeros(2)), MOI.SecondOrderCone(2))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
@@ -573,9 +549,7 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     MOI.canaddvariable(model)
     x = MOI.addvariables!(model, 5)
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,2,3,2,3], MOI.ScalarAffineTerm.([1.0,1.0,1.0,-1.0,-1.0], x)),[-1.0, 0.0, 0.0]), MOI.Zeros(3))
-    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
     c2 = MOI.addconstraint!(model, MOI.VectorOfVariables([x[1],x[4],x[5]]), MOI.SecondOrderCone(3))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
@@ -661,16 +635,12 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
         a = MOI.addvariable!(model)
         MOI.canaddvariable(model)
         b = MOI.addvariable!(model)
-        @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
         vc1 = MOI.addconstraint!(model, MOI.SingleVariable(a), MOI.EqualTo(0.5))
-        @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
         vc2 = MOI.addconstraint!(model, MOI.SingleVariable(b), MOI.EqualTo(1.0))
-        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.RotatedSecondOrderCone)
         rsoc = MOI.addconstraint!(model, MOI.VectorOfVariables([a; b; x]), MOI.RotatedSecondOrderCone(4))
     else
         a = 0.5
         b = 1.0
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)
         rsoc = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([3, 4], MOI.ScalarAffineTerm.([1., 1.], x)), [a, b, 0., 0.]), MOI.RotatedSecondOrderCone(4))
     end
 
@@ -768,14 +738,10 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     MOI.canaddvariable(model)
     x = MOI.addvariables!(model, 3)
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
     vc1 = MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.LessThan(1.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
     vc2 = MOI.addconstraint!(model, MOI.SingleVariable(x[2]), MOI.EqualTo(0.5))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     vc3 = MOI.addconstraint!(model, MOI.SingleVariable(x[3]), MOI.GreaterThan(2.0))
 
-    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.RotatedSecondOrderCone)
     rsoc = MOI.addconstraint!(model, MOI.VectorOfVariables(x), MOI.RotatedSecondOrderCone(3))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
@@ -852,20 +818,13 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     MOI.canaddvariable(model)
     t = MOI.addvariables!(model, 2)
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
     ct1 = MOI.addconstraint!(model, MOI.SingleVariable(t[1]), MOI.EqualTo(1.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
     ct2 = MOI.addconstraint!(model, MOI.SingleVariable(t[2]), MOI.EqualTo(1.0))
-    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
     cx  = MOI.addconstraint!(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(n))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     cu1 = MOI.addconstraint!(model, MOI.SingleVariable(u), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
     cu2 = MOI.addconstraint!(model, MOI.SingleVariable(u), MOI.LessThan(ub))
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)
     c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.(1:(2+n), MOI.ScalarAffineTerm.([1/√2; 1/√2; ones(n)], [t; x])), zeros(2+n)), MOI.RotatedSecondOrderCone(2+n))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone)
     c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 2, 3], MOI.ScalarAffineTerm.([1/√2; 1/√2; 1.0], [x[1], u, v])), zeros(3)), MOI.RotatedSecondOrderCone(3))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 2
@@ -981,13 +940,10 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
 
     vov = MOI.VectorOfVariables([t; x])
     if vecofvars
-        @test MOI.canaddconstraint(model, typeof(vov), MOI.GeometricMeanCone)
         gmc = MOI.addconstraint!(model, vov, MOI.GeometricMeanCone(n+1))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone)
         gmc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.GeometricMeanCone(n+1))
     end
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0), MOI.LessThan(Float64(n)))
 
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()) == 1
@@ -1065,16 +1021,12 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
 
     vov = MOI.VectorOfVariables(v)
     if vecofvars
-        @test MOI.canaddconstraint(model, typeof(vov), MOI.ExponentialCone)
         vc = MOI.addconstraint!(model, vov, MOI.ExponentialCone())
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
         vc = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), MOI.ExponentialCone())
     end
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     cx = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[1])], 0.), MOI.EqualTo(1.))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     cy = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[2])], 0.), MOI.EqualTo(2.))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1145,19 +1097,12 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     v = MOI.addvariables!(model, 9)
     @test MOI.get(model, MOI.NumberOfVariables()) == 9
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
     ec1 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 1, 3], MOI.ScalarAffineTerm.(1.0, [v[2], v[3], v[4]])), [0., 1., 0.]), MOI.ExponentialCone())
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
     ec2 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 1, 3], MOI.ScalarAffineTerm.([1., -1., 1.], [v[2], v[3], v[5]])), [0., 1., 0.]), MOI.ExponentialCone())
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([.5, .5, -1.], [v[4], v[5], v[6]]), 0.), MOI.EqualTo(0.))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 2, 3, 1, 2, 3], MOI.ScalarAffineTerm.([ 1.,  1.,  1., 0.3, 0.3, 0.3], [v[1], v[2], v[3], v[7], v[8], v[9]])), zeros(3)), MOI.Nonnegatives(3))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     c3 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 2, 3, 1, 2, 3], MOI.ScalarAffineTerm.([-1., -1., -1., 0.3, 0.3, 0.3], [v[1], v[2], v[3], v[7], v[8], v[9]])), zeros(3)), MOI.Nonnegatives(3))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     c4 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, [v[7], v[8], v[9]]), 0.), MOI.LessThan(1.))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     c5 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[7])], 0.0), MOI.EqualTo(0.0))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1240,11 +1185,8 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     y = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     xc = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(2.0, x)], 0.0), MOI.LessThan(4.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
     yc = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.LessThan(5.0))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
     ec = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 3], MOI.ScalarAffineTerm.(1.0, [x, y])), [0.0, 1.0, 0.0]), MOI.ExponentialCone())
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1328,14 +1270,11 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
 
     vov = MOI.VectorOfVariables(X)
     if vecofvars
-        @test MOI.canaddconstraint(model, typeof(vov), psdcone)
         cX = MOI.addconstraint!(model, vov, psdcone(2))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, psdcone)
         cX = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), psdcone(2))
     end
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, X[2])], 0.0), MOI.EqualTo(1.0))
 
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, psdcone}()) == 1
@@ -1478,18 +1417,13 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
 
     vov = MOI.VectorOfVariables(X)
     if vecofvars
-        @test MOI.canaddconstraint(model, typeof(vov), psdcone)
         cX = MOI.addconstraint!(model, vov, psdcone(3))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, psdcone)
         cX = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), psdcone(3))
     end
-    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
     cx = MOI.addconstraint!(model, MOI.VectorOfVariables(x), MOI.SecondOrderCone(3))
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1., 1, 1, 1], [X[1], X[square ? 5 : 3], X[end], x[1]]), 0.), MOI.EqualTo(1.))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(square ? ones(11) : [1., 2, 1, 2, 2, 1, 1, 1], [X; x[2]; x[3]]), 0.), MOI.EqualTo(1/2))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1571,9 +1505,7 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 7
 
     η = 10.0
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(-1.0, x[1:6]), η), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
     c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.(1:6, MOI.ScalarAffineTerm.(-1.0, x[1:6])), zeros(6)), MOI.Nonpositives(6))
     α = 0.8
     δ = 0.9
@@ -1584,7 +1516,6 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
                                                                  δ/2,     δ-α,   0,      δ/8,      δ/4, -1.0],
                                                                [x[1:7];     x[1:3]; x[5:6]; x[1:3]; x[5:7]])),
                                                                zeros(3)), MOI.PositiveSemidefiniteConeTriangle(2))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     c4 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(0.0, [x[1:3]; x[5:6]]), 0.0), MOI.EqualTo(0.))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
@@ -1693,14 +1624,11 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
 
     vov = MOI.VectorOfVariables([t; Q])
     if vecofvars
-        @test MOI.canaddconstraint(model, typeof(vov), detcone)
         cX = MOI.addconstraint!(model, vov, detcone(2))
     else
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, detcone)
         cX = MOI.addconstraint!(model, MOI.VectorAffineFunction{Float64}(vov), detcone(2))
     end
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     c = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.(1:2, MOI.ScalarAffineTerm.([-1., -1.], [Q[1], Q[end]])), ones(2)), MOI.Nonnegatives(2))
 
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, detcone}()) == 1

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -12,6 +12,7 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     # Opt obj = -11, soln x = 1, y = 0, z = 2
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
     else
@@ -40,9 +41,7 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     @test (vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonnegatives) in loc
     @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-3.0, -2.0, -4.0], v), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -103,6 +102,7 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     # x = -4, y = -3, z = 16, s == 0
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.Nonpositives)
@@ -119,9 +119,7 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     x,y,z,s = MOI.addvariables!(model, 4)
     @test MOI.get(model, MOI.NumberOfVariables()) == 4
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([3.0, 2.0, -4.0], [x,y,z]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     c = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,1,2,3,3], MOI.ScalarAffineTerm.([1.0,-1.0,1.0,1.0,1.0], [x,s,y,x,z])), [4.0,3.0,-12.0]), MOI.Zeros(3))
@@ -209,6 +207,7 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
     #       1 + x ∈ R₋
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
 
@@ -256,6 +255,7 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
     #           x ∈ R₋
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.Nonpositives)
 
@@ -309,6 +309,7 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     #      x >= ||(y,z)||
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.Zeros)
     else
@@ -321,9 +322,7 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
 
     x,y,z = MOI.addvariables!(model, 3)
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [y,z]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     ceq = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Zeros(1))
@@ -395,6 +394,7 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     #      (t,x,y) ∈ SOC₃
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     if nonneg
         @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
@@ -408,9 +408,7 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
 
     x,y,t = MOI.addvariables!(model, 3)
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if nonneg
@@ -481,6 +479,7 @@ function soc3test(model::MOI.ModelLike, config::TestConfig)
     #       (x,y) ∈ SOC₂
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64},MOI.Nonnegatives)
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64},MOI.Nonpositives)
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone)
@@ -533,6 +532,7 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     # Tests out-of-order indices in cones
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
 
@@ -547,9 +547,7 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,-2.0,-1.0, 0.0, 0.0], x), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
     if config.solve
         MOI.optimize!(model)
@@ -610,6 +608,7 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
 
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     if abvars
         @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.RotatedSecondOrderCone)
@@ -636,9 +635,7 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == (abvars ? 2 : 0)
     @test MOI.get(model, MOI.NumberOfConstraints{abvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
     if config.solve
         MOI.optimize!(model)
@@ -716,6 +713,7 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     c = [0.0,0.0,0.0]
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.SingleVariable,MOI.EqualTo{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable,MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable,MOI.GreaterThan{Float64})
@@ -737,9 +735,7 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.RotatedSecondOrderCone}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(c, x), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
     if config.solve
         MOI.optimize!(model)
@@ -788,6 +784,7 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     # [x1/√2, u/√2,  v] in SOC3
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
     @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
@@ -818,9 +815,7 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 2
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -907,6 +902,7 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
     # This can be attained using x = y = z = 1 so it is optimal.
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.GeometricMeanCone)
     else
@@ -931,9 +927,7 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, t)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
     if config.solve
         MOI.optimize!(model)
@@ -987,6 +981,7 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     #      y == 2
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.ExponentialCone)
     else
@@ -1010,9 +1005,7 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     cx = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[1])], 0.), MOI.EqualTo(1.))
     cy = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[2])], 0.), MOI.EqualTo(2.))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, v), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -1066,6 +1059,7 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     rtol = config.rtol
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -1085,9 +1079,7 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     c4 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, [v[7], v[8], v[9]]), 0.), MOI.LessThan(1.))
     c5 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[7])], 0.0), MOI.EqualTo(0.0))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[6])], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -1152,6 +1144,7 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     rtol = config.rtol
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable,                MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
@@ -1167,9 +1160,7 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     yc = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.LessThan(5.0))
     ec = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 3], MOI.ScalarAffineTerm.(1.0, [x, y])), [0.0, 1.0, 0.0]), MOI.ExponentialCone())
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -1232,6 +1223,7 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     #     ⎝ 1   1 ⎠
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, psdcone)
     else
@@ -1257,9 +1249,7 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, psdcone}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, [X[1], X[end]]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
     if config.solve
         MOI.optimize!(model)
@@ -1374,6 +1364,7 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     β = k*α
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     if vecofvars
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, psdcone)
@@ -1401,11 +1392,9 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1., 1, 1, 1], [X[1], X[square ? 5 : 3], X[end], x[1]]), 0.), MOI.EqualTo(1.))
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(square ? ones(11) : [1., 2, 1, 2, 2, 1, 1, 1], [X; x[2]; x[3]]), 0.), MOI.EqualTo(1/2))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     objXidx = square ? [1:2; 4:6; 8:9] : [1:3; 5:6]
     objXcoefs = square ? [2., 1., 1., 2., 1., 1., 2.] : 2*ones(5)
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([objXcoefs; 1.0], [X[objXidx]; x[1]]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, psdcone}()) == 1
@@ -1467,6 +1456,7 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     # Caused getdual to fail on SCS and Mosek
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
     @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle)
@@ -1497,9 +1487,7 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x[7])], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
     if config.solve
         MOI.optimize!(model)
@@ -1579,6 +1567,7 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
     #            -Q22 ≥ -1
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, detcone)
     else
@@ -1606,9 +1595,7 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, detcone}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, t)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
     if config.solve
         MOI.optimize!(model)

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -22,7 +22,6 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
@@ -117,7 +116,6 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x,y,z,s = MOI.addvariables!(model, 4)
     @test MOI.get(model, MOI.NumberOfVariables()) == 4
 
@@ -217,7 +215,6 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
 
     MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))],[-1.0]), MOI.Nonnegatives(1))
@@ -265,7 +262,6 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
 
     MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Nonnegatives(1))
@@ -323,7 +319,6 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x,y,z = MOI.addvariables!(model, 3)
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -411,7 +406,6 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x,y,t = MOI.addvariables!(model, 3)
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -494,7 +488,6 @@ function soc3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x,y = MOI.addvariables!(model, 2)
 
     MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [-2.0]), MOI.Nonnegatives(1))
@@ -546,7 +539,6 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariables!(model, 5)
 
     c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,2,3,2,3], MOI.ScalarAffineTerm.([1.0,1.0,1.0,-1.0,-1.0], x)),[-1.0, 0.0, 0.0]), MOI.Zeros(3))
@@ -628,12 +620,9 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariables!(model, 2)
     if abvars
-        MOI.canaddvariable(model)
         a = MOI.addvariable!(model)
-        MOI.canaddvariable(model)
         b = MOI.addvariable!(model)
         vc1 = MOI.addconstraint!(model, MOI.SingleVariable(a), MOI.EqualTo(0.5))
         vc2 = MOI.addconstraint!(model, MOI.SingleVariable(b), MOI.EqualTo(1.0))
@@ -735,7 +724,6 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariables!(model, 3)
 
     vc1 = MOI.addconstraint!(model, MOI.SingleVariable(x[1]), MOI.LessThan(1.0))
@@ -809,13 +797,9 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariables!(model, n)
-    MOI.canaddvariable(model)
     u = MOI.addvariable!(model)
-    MOI.canaddvariable(model)
     v = MOI.addvariable!(model)
-    MOI.canaddvariable(model)
     t = MOI.addvariables!(model, 2)
 
     ct1 = MOI.addconstraint!(model, MOI.SingleVariable(t[1]), MOI.EqualTo(1.0))
@@ -933,9 +917,7 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     t = MOI.addvariable!(model)
-    MOI.canaddvariable(model)
     x = MOI.addvariables!(model, n)
 
     vov = MOI.VectorOfVariables([t; x])
@@ -1015,7 +997,6 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
@@ -1093,7 +1074,6 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 9)
     @test MOI.get(model, MOI.NumberOfVariables()) == 9
 
@@ -1179,9 +1159,7 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
@@ -1264,7 +1242,6 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     X = MOI.addvariables!(model, square ? 4 : 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 4 : 3)
 
@@ -1408,10 +1385,8 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     X = MOI.addvariables!(model, square ? 9 : 6)
     @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 9 : 6)
-    MOI.canaddvariable(model)
     x = MOI.addvariables!(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 12 : 9)
 
@@ -1500,7 +1475,6 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariables!(model, 7)
     @test MOI.get(model, MOI.NumberOfVariables()) == 7
 
@@ -1615,10 +1589,8 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     t = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-    MOI.canaddvariable(model)
     Q = MOI.addvariables!(model, square ? 4 : 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 5 : 4)
 

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -23,7 +23,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
@@ -150,7 +149,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x + y + z <= 1
     # x,y,z >= 0
 
-    @test MOI.canaddvariable(model)
     z = MOI.addvariable!(model)
     push!(v, z)
     @test v[3] == z
@@ -456,9 +454,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
 
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -532,7 +528,6 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
@@ -575,7 +570,6 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
@@ -624,9 +618,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
 
     # Min  x - y
@@ -711,9 +703,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
 
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -856,9 +846,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
 
     # Min  x - y
@@ -927,9 +915,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
 
     # Min  x - y
@@ -1017,9 +1003,7 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,1.0], [x,y]), 0.0), MOI.LessThan(-1.0))
     bndx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
@@ -1074,9 +1058,7 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
     MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0,2.0], [x,y]), 0.0), MOI.LessThan(0.0))
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
@@ -1121,9 +1103,7 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
     MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,-1.0], [x,y]), 0.0), MOI.EqualTo(0.0))
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
@@ -1180,9 +1160,7 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
 
     MOI.addconstraints!(model,
@@ -1240,9 +1218,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
 
     MOI.addconstraints!(model,
@@ -1348,7 +1324,6 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 2)
 
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.GreaterThan(1.0))
@@ -1398,9 +1373,7 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,-3.0], [x,y]), 0.0), MOI.LessThan(-7.0))
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, y)], 0.0), MOI.LessThan(2.0))
@@ -1455,9 +1428,7 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0), MOI.GreaterThan(1.0))
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,-1.0], [x,y]), 0.0), MOI.EqualTo(0.0))
@@ -1518,7 +1489,6 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     x, y, z = MOI.addvariables!(model, 3)
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([3.0, 2.0, 1.0], [x, y, z]), 0.0), MOI.LessThan(2.0))
     clbx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -28,14 +28,11 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
     cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, cf, MOI.LessThan(1.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     vc1 = MOI.addconstraint!(model, MOI.SingleVariable(v[1]), MOI.GreaterThan(0.0))
     # test fallback
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     vc2 = MOI.addconstraint!(model, v[2], MOI.GreaterThan(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
@@ -167,7 +164,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[1])], 0.0) ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     end
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     vc3 = MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.GreaterThan(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
@@ -178,7 +174,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.candelete(model, c)
         MOI.delete!(model, c)
         cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0,1.0], v), 0.0)
-        @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
         c = MOI.addconstraint!(model, cf, MOI.LessThan(1.0))
     end
 
@@ -267,7 +262,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.candelete(model, vc3)
     MOI.delete!(model, vc3)
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
     vc3 = MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
@@ -298,7 +292,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     MOI.delete!(model, c)
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
     cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,0.0,0.0,1.0,1.0,1.0,0.0,0.0,0.0], [v; v; v]), 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf), MOI.EqualTo{Float64})
     c = MOI.addconstraint!(model, cf, MOI.EqualTo(2.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
@@ -364,7 +357,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # x,y >= 0 (vc1,vc2), z = 0 (vc3)
 
     cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0, 0.0], v), 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf2), MOI.GreaterThan{Float64})
     c2 = MOI.addconstraint!(model, cf2, MOI.GreaterThan(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
@@ -472,13 +464,10 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
     cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [x, y]), 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, cf, MOI.LessThan(1.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     vc1 = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     vc2 = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
@@ -547,10 +536,8 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     x = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     cf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf), MOI.GreaterThan{Float64})
     MOI.addconstraint!(model, cf, MOI.GreaterThan(3.0))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
@@ -592,10 +579,8 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     x = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.LessThan(0.0))
     cf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
     MOI.addconstraint!(model, cf, MOI.LessThan(3.0))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
@@ -653,9 +638,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
     c2 = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.LessThan(0.0))
 
     if config.solve
@@ -738,16 +721,12 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,1.0], [x, y]), 0.0)
     cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,2.0], [x, y]), 0.0)
 
-    @test MOI.canaddconstraint(model, typeof(cf1), MOI.LessThan{Float64})
     c1 = MOI.addconstraint!(model, cf1, MOI.LessThan(4.0))
-    @test MOI.canaddconstraint(model, typeof(cf2), MOI.LessThan{Float64})
     c2 = MOI.addconstraint!(model, cf2, MOI.LessThan(4.0))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     vc1 = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     vc2 = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
@@ -793,7 +772,6 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.candelete(model, c1)
         MOI.delete!(model, c1)
         cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0)
-        @test MOI.canaddconstraint(model, typeof(cf1), MOI.LessThan{Float64})
         c1 = MOI.addconstraint!(model, cf1, MOI.LessThan(4.0))
     end
 
@@ -892,9 +870,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, y)], 0.0), MOI.LessThan(0.0))
 
     if config.solve
@@ -965,9 +941,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [0.0]), MOI.Nonnegatives(1))
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
     c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [0.0]), MOI.Nonpositives(1))
 
     if config.solve
@@ -991,7 +965,6 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     else
         @test MOI.candelete(model, c1)
         MOI.delete!(model, c1)
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
         c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-100.0]), MOI.Nonnegatives(1))
     end
 
@@ -1015,7 +988,6 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     else
         @test MOI.candelete(model, c2)
         MOI.delete!(model, c2)
-        @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
         c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [100.0]), MOI.Nonpositives(1))
     end
 
@@ -1049,11 +1021,8 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     x = MOI.addvariable!(model)
     @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,1.0], [x,y]), 0.0), MOI.LessThan(-1.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     bndx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     bndy = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1109,11 +1078,8 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     x = MOI.addvariable!(model)
     @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0,2.0], [x,y]), 0.0), MOI.LessThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1159,11 +1125,8 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     x = MOI.addvariable!(model)
     @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,-1.0], [x,y]), 0.0), MOI.EqualTo(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1287,7 +1250,6 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         [MOI.GreaterThan(0.0), MOI.GreaterThan(0.0)]
     )
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x,y]), 0.0), MOI.Interval(5.0, 10.0))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1389,9 +1351,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 2)
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.GreaterThan(1.0))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.GreaterThan(2.0))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1442,13 +1402,9 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     x = MOI.addvariable!(model)
     @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,-3.0], [x,y]), 0.0), MOI.LessThan(-7.0))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, y)], 0.0), MOI.LessThan(2.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     bndx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     bndy = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1503,9 +1459,7 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
     x = MOI.addvariable!(model)
     @test MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0), MOI.GreaterThan(1.0))
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,-1.0], [x,y]), 0.0), MOI.EqualTo(0.0))
     @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
@@ -1566,13 +1520,10 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
 
     @test MOI.canaddvariable(model)
     x, y, z = MOI.addvariables!(model, 3)
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([3.0, 2.0, 1.0], [x, y, z]), 0.0), MOI.LessThan(2.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     clbx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     clby = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
     clbz = MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
     cubz = MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.LessThan(1.0))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -1407,7 +1407,6 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
     end
 
-    @test MOI.cantransform(model, c2, MOI.LessThan{Float64})
     c3 = MOI.transform!(model, c2, MOI.LessThan(2.0))
 
     @test isa(c3, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}})

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -163,7 +163,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
 
     if config.modify_lhs
-        @test MOI.canmodify(model, typeof(c), MOI.ScalarCoefficientChange{Float64})
         MOI.modify!(model, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
     else
         @test MOI.candelete(model, c)
@@ -172,10 +171,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         c = MOI.addconstraint!(model, cf, MOI.LessThan(1.0))
     end
 
-    @test MOI.canmodify(model,
-        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-        MOI.ScalarCoefficientChange{Float64}
-    )
     MOI.modify!(model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarCoefficientChange{Float64}(z, 2.0)
@@ -745,7 +740,6 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #   solution: x = 2, y = 0, objv = 2
 
     if config.modify_lhs
-        @test MOI.canmodify(model, typeof(c1), MOI.ScalarCoefficientChange{Float64})
         MOI.modify!(model, c1, MOI.ScalarCoefficientChange(y, 3.0))
     else
         @test MOI.candelete(model, c1)
@@ -933,7 +927,6 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     #               y <= 0.0
 
     if config.modify_lhs
-        @test MOI.canmodify(model, typeof(c1), MOI.VectorConstantChange{Float64})
         MOI.modify!(model, c1, MOI.VectorConstantChange([-100.0]))
     else
         @test MOI.candelete(model, c1)
@@ -956,7 +949,6 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     #               y <= -100.0
 
     if config.modify_lhs
-        @test MOI.canmodify(model, typeof(c2), MOI.VectorConstantChange{Float64})
         MOI.modify!(model, c2, MOI.VectorConstantChange([100.0]))
     else
         @test MOI.candelete(model, c2)

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -10,6 +10,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     #       x, y >= 0   (x, y ∈ Nonnegatives)
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -37,9 +38,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,0.0,-1.0,0.0,0.0,0.0], [v; v; v]), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
@@ -104,9 +103,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # change objective to Max +x
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,0.0], v), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.query
@@ -228,7 +225,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x + y + z <= 1
     # x >= -1
     # y,z >= 0
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(vc1))
+    MOI.supports(model, MOI.ConstraintSet(), typeof(vc1))
     MOI.set!(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(-1.0))
 
     if config.solve
@@ -254,7 +251,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # max x + 2z
     # s.t. x + y + z <= 1
     # x, y >= 0, z = 0 (vc3)
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(vc1))
+    MOI.supports(model, MOI.ConstraintSet(), typeof(vc1))
     MOI.set!(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(0.0))
 
     @test MOI.candelete(model, vc3)
@@ -319,9 +316,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # x,y >= 0, z = 0
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,2.0,0.0], v), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.query
@@ -448,6 +443,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
     # x, y >= 0
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
 
@@ -468,9 +464,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0,0.0], [x, y]), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
@@ -520,6 +514,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     #      x >= 3
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
@@ -539,9 +534,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
 
     objf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -581,9 +574,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
     objf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -612,6 +603,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     rtol = config.rtol
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
 
@@ -625,9 +617,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     # s.t. 0.0 <= x          (c1)
     #             y <= 0.0   (c2)
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x,y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     c1 = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
@@ -647,7 +637,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= 0.0
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(c1))
+    MOI.supports(model, MOI.ConstraintSet(), typeof(c1))
     MOI.set!(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(100.0))
     if config.solve
         MOI.optimize!(model)
@@ -662,7 +652,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= -100.0
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(c2))
+    MOI.supports(model, MOI.ConstraintSet(), typeof(c2))
     MOI.set!(model, MOI.ConstraintSet(), c2, MOI.LessThan(-100.0))
     if config.solve
         MOI.optimize!(model)
@@ -697,6 +687,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #   solution: x = 1.3333333, y = 1.3333333, objv = 2.66666666
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
 
@@ -722,9 +713,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [x, y]), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -840,6 +829,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     rtol = config.rtol
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
 
@@ -853,9 +843,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     # s.t. 0.0 <= x          (c1)
     #             y <= 0.0   (c2)
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x,y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0), MOI.GreaterThan(0.0))
@@ -875,7 +863,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= 0.0
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(c1))
+    MOI.supports(model, MOI.ConstraintSet(), typeof(c1))
     MOI.set!(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(100.0))
     if config.solve
         MOI.optimize!(model)
@@ -890,7 +878,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= -100.0
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(c2))
+    MOI.supports(model, MOI.ConstraintSet(), typeof(c2))
     MOI.set!(model, MOI.ConstraintSet(), c2, MOI.LessThan(-100.0))
     if config.solve
         MOI.optimize!(model)
@@ -909,6 +897,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     rtol = config.rtol
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     @test MOI.supportsconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
 
@@ -922,9 +911,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     # s.t. 0.0 <= x          (c1)
     #             y <= 0.0   (c2)
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x,y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [0.0]), MOI.Nonnegatives(1))
@@ -997,6 +984,7 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     # x,y >= 0
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
 
@@ -1009,9 +997,7 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     bndx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     bndy = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -1052,6 +1038,7 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     # x,y >= 0
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
 
@@ -1064,9 +1051,7 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0, -1.0], [x, y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -1097,6 +1082,7 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     # x,y >= 0
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
 
@@ -1109,9 +1095,7 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0, -1.0], [x, y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -1153,6 +1137,7 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
     #   objv: 71818.1818
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
@@ -1184,10 +1169,8 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
         ]
     )
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
                       MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1_000.0, 350.0], [x, y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -1212,6 +1195,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     #                  x,  y >= 0
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
 
@@ -1228,9 +1212,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
 
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x,y]), 0.0), MOI.Interval(5.0, 10.0))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -1251,9 +1233,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         end
     end
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -1274,7 +1254,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         end
     end
 
-    @test MOI.canset(model, MOI.ConstraintSet(), typeof(c))
+    MOI.supports(model, MOI.ConstraintSet(), typeof(c))
     MOI.set!(model, MOI.ConstraintSet(), c, MOI.Interval(2.0, 12.0))
 
     if config.query
@@ -1292,9 +1272,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
     end
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -1318,6 +1296,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     #      x + y >= 2
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
 
@@ -1329,9 +1308,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.GreaterThan(1.0))
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.GreaterThan(2.0))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -1367,6 +1344,7 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     # x,y >= 0
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
 
@@ -1380,9 +1358,7 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     bndx = MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     bndy = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -1432,7 +1408,6 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
     y = MOI.addvariable!(model)
     c1 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0), MOI.GreaterThan(1.0))
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,-1.0], [x,y]), 0.0), MOI.EqualTo(0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FeasibilitySense
 
@@ -1482,6 +1457,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     #      z <= 1
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
@@ -1496,9 +1472,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     clbz = MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.GreaterThan(0.0))
     cubz = MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.LessThan(1.0))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], [x, y, z]), 4.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -165,7 +165,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.modify_lhs
         MOI.modify!(model, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
     else
-        @test MOI.candelete(model, c)
         MOI.delete!(model, c)
         cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0,1.0], v), 0.0)
         c = MOI.addconstraint!(model, cf, MOI.LessThan(1.0))
@@ -249,7 +248,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     MOI.supports(model, MOI.ConstraintSet(), typeof(vc1))
     MOI.set!(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(0.0))
 
-    @test MOI.candelete(model, vc3)
     MOI.delete!(model, vc3)
 
     vc3 = MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
@@ -278,7 +276,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # max x + 2z
     # s.t. x + y + z == 2 (c)
     # x,y >= 0, z = 0
-    @test MOI.candelete(model, c)
     MOI.delete!(model, c)
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
     cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,0.0,0.0,1.0,1.0,1.0,0.0,0.0,0.0], [v; v; v]), 0.0)
@@ -742,7 +739,6 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.modify_lhs
         MOI.modify!(model, c1, MOI.ScalarCoefficientChange(y, 3.0))
     else
-        @test MOI.candelete(model, c1)
         MOI.delete!(model, c1)
         cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0)
         c1 = MOI.addconstraint!(model, cf1, MOI.LessThan(4.0))
@@ -771,7 +767,6 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #        x >= 0, y >= 0
     #
     #   solution: x = 4, y = 0, objv = 4
-    @test MOI.candelete(model, c1)
     MOI.delete!(model, c1)
 
     if config.solve
@@ -797,7 +792,6 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #           y >= 0
     #
     #   solution: y = 2, objv = 2
-    @test MOI.candelete(model, x)
     MOI.delete!(model, x)
 
     if config.solve
@@ -929,7 +923,6 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     if config.modify_lhs
         MOI.modify!(model, c1, MOI.VectorConstantChange([-100.0]))
     else
-        @test MOI.candelete(model, c1)
         MOI.delete!(model, c1)
         c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-100.0]), MOI.Nonnegatives(1))
     end
@@ -951,7 +944,6 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     if config.modify_lhs
         MOI.modify!(model, c2, MOI.VectorConstantChange([100.0]))
     else
-        @test MOI.candelete(model, c2)
         MOI.delete!(model, c2)
         c2 = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [100.0]), MOI.Nonpositives(1))
     end
@@ -1513,7 +1505,6 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
         end
     end
 
-    @test MOI.candelete(model, [x, z])
     MOI.delete!(model, [x, z])
 
     if config.solve

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -26,9 +26,7 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
 
     obj = MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm{Float64}[], MOI.ScalarQuadraticTerm.([2.0, 1.0, 2.0, 1.0, 2.0], v[[1,1,2,2,3]], v[[1,2,2,3,3]]), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 
@@ -88,9 +86,7 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
 
     obj = MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm.(0.0, v), MOI.ScalarQuadraticTerm.([2.0, 0.5, 0.5, 2.0, 1.0, 1.0, 1.0], [v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]]), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 
@@ -123,9 +119,7 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
 
     # change objective to Max -2(x^2 + xy + y^2 + yz + z^2)
     obj2 = MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm.(0.0, v), MOI.ScalarQuadraticTerm.([-4.0, -1.0, -1.0, -4.0, -2.0, -2.0, -2.0], [v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]]), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj2)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 
@@ -182,9 +176,7 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
             MOI.ScalarQuadraticTerm.([4.0, 2.0, 1.0], [x,y,x], [x,y,y]),
             1.0
           )
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     if config.solve
@@ -208,9 +200,7 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     #             x + y = 1
     # (x,y) = (1,0), obj = 3
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,1.0], [x,y]), 1.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -268,9 +258,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     c2 = MOI.addconstraint!(model, c2f, MOI.LessThan(2.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [x,y]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 
@@ -336,9 +324,7 @@ function qcp2test(model::MOI.ModelLike, config::TestConfig)
     c = MOI.addconstraint!(model, cf, MOI.LessThan(2.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 
@@ -395,9 +381,7 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     c = MOI.addconstraint!(model, cf, MOI.LessThan(2.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(-1.0, x)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 
@@ -477,9 +461,7 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     bound = MOI.addconstraint!(model, MOI.SingleVariable(t), MOI.GreaterThan(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable, MOI.GreaterThan{Float64}}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, t)], 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -20,11 +20,9 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
     cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,2.0,3.0], v), 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf1), MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(model, cf1, MOI.GreaterThan(4.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [v[1],v[2]]), 0.0), MOI.GreaterThan(1.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
 
@@ -85,11 +83,9 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
     c1f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,2.0,3.0], v), 0.0)
-    @test MOI.canaddconstraint(model, typeof(c1f), MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(model, c1f, MOI.GreaterThan(4.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
     c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [v[1],v[2]]), 0.0), MOI.GreaterThan(1.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 2
 
@@ -182,9 +178,7 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
         MOI.EqualTo(1.0)
     )
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     obj = MOI.ScalarQuadraticFunction(
@@ -273,12 +267,10 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     y = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     c1 = MOI.addconstraint!(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,1,2,2], MOI.ScalarAffineTerm.([-1.0,1.0,1.0,1.0], [x,y,x,y])), [0.0,0.0]), MOI.Nonnegatives(2))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}()) == 1
 
     c2f = MOI.ScalarQuadraticFunction([MOI.ScalarAffineTerm(1.0, y)], [MOI.ScalarQuadraticTerm(2.0, x, x)], 0.0)
-    @test MOI.canaddconstraint(model, typeof(c2f), MOI.LessThan{Float64})
     c2 = MOI.addconstraint!(model, c2f, MOI.LessThan(2.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
@@ -348,7 +340,6 @@ function qcp2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
     cf = MOI.ScalarQuadraticFunction([MOI.ScalarAffineTerm(0.0, x)], [MOI.ScalarQuadraticTerm(2.0, x, x)], 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, cf, MOI.LessThan(2.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
@@ -409,7 +400,6 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
     cf = MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm{Float64}[], [MOI.ScalarQuadraticTerm(2.0, x, x)], 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, cf, MOI.LessThan(2.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
@@ -488,16 +478,13 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
     c1f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x,y]), 0.0)
-    @test MOI.canaddconstraint(model, typeof(c1f), MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(model, c1f, MOI.GreaterThan(1.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}}()) == 1
 
     c2f = MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm{Float64}[], MOI.ScalarQuadraticTerm.([1.0,1.0,-1.0], [x,y,t], [x,y,t]), 0.0)
-    @test MOI.canaddconstraint(model, typeof(c2f), MOI.LessThan{Float64})
     c2 = MOI.addconstraint!(model, c2f, MOI.LessThan(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     bound = MOI.addconstraint!(model, MOI.SingleVariable(t), MOI.GreaterThan(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable, MOI.GreaterThan{Float64}}()) == 1
 

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -15,7 +15,6 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
@@ -78,7 +77,6 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
@@ -168,9 +166,7 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
 
     MOI.addconstraint!(model,
@@ -261,9 +257,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
@@ -335,7 +329,6 @@ function qcp2test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
@@ -395,7 +388,6 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
@@ -469,11 +461,8 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
-    MOI.canaddvariable(model)
     y = MOI.addvariable!(model)
-    MOI.canaddvariable(model)
     t = MOI.addvariable!(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -26,9 +26,7 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
-    @test MOI.canaddconstraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     ceq = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Zeros(1))
-    @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SecondOrderCone)
     csoc = MOI.addconstraint!(model, MOI.VectorOfVariables([x,y,z]), MOI.SecondOrderCone(3))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}()) == 1
@@ -38,9 +36,7 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
     @test (MOI.VectorOfVariables,MOI.SecondOrderCone) in loc
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.ZeroOne)
     bin1 = MOI.addconstraint!(model, MOI.SingleVariable(y), MOI.ZeroOne())
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.ZeroOne)
     bin2 = MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.ZeroOne())
 
     if config.solve

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -18,7 +18,6 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    MOI.canaddvariable(model)
     x,y,z = MOI.addvariables!(model, 3)
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -20,9 +20,7 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
 
     x,y,z = MOI.addvariables!(model, 3)
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-2.0,-1.0], [y,z]), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
 
     ceq = MOI.addconstraint!(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Zeros(1))

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -163,9 +163,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
             @test MOI.canget(model, MOI.DualStatus()) == false
         end
 
-        @test MOI.candelete(model, c1)
         MOI.delete!(model, c1)
-        @test MOI.candelete(model, c2)
         MOI.delete!(model, c2)
 
         if config.solve
@@ -265,7 +263,6 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         end
 
         for cref in bin_constraints
-            @test MOI.candelete(model, cref)
             MOI.delete!(model, cref)
         end
 

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -14,6 +14,7 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     #         z is binary
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.ZeroOne)
@@ -46,9 +47,7 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 1
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.1, 2.0, 5.0], v), 0.0)
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
@@ -108,6 +107,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
     rtol = config.rtol
     @testset "SOSI" begin
         @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test MOI.supports(model, MOI.ObjectiveSense())
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
         @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
 
@@ -138,9 +138,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         @test cf_sos.variables[p] == v[[1,3]]
 
         objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 1.0, 1.0], v), 0.0)
-        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-        @test MOI.canset(model, MOI.ObjectiveSense())
         MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
         @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 
@@ -191,6 +189,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
     end
     @testset "SOSII" begin
         @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test MOI.supports(model, MOI.ObjectiveSense())
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
         @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.SOS2{Float64})
         @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.ZeroOne)
@@ -240,9 +239,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         @test cf_sos.variables[p] == v[[8,7,5,4,6]]
 
         objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [v[9], v[10]]), 0.0)
-        @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-        @test MOI.canset(model, MOI.ObjectiveSense())
         MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
         @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 
@@ -309,6 +306,7 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.isempty(model)
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.ZeroOne)
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.Integer)
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.Interval{Float64})
@@ -326,9 +324,7 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
 
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(vcat(1.0, fill(-0.5 / 40, 10)), vcat(z, b)), 0.0), MOI.Interval(0.0, 0.999))
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(vcat(1.0, fill(-0.5 / 40, 3)), vcat(z, b[1:3])), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.solve
@@ -372,6 +368,7 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     @test MOI.isempty(model)
 
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.ZeroOne)
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
 
@@ -385,12 +382,10 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 8.0, 4.0, 2.0, 5.0], v), 0.0), MOI.LessThan(10.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
-    @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     MOI.set!(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([5.0, 3.0, 2.0, 7.0, 4.0], v), 0.0))
-    @test MOI.canset(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
-    if MOI.canset(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
+    if MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
         MOI.set!(model, MOI.VariablePrimalStart(), v, [0.0, 0.0, 0.0, 0.0, 0.0])
     end
 

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -27,28 +27,22 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
     cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0,1.0], v), 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf), MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, cf, MOI.LessThan(10.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
     cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,2.0,1.0], v), 0.0)
-    @test MOI.canaddconstraint(model, typeof(cf2), MOI.LessThan{Float64})
     c2 = MOI.addconstraint!(model, cf2, MOI.LessThan(15.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
 
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Interval{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(v[1]), MOI.Interval(0.0, 5.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}()) == 1
 
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Interval{Float64})
     MOI.addconstraint!(model, MOI.SingleVariable(v[2]), MOI.Interval(0.0, 10.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}()) == 2
-    @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[2])), MOI.Integer)
     MOI.addconstraint!(model, MOI.SingleVariable(v[2]), MOI.Integer())
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Integer}()) == 1
 
-    @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[3])), MOI.ZeroOne)
     MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.ZeroOne())
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 1
 
@@ -124,16 +118,11 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.canaddvariable(model)
         v = MOI.addvariables!(model, 3)
         @test MOI.get(model, MOI.NumberOfVariables()) == 3
-        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[1])), MOI.LessThan{Float64})
         MOI.addconstraint!(model, MOI.SingleVariable(v[1]), MOI.LessThan(1.0))
-        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[2])), MOI.LessThan{Float64})
         MOI.addconstraint!(model, MOI.SingleVariable(v[2]), MOI.LessThan(1.0))
-        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[3])), MOI.LessThan{Float64})
         MOI.addconstraint!(model, MOI.SingleVariable(v[3]), MOI.LessThan(2.0))
 
-        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
         c1 = MOI.addconstraint!(model, MOI.VectorOfVariables([v[1], v[2]]), MOI.SOS1([1.0, 2.0]))
-        @test MOI.canaddconstraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
         c2 = MOI.addconstraint!(model, MOI.VectorOfVariables([v[1], v[3]]), MOI.SOS1([1.0, 2.0]))
         @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SOS1{Float64}}()) == 2
 
@@ -218,9 +207,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
 
         bin_constraints = []
         for i in 1:8
-            @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Interval{Float64})
             MOI.addconstraint!(model, MOI.SingleVariable(v[i]), MOI.Interval(0.0, 2.0))
-            @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(v[i])), MOI.ZeroOne)
             push!(bin_constraints, MOI.addconstraint!(model, MOI.SingleVariable(v[i]), MOI.ZeroOne()))
         end
 
@@ -241,7 +228,6 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
 
         vv   = MOI.VectorOfVariables(v[[4,5,6,7,8]])
         sos2 = MOI.SOS2([5.0, 4.0, 7.0, 2.0, 1.0])
-        @test MOI.canaddconstraint(model, typeof(vv), MOI.SOS2{Float64})
         c = MOI.addconstraint!(model, vv, sos2)
 
         @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
@@ -333,20 +319,16 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
 
     @test MOI.canaddvariable(model)
     z = MOI.addvariable!(model)
-    @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(z)), MOI.Integer)
     MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.Integer())
-    @test MOI.canaddconstraint(model, MOI.SingleVariable, MOI.Integer)
     MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.Interval(0.0, 100.0))
 
     @test MOI.canaddvariable(model)
     b = MOI.addvariables!(model, 10)
 
     for bi in b
-        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(bi)), MOI.ZeroOne)
         MOI.addconstraint!(model, MOI.SingleVariable(bi), MOI.ZeroOne())
     end
 
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(vcat(1.0, fill(-0.5 / 40, 10)), vcat(z, b)), 0.0), MOI.Interval(0.0, 0.999))
 
     @test MOI.canset(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -403,11 +385,9 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 5
 
     for vi in v
-        @test MOI.canaddconstraint(model, typeof(MOI.SingleVariable(vi)), MOI.ZeroOne)
         MOI.addconstraint!(model, MOI.SingleVariable(vi), MOI.ZeroOne())
     end
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}()) == 5
-    @test MOI.canaddconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 8.0, 4.0, 2.0, 5.0], v), 0.0), MOI.LessThan(10.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -22,7 +22,6 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.isempty(model)
 
-    @test MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
 
@@ -115,7 +114,6 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         MOI.empty!(model)
         @test MOI.isempty(model)
 
-        @test MOI.canaddvariable(model)
         v = MOI.addvariables!(model, 3)
         @test MOI.get(model, MOI.NumberOfVariables()) == 3
         MOI.addconstraint!(model, MOI.SingleVariable(v[1]), MOI.LessThan(1.0))
@@ -201,7 +199,6 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         MOI.empty!(model)
         @test MOI.isempty(model)
 
-        @test MOI.canaddvariable(model)
         v = MOI.addvariables!(model, 10)
         @test MOI.get(model, MOI.NumberOfVariables()) == 10
 
@@ -317,12 +314,10 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.Interval{Float64})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
 
-    @test MOI.canaddvariable(model)
     z = MOI.addvariable!(model)
     MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.Integer())
     MOI.addconstraint!(model, MOI.SingleVariable(z), MOI.Interval(0.0, 100.0))
 
-    @test MOI.canaddvariable(model)
     b = MOI.addvariables!(model, 10)
 
     for bi in b
@@ -380,7 +375,6 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.ZeroOne)
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
 
-    @test MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 5)
     @test MOI.get(model, MOI.NumberOfVariables()) == 5
 

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -84,19 +84,15 @@ function nametest(model::MOI.ModelLike)
         @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1") == c
         @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}, "Con0") == c2
 
-        if MOI.candelete(model, v[2])
-            MOI.delete!(model, v[2])
-            @test !MOI.canget(model, MOI.VariableIndex, "Var2")
-            @test_throws KeyError MOI.get(model, MOI.VariableIndex, "Var2")
-        end
+        MOI.delete!(model, v[2])
+        @test !MOI.canget(model, MOI.VariableIndex, "Var2")
+        @test_throws KeyError MOI.get(model, MOI.VariableIndex, "Var2")
 
-        if MOI.candelete(model, c)
-            MOI.delete!(model, c)
-            @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
-            @test !MOI.canget(model, MOI.ConstraintIndex, "Con1")
-            @test_throws KeyError MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
-            @test_throws KeyError MOI.get(model, MOI.ConstraintIndex, "Con1")
-        end
+        MOI.delete!(model, c)
+        @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
+        @test !MOI.canget(model, MOI.ConstraintIndex, "Con1")
+        @test_throws KeyError MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
+        @test_throws KeyError MOI.get(model, MOI.ConstraintIndex, "Con1")
     end
 end
 

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -21,7 +21,6 @@ function nametest(model::MOI.ModelLike)
         @test MOI.get(model, MOI.NumberOfVariables()) == 0
         @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
 
-        MOI.canaddvariable(model)
         v = MOI.addvariables!(model, 2)
         @test MOI.canget(model, MOI.VariableName(), typeof(v[1]))
         @test MOI.get(model, MOI.VariableName(), v[1]) == ""
@@ -104,11 +103,9 @@ end
 
 # Taken from https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/41
 function validtest(model::MOI.ModelLike)
-    MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 2)
     @test MOI.isvalid(model, v[1])
     @test MOI.isvalid(model, v[2])
-    MOI.canaddvariable(model)
     x = MOI.addvariable!(model)
     @test MOI.isvalid(model, x)
     MOI.delete!(model, x)
@@ -125,7 +122,6 @@ end
 
 function emptytest(model::MOI.ModelLike)
     # Taken from LIN1
-    MOI.canaddvariable(model)
     v = MOI.addvariables!(model, 3)
     @test MOI.supportsconstraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
     vc = MOI.addconstraint!(model, MOI.VectorOfVariables(v), MOI.Nonnegatives(3))
@@ -213,7 +209,6 @@ function failcopytestca(dest::MOI.ModelLike)
 end
 
 function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
-    MOI.canaddvariable(src)
     MOI.set!(src, MOI.Name(), "ModelName")
     v = MOI.addvariables!(src, 3)
     MOI.set!(src, MOI.VariableName(), v, ["var1", "var2", "var3"])
@@ -284,7 +279,6 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
 end
 
 function supportsconstrainttest(model::MOI.ModelLike, ::Type{GoodT}, ::Type{BadT}) where {GoodT, BadT}
-    MOI.canaddvariable(model)
     v = MOI.addvariable!(model)
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.EqualTo{GoodT})
     @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{GoodT}, MOI.EqualTo{GoodT})

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -106,7 +106,7 @@ function hs071test_template(model::MOI.ModelLike, config::TestConfig, evaluator:
     @test MOI.supports(model, MOI.NLPBlock())
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
-    @test MOI.canset(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
+    @test MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
 
     MOI.empty!(model)
     @test MOI.isempty(model)
@@ -224,7 +224,7 @@ function feasibility_sense_test_template(model::MOI.ModelLike,
     rtol = config.rtol
 
     @test MOI.supports(model, MOI.NLPBlock())
-    @test MOI.canset(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
+    @test MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
 
     MOI.empty!(model)
     @test MOI.isempty(model)

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -332,7 +332,7 @@ function MOI.delete!(m::CachingOptimizer, index::MOI.Index)
 end
 
 
-# TODO: addconstraints!, transform!, cantransform
+# TODO: addconstraints!, transform!
 
 ## CachingOptimizer get and set attributes
 

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -20,51 +20,47 @@ Base.delete!(idxmap::IndexMap, ci::MOI.ConstraintIndex) = delete!(idxmap.conmap,
 Base.keys(idxmap::IndexMap) = Iterators.flatten((keys(idxmap.varmap), keys(idxmap.conmap)))
 
 """
-    passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, canpassattr::Function=MOI.canset, passattr!::Function=MOI.set!)
+    passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, passattr!::Function=MOI.set!)
 
 Pass the model attributes from the model `src` to the model `dest` using `canpassattr` to check if the attribute can be passed and `passattr!` to pass the attribute. Does not copy `Name` if `copynames` is `false`.
 
-    passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, vis_src::Vector{MOI.VariableIndex}, canpassattr::Function=MOI.canset, passattr!::Function=MOI.set!)
+    passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, vis_src::Vector{MOI.VariableIndex}, passattr!::Function=MOI.set!)
 
 Pass the variable attributes from the model `src` to the model `dest` using `canpassattr` to check if the attribute can be passed and `passattr!` to pass the attribute. Does not copy `VariableName` if `copynames` is `false`.
 
-    passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, cis_src::Vector{MOI.ConstraintIndex{F, S}}, canpassattr::Function=MOI.canset, passattr!::Function=MOI.set!) where {F, S}
+    passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, cis_src::Vector{MOI.ConstraintIndex{F, S}}, passattr!::Function=MOI.set!) where {F, S}
 
 Pass the constraint attributes of `F`-in-`S` constraints from the model `src` to the model `dest` using `canpassattr` to check if the attribute can be passed and `passattr!` to pass the attribute. Does not copy `ConstraintName` if `copynames` is `false`.
 """
 function passattributes! end
 
-function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, canpassattr::Function=MOI.canset, passattr!::Function=MOI.set!)
+function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, passattr!::Function=MOI.set!)
     # Copy model attributes
     @assert MOI.canget(src, MOI.ListOfModelAttributesSet())
     attrs = MOI.get(src, MOI.ListOfModelAttributesSet())
-    _passattributes!(dest, src, copynames, idxmap, attrs, tuple(), tuple(), tuple(), canpassattr, passattr!)
+    _passattributes!(dest, src, copynames, idxmap, attrs, tuple(), tuple(), tuple(), passattr!)
 end
-function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, vis_src::Vector{VI}, canpassattr::Function=MOI.canset, passattr!::Function=MOI.set!)
+function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, vis_src::Vector{VI}, passattr!::Function=MOI.set!)
     # Copy variable attributes
     @assert MOI.canget(src, MOI.ListOfVariableAttributesSet())
     attrs = MOI.get(src, MOI.ListOfVariableAttributesSet())
     vis_dest = map(vi -> idxmap[vi], vis_src)
-    _passattributes!(dest, src, copynames, idxmap, attrs, (VI,), (vis_src,), (vis_dest,), canpassattr, passattr!)
+    _passattributes!(dest, src, copynames, idxmap, attrs, (VI,), (vis_src,), (vis_dest,), passattr!)
 end
-function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, cis_src::Vector{CI{F, S}}, canpassattr::Function=MOI.canset, passattr!::Function=MOI.set!) where {F, S}
+function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, cis_src::Vector{CI{F, S}}, passattr!::Function=MOI.set!) where {F, S}
     # Copy constraint attributes
     @assert MOI.canget(src, MOI.ListOfConstraintAttributesSet{F, S}())
     attrs = MOI.get(src, MOI.ListOfConstraintAttributesSet{F, S}())
     cis_dest = map(ci -> idxmap[ci], cis_src)
-    _passattributes!(dest, src, copynames, idxmap, attrs, (CI{F, S},), (cis_src,), (cis_dest,), canpassattr, passattr!)
+    _passattributes!(dest, src, copynames, idxmap, attrs, (CI{F, S},), (cis_src,), (cis_dest,), passattr!)
 end
 
-function _passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, attrs, canargs, getargs, setargs, canpassattr::Function=MOI.canset, passattr!::Function=MOI.set!)
+function _passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, attrs, canargs, getargs, setargs, passattr!::Function=MOI.set!)
     for attr in attrs
         if (copynames || !(attr isa MOI.Name || attr isa MOI.VariableName || attr isa MOI.ConstraintName)) && MOI.canget(src, attr, canargs...)
-            if !canpassattr(dest, attr, canargs...)
-                return MOI.CopyResult(MOI.CopyUnsupportedAttribute, "Unsupported attribute $attr", idxmap)
-            end
             passattr!(dest, attr, setargs..., attribute_value_map(idxmap, MOI.get(src, attr, getargs...)))
         end
     end
-    return MOI.CopyResult(MOI.CopySuccess, "", idxmap)
 end
 
 """
@@ -83,7 +79,7 @@ function copyconstraints!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bo
         idxmap.conmap[ci_src] = ci_dest
     end
 
-    return passattributes!(dest, src, copynames, idxmap, cis_src)
+    passattributes!(dest, src, copynames, idxmap, cis_src)
 end
 
 attribute_value_map(idxmap, f::MOI.AbstractFunction) = mapvariables(idxmap, f)
@@ -104,21 +100,18 @@ function defaultcopy!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
     end
 
     # Copy variable attributes
-    res = passattributes!(dest, src, copynames, idxmap, vis_src)
-    res.status == MOI.CopySuccess || return res
+    passattributes!(dest, src, copynames, idxmap, vis_src)
 
     # Copy model attributes
-    res = passattributes!(dest, src, copynames, idxmap)
-    res.status == MOI.CopySuccess || return res
+    passattributes!(dest, src, copynames, idxmap)
 
     # Copy constraints
     for (F, S) in MOI.get(src, MOI.ListOfConstraints())
         # do the rest in copyconstraints! which is type stable
-        res = copyconstraints!(dest, src, copynames, idxmap, F, S)
-        res.status == MOI.CopySuccess || return res
+        copyconstraints!(dest, src, copynames, idxmap, F, S)
     end
 
-    return MOI.CopyResult(MOI.CopySuccess, "", idxmap)
+    return idxmap
 end
 
 # Allocate-Load Interface: 2-pass copy of a MathOptInterface model
@@ -162,16 +155,11 @@ Informs `model` that `load!` will be called with the same arguments after `loadv
 """
 function allocate! end
 
-"""
-    canallocate(model::ModelLike, attr::ModelLikeAttribute)::Bool
-    canallocate(model::ModelLike, attr::AbstractVariableAttribute, R::Type{VariableIndex})::Bool
-    canallocate(model::ModelLike, attr::AbstractConstraintAttribute, R::Type{ConstraintIndex{F,S})::Bool
-
-Return a `Bool` indicating whether it is possible to allocate attribute `attr` applied to the index type `R` in the model `model`.
-"""
-function canallocate end
-canallocate(::MOI.ModelLike, ::MOI.AnyAttribute) = false
-canallocate(::MOI.ModelLike, ::MOI.AnyAttribute, ::Type{<:MOI.Index}) = false
+function allocate!(model::MOI.ModelLike, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector, values::Vector)
+    for (index, value) in zip(indices, values)
+        allocate!(model, attr, index, value)
+    end
+end
 
 """
     allocateconstraint!(model::MOI.ModelLike, f::MOI.AbstractFunction, s::MOI.AbstractSet)
@@ -196,16 +184,11 @@ This has the same effect that `set!` with the same arguments except that `alloca
 """
 function load! end
 
-"""
-    canload(model::ModelLike, attr::ModelLikeAttribute)::Bool
-    canload(model::ModelLike, attr::AbstractVariableAttribute, R::Type{VariableIndex})::Bool
-    canload(model::ModelLike, attr::AbstractConstraintAttribute, R::Type{ConstraintIndex{F,S})::Bool
-
-Return a `Bool` indicating whether it is possible to load attribute `attr` applied to the index type `R` in the model `model`.
-"""
-function canload end
-canload(::MOI.ModelLike, ::MOI.AnyAttribute) = false
-canload(::MOI.ModelLike, ::MOI.AnyAttribute, ::Type{<:MOI.Index}) = false
+function load!(model::MOI.ModelLike, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector, values::Vector)
+    for (index, value) in zip(indices, values)
+        load!(model, attr, index, value)
+    end
+end
 
 """
     loadconstraint!(model::MOI.ModelLike, ci::MOI.ConstraintIndex, f::MOI.AbstractFunction, s::MOI.AbstractSet)
@@ -226,7 +209,7 @@ function allocateconstraints!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames
         idxmap.conmap[ci_src] = ci_dest
     end
 
-    return passattributes!(dest, src, copynames, idxmap, cis_src, canallocate, allocate!)
+    return passattributes!(dest, src, copynames, idxmap, cis_src, allocate!)
 end
 
 function loadconstraints!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
@@ -240,7 +223,7 @@ function loadconstraints!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bo
         loadconstraint!(dest, ci_dest, f_dest, s)
     end
 
-    return passattributes!(dest, src, copynames, idxmap, cis_src, canload, load!)
+    return passattributes!(dest, src, copynames, idxmap, cis_src, load!)
 end
 
 """
@@ -262,37 +245,31 @@ function allocateload!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
     end
 
     # Allocate variable attributes
-    res = passattributes!(dest, src, copynames, idxmap, vis_src, canallocate, allocate!)
-    res.status == MOI.CopySuccess || return res
+    passattributes!(dest, src, copynames, idxmap, vis_src, allocate!)
 
     # Allocate model attributes
-    res = passattributes!(dest, src, copynames, idxmap, canallocate, allocate!)
-    res.status == MOI.CopySuccess || return res
+    passattributes!(dest, src, copynames, idxmap, allocate!)
 
     # Allocate constraints
     for (F, S) in MOI.get(src, MOI.ListOfConstraints())
         # do the rest in copyconstraints! which is type stable
-        res = allocateconstraints!(dest, src, copynames, idxmap, F, S)
-        res.status == MOI.CopySuccess || return res
+        allocateconstraints!(dest, src, copynames, idxmap, F, S)
     end
 
     # Load variables
     loadvariables!(dest, nvars)
 
     # Load variable attributes
-    res = passattributes!(dest, src, copynames, idxmap, vis_src, canload, load!)
-    res.status == MOI.CopySuccess || return res
+    passattributes!(dest, src, copynames, idxmap, vis_src, load!)
 
     # Load model attributes
-    res = passattributes!(dest, src, copynames, idxmap, canload, load!)
-    res.status == MOI.CopySuccess || return res
+    passattributes!(dest, src, copynames, idxmap, load!)
 
     # Copy constraints
     for (F, S) in MOI.get(src, MOI.ListOfConstraints())
         # do the rest in copyconstraints! which is type stable
-        res = loadconstraints!(dest, src, copynames, idxmap, F, S)
-        res.status == MOI.CopySuccess || return res
+        loadconstraints!(dest, src, copynames, idxmap, F, S)
     end
 
-    return MOI.CopyResult(MOI.CopySuccess, "", idxmap)
+    return idxmap
 end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -99,9 +99,6 @@ function defaultcopy!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
 
     # Copy variables
     vis_src = MOI.get(src, MOI.ListOfVariableIndices())
-    if !MOI.canaddvariable(dest)
-        return MOI.CopyResult(MOI.CopyOtherError, "Adding variables is not supported", idxmap)
-    end
     for vi in vis_src
         idxmap.varmap[vi] = MOI.addvariable!(dest)
     end

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -19,6 +19,7 @@ mutable struct MockOptimizer{MT<:MOI.ModelLike} <: MOI.AbstractOptimizer
     conattribute::Dict{MOI.ConstraintIndex,Int} # MockConstraintAttribute
     needsallocateload::Bool # Allows to tests the Allocate-Load interface, see copy!
     canaddvar::Bool
+    canaddcon::Bool # If false, the optimizer throws CannotAddConstraint
     optimize!::Function
     solved::Bool
     hasprimal::Bool
@@ -47,6 +48,7 @@ MockOptimizer(inner_model::MOI.ModelLike; needsallocateload=false, evalobjective
                   Dict{MOI.ConstraintIndex,Int}(),
                   needsallocateload,
                   true,
+                  true,
                   (::MockOptimizer) -> begin end,
                   false,
                   false,
@@ -63,8 +65,16 @@ MockOptimizer(inner_model::MOI.ModelLike; needsallocateload=false, evalobjective
 MOI.canaddvariable(mock::MockOptimizer) = MOI.canaddvariable(mock.inner_model) && mock.canaddvar
 MOI.addvariable!(mock::MockOptimizer) = xor_index(MOI.addvariable!(mock.inner_model))
 MOI.addvariables!(mock::MockOptimizer, n::Int) = xor_index.(MOI.addvariables!(mock.inner_model, n))
-MOI.canaddconstraint(mock::MockOptimizer, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet} = MOI.canaddconstraint(mock.inner_model, F, S)
-MOI.addconstraint!(mock::MockOptimizer, F::MOI.AbstractFunction, S::MOI.AbstractSet) = xor_index(MOI.addconstraint!(mock.inner_model, xor_variables(F), S))
+function MOI.addconstraint!(mock::MockOptimizer,
+                            func::MOI.AbstractFunction,
+                            set::MOI.AbstractSet)
+    if mock.canaddcon
+        ci = MOI.addconstraint!(mock.inner_model, xor_variables(func), set)
+        return xor_index(ci)
+    else
+        throw(MOI.CannotAddConstraint{typeof(func), typeof(set)}())
+    end
+end
 function MOI.optimize!(mock::MockOptimizer)
     mock.solved = true
     mock.hasprimal = true
@@ -248,7 +258,6 @@ allocate!(mock::MockOptimizer, attr::MOI.AnyAttribute, idx::MOI.Index, value) = 
 canallocate(mock::MockOptimizer, attr::MOI.AnyAttribute) = canallocate(mock.inner_model, attr)
 canallocate(mock::MockOptimizer, attr::MOI.AnyAttribute, IdxT::Type{<:MOI.Index}) = canallocate(mock.inner_model, attr, IdxT)
 allocateconstraint!(mock::MockOptimizer, f::MOI.AbstractFunction, s::MOI.AbstractSet) = xor_index(allocateconstraint!(mock.inner_model, xor_variables(f), s))
-canallocateconstraint(mock::MockOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet}) = canallocateconstraint(mock.inner_model, F, S)
 
 loadvariables!(mock::MockOptimizer, nvars) = loadvariables!(mock.inner_model, nvars)
 load!(mock::MockOptimizer, attr::MOI.AnyAttribute, value) = load!(mock.inner_model, attr, value)
@@ -257,7 +266,6 @@ load!(mock::MockOptimizer, attr::MOI.AnyAttribute, idx::MOI.Index, value) = load
 canload(mock::MockOptimizer, attr::MOI.AnyAttribute) = canload(mock.inner_model, attr)
 canload(mock::MockOptimizer, attr::MOI.AnyAttribute, IdxT::Type{<:MOI.Index}) = canload(mock.inner_model, attr, IdxT)
 loadconstraint!(mock::MockOptimizer, ci::CI, f::MOI.AbstractFunction, s::MOI.AbstractSet) = loadconstraint!(mock.inner_model, xor_index(ci), xor_variables(f), s)
-canloadconstraint(mock::MockOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet}) = canloadconstraint(mock.inner_model, F, S)
 
 """
     set_mock_optimize!(mock::MockOptimizer, opt::Function...)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -226,7 +226,7 @@ function MOI.modify!(mock::MockOptimizer, obj::MOI.ObjectiveFunction, change::MO
     MOI.modify!(mock.inner_model, obj, xor_variables(change))
 end
 
-# TODO: transform and cantransform
+# TODO: transform
 
 MOI.supports(mock::MockOptimizer, attr::MOI.ObjectiveFunction) = MOI.supports(mock.inner_model, attr)
 MOI.supportsconstraint(mock::MockOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet}) = MOI.supportsconstraint(mock.inner_model, F, S)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -222,10 +222,7 @@ function MOI.delete!(mock::MockOptimizer, idx::MOI.ConstraintIndex)
     MOI.delete!(mock.condual, idx)
 end
 
-function MOI.canmodify(mock::MockOptimizer, ::Type{C}, change) where C <: CI
-    MOI.canmodify(mock.inner_model, C, change)
-end
-function MOI.modify!(mock::MockOptimizer, c::CI, change)
+function MOI.modify!(mock::MockOptimizer, c::CI, change::MOI.AbstractFunctionModification)
     MOI.modify!(mock.inner_model, xor_index(c), xor_variables(change))
 end
 
@@ -235,10 +232,6 @@ end
 
 function MOI.set!(mock::MockOptimizer, ::MOI.ConstraintFunction, c::CI{F,S}, func::F) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
     MOI.set!(mock.inner_model, MOI.ConstraintFunction(), xor_index(c), xor_variables(func))
-end
-
-function MOI.canmodify(mock::MockOptimizer, obj::MOI.ObjectiveFunction, change)
-    MOI.canmodify(mock.inner_model, obj, change)
 end
 
 function MOI.modify!(mock::MockOptimizer, obj::MOI.ObjectiveFunction, change::MOI.AbstractFunctionModification)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -212,14 +212,21 @@ end
 
 MOI.isvalid(mock::MockOptimizer, idx::MOI.Index) = MOI.isvalid(mock.inner_model, xor_index(idx))
 
-MOI.candelete(mock::MockOptimizer, idx::MOI.Index) = MOI.candelete(mock.inner_model, xor_index(idx))
-function MOI.delete!(mock::MockOptimizer, idx::MOI.VariableIndex)
-    MOI.delete!(mock.inner_model, xor_index(idx))
-    MOI.delete!(mock.varprimal, idx)
+function MOI.delete!(mock::MockOptimizer, index::MOI.VariableIndex)
+    if !MOI.isvalid(mock, index)
+        # The index thrown by `mock.inner_model` would be xored
+        throw(MOI.InvalidIndex(index))
+    end
+    MOI.delete!(mock.inner_model, xor_index(index))
+    MOI.delete!(mock.varprimal, index)
 end
-function MOI.delete!(mock::MockOptimizer, idx::MOI.ConstraintIndex)
-    MOI.delete!(mock.inner_model, xor_index(idx))
-    MOI.delete!(mock.condual, idx)
+function MOI.delete!(mock::MockOptimizer, index::MOI.ConstraintIndex)
+    if !MOI.isvalid(mock, index)
+        # The index thrown by `mock.inner_model` would be xored
+        throw(MOI.InvalidIndex(index))
+    end
+    MOI.delete!(mock.inner_model, xor_index(index))
+    MOI.delete!(mock.condual, index)
 end
 
 function MOI.modify!(mock::MockOptimizer, c::CI, change::MOI.AbstractFunctionModification)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -62,9 +62,20 @@ MockOptimizer(inner_model::MOI.ModelLike; needsallocateload=false, evalobjective
                   Dict{MOI.VariableIndex,Float64}(),
                   Dict{MOI.ConstraintIndex,Any}())
 
-MOI.canaddvariable(mock::MockOptimizer) = MOI.canaddvariable(mock.inner_model) && mock.canaddvar
-MOI.addvariable!(mock::MockOptimizer) = xor_index(MOI.addvariable!(mock.inner_model))
-MOI.addvariables!(mock::MockOptimizer, n::Int) = xor_index.(MOI.addvariables!(mock.inner_model, n))
+function MOI.addvariable!(mock::MockOptimizer)
+    if mock.canaddvar
+        return xor_index(MOI.addvariable!(mock.inner_model))
+    else
+        throw(MOI.CannotAddVariable())
+    end
+end
+function MOI.addvariables!(mock::MockOptimizer, n::Int)
+    if mock.canaddvar
+        return xor_index.(MOI.addvariables!(mock.inner_model, n))
+    else
+        throw(MOI.CannotAddVariable())
+    end
+end
 function MOI.addconstraint!(mock::MockOptimizer,
                             func::MOI.AbstractFunction,
                             set::MOI.AbstractSet)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -93,19 +93,19 @@ function MOI.optimize!(mock::MockOptimizer)
     mock.optimize!(mock)
 end
 
-MOI.canset(mock::MockOptimizer, ::Union{MOI.VariablePrimal,MockVariableAttribute}, ::Type{MOI.VariableIndex}) = true
-MOI.canset(mock::MockOptimizer, attr::MOI.AbstractVariableAttribute, IdxT::Type{MOI.VariableIndex}) = MOI.canset(mock.inner_model, attr, IdxT)
-MOI.canset(mock::MockOptimizer, ::Union{MOI.ConstraintDual,MockConstraintAttribute}, ::Type{<:MOI.ConstraintIndex}) = true
-MOI.canset(mock::MockOptimizer, attr::MOI.AbstractConstraintAttribute, IdxT::Type{<:MOI.ConstraintIndex}) = MOI.canset(mock.inner_model, attr, IdxT)
+MOI.supports(mock::MockOptimizer, ::Union{MOI.VariablePrimal,MockVariableAttribute}, ::Type{MOI.VariableIndex}) = true
+MOI.supports(mock::MockOptimizer, attr::MOI.AbstractVariableAttribute, IdxT::Type{MOI.VariableIndex}) = MOI.supports(mock.inner_model, attr, IdxT)
+MOI.supports(mock::MockOptimizer, ::Union{MOI.ConstraintDual,MockConstraintAttribute}, ::Type{<:MOI.ConstraintIndex}) = true
+MOI.supports(mock::MockOptimizer, attr::MOI.AbstractConstraintAttribute, IdxT::Type{<:MOI.ConstraintIndex}) = MOI.supports(mock.inner_model, attr, IdxT)
 
-MOI.canset(mock::MockOptimizer, ::Union{MOI.ResultCount,MOI.TerminationStatus,MOI.ObjectiveValue,MOI.PrimalStatus,MOI.DualStatus,MockModelAttribute}) = true
+MOI.supports(mock::MockOptimizer, ::Union{MOI.ResultCount,MOI.TerminationStatus,MOI.ObjectiveValue,MOI.PrimalStatus,MOI.DualStatus,MockModelAttribute}) = true
 MOI.set!(mock::MockOptimizer, ::MOI.ResultCount, value::Integer) = (mock.resultcount = value)
 MOI.set!(mock::MockOptimizer, ::MOI.TerminationStatus, value::MOI.TerminationStatusCode) = (mock.terminationstatus = value)
 MOI.set!(mock::MockOptimizer, ::MOI.ObjectiveValue, value::Real) = (mock.objectivevalue = value)
 MOI.set!(mock::MockOptimizer, ::MOI.PrimalStatus, value::MOI.ResultStatusCode) = (mock.primalstatus = value)
 MOI.set!(mock::MockOptimizer, ::MOI.DualStatus, value::MOI.ResultStatusCode) = (mock.dualstatus = value)
 MOI.set!(mock::MockOptimizer, ::MockModelAttribute, value::Integer) = (mock.attribute = value)
-MOI.canset(mock::MockOptimizer, attr::MOI.AbstractModelAttribute) = MOI.canset(mock.inner_model, attr)
+MOI.supports(mock::MockOptimizer, attr::MOI.AbstractModelAttribute) = MOI.supports(mock.inner_model, attr)
 MOI.set!(mock::MockOptimizer, attr::MOI.AbstractModelAttribute, value) = MOI.set!(mock.inner_model, attr, value)
 MOI.set!(mock::MockOptimizer, attr::MOI.ObjectiveFunction, value) = MOI.set!(mock.inner_model, attr, xor_variables(value))
 
@@ -229,12 +229,10 @@ function MOI.modify!(mock::MockOptimizer, c::CI, change)
     MOI.modify!(mock.inner_model, xor_index(c), xor_variables(change))
 end
 
-MOI.canset(mock::MockOptimizer, ::MOI.ConstraintSet, ::Type{C}) where C <: CI = true
 function MOI.set!(mock::MockOptimizer, ::MOI.ConstraintSet, c::CI{F,S}, set::S) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
     MOI.set!(mock.inner_model, MOI.ConstraintSet(), xor_index(c), set)
 end
 
-MOI.canset(mock::MockOptimizer, ::MOI.ConstraintFunction, ::Type{C}) where C <: CI = true
 function MOI.set!(mock::MockOptimizer, ::MOI.ConstraintFunction, c::CI{F,S}, func::F) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
     MOI.set!(mock.inner_model, MOI.ConstraintFunction(), xor_index(c), xor_variables(func))
 end
@@ -249,7 +247,6 @@ end
 
 # TODO: transform
 
-MOI.supports(mock::MockOptimizer, attr::MOI.ObjectiveFunction) = MOI.supports(mock.inner_model, attr)
 MOI.supportsconstraint(mock::MockOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet}) = MOI.supportsconstraint(mock.inner_model, F, S)
 function MOI.copy!(mock::MockOptimizer, src::MOI.ModelLike; copynames=true)
     if needsallocateload(mock)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -237,7 +237,6 @@ function MOI.set!(model::AbstractModel, ::MOI.ObjectiveFunction, f::MOI.Abstract
     model.objective = deepcopy(f)
 end
 
-MOI.canmodify(::AbstractModel, ::MOI.ObjectiveFunction, ::Type{<:MOI.AbstractFunctionModification}) = true
 function MOI.modify!(model::AbstractModel, obj::MOI.ObjectiveFunction, change::MOI.AbstractFunctionModification)
     model.objective = modifyfunction(model.objective, change)
 end
@@ -286,7 +285,6 @@ function MOI.delete!(model::AbstractModel, ci::CI)
     end
 end
 
-MOI.canmodify(::AbstractModel, ::Type{<:CI}, ::Type{<:MOI.AbstractFunctionModification}) = true
 function MOI.modify!(model::AbstractModel, ci::CI, change::MOI.AbstractFunctionModification)
     _modify!(model, ci, getconstrloc(model, ci), change)
 end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -137,7 +137,7 @@ function MOI.get(model::AbstractModel, ::MOI.ListOfVariableIndices)
 end
 
 # Names
-MOI.canset(::AbstractModel, ::MOI.Name) = true
+MOI.supports(::AbstractModel, ::MOI.Name) = true
 function MOI.set!(model::AbstractModel, ::MOI.Name, name::String)
     model.name = name
 end
@@ -181,7 +181,7 @@ function setname(index_to_names::Dict{<:MOI.Index, String}, names_to_index::Dict
     return
 end
 
-MOI.canset(::AbstractModel, ::MOI.VariableName, vi::Type{VI}) = true
+MOI.supports(::AbstractModel, ::MOI.VariableName, vi::Type{VI}) = true
 function MOI.set!(model::AbstractModel, ::MOI.VariableName, vi::VI, name::String)
     if check_can_assign_name(model, VI, vi, name)
         setname(model.varnames, model.namesvar, vi, name)
@@ -198,7 +198,7 @@ function MOI.get(model::AbstractModel, ::MOI.ListOfVariableAttributesSet)::Vecto
     isempty(model.varnames) ? [] : [MOI.VariableName()]
 end
 
-MOI.canset(model::AbstractModel, ::MOI.ConstraintName, ::Type{<:CI}) = true
+MOI.supports(model::AbstractModel, ::MOI.ConstraintName, ::Type{<:CI}) = true
 function MOI.set!(model::AbstractModel, ::MOI.ConstraintName, ci::CI, name::String)
     if check_can_assign_name(model, CI, ci, name)
         setname(model.connames, model.namescon, ci, name)
@@ -218,7 +218,7 @@ end
 # Objective
 MOI.canget(model::AbstractModel, ::MOI.ObjectiveSense) = model.senseset
 MOI.get(model::AbstractModel, ::MOI.ObjectiveSense) = model.sense
-MOI.canset(model::AbstractModel, ::MOI.ObjectiveSense) = true
+MOI.supports(model::AbstractModel, ::MOI.ObjectiveSense) = true
 function MOI.set!(model::AbstractModel, ::MOI.ObjectiveSense, sense::MOI.OptimizationSense)
     model.senseset = true
     model.sense = sense
@@ -230,7 +230,7 @@ function MOI.get(model::AbstractModel, ::MOI.ObjectiveFunction{T})::T where T
     end
     model.objective
 end
-MOI.canset(model::AbstractModel, ::MOI.ObjectiveFunction) = true
+MOI.supports(model::AbstractModel, ::MOI.ObjectiveFunction) = true
 function MOI.set!(model::AbstractModel, ::MOI.ObjectiveFunction, f::MOI.AbstractFunction)
     model.objectiveset = true
     # f needs to be copied, see #2
@@ -291,11 +291,11 @@ function MOI.modify!(model::AbstractModel, ci::CI, change::MOI.AbstractFunctionM
     _modify!(model, ci, getconstrloc(model, ci), change)
 end
 
-MOI.canset(::AbstractModel, ::MOI.ConstraintFunction, ::Type{<:CI}) = true
+MOI.supports(::AbstractModel, ::MOI.ConstraintFunction, ::Type{<:CI}) = true
 function MOI.set!(model::AbstractModel, ::MOI.ConstraintFunction, ci::CI, change::MOI.AbstractFunction)
     _modify!(model, ci, getconstrloc(model, ci), change)
 end
-MOI.canset(::AbstractModel, ::MOI.ConstraintSet, ::Type{<:CI}) = true
+MOI.supports(::AbstractModel, ::MOI.ConstraintSet, ::Type{<:CI}) = true
 function MOI.set!(model::AbstractModel, ::MOI.ConstraintSet, ci::CI, change::MOI.AbstractSet)
     _modify!(model, ci, getconstrloc(model, ci), change)
 end
@@ -331,7 +331,6 @@ function MOI.isempty(model::AbstractModel)
     iszero(model.nextvariableid) && iszero(model.nextconstraintid)
 end
 
-MOI.supports(::AbstractModel, ::MOI.ObjectiveFunction) = true
 MOI.copy!(dest::AbstractModel, src::MOI.ModelLike; copynames=true) = defaultcopy!(dest, src, copynames)
 
 # Allocate-Load Interface
@@ -340,14 +339,14 @@ needsallocateload(model::AbstractModel) = false
 
 allocatevariables!(model::AbstractModel, nvars) = MOI.addvariables!(model, nvars)
 allocate!(model::AbstractModel, attr...) = MOI.set!(model, attr...)
-canallocate(model::AbstractModel, attr::MOI.AnyAttribute) = MOI.canset(model, attr)
-canallocate(model::AbstractModel, attr::MOI.AnyAttribute, IndexType::Type{<:MOI.Index}) = MOI.canset(model, attr, IndexType)
+canallocate(model::AbstractModel, attr::MOI.AnyAttribute) = MOI.supports(model, attr)
+canallocate(model::AbstractModel, attr::MOI.AnyAttribute, IndexType::Type{<:MOI.Index}) = MOI.supports(model, attr, IndexType)
 allocateconstraint!(model::AbstractModel, f::MOI.AbstractFunction, s::MOI.AbstractSet) = MOI.addconstraint!(model, f, s)
 
 function loadvariables!(::AbstractModel, nvars) end
 function load!(::AbstractModel, attr...) end
-canload(model::AbstractModel, attr::MOI.AnyAttribute) = MOI.canset(model, attr)
-canload(model::AbstractModel, attr::MOI.AnyAttribute, IndexType::Type{<:MOI.Index}) = MOI.canset(model, attr, IndexType)
+canload(model::AbstractModel, attr::MOI.AnyAttribute) = MOI.supports(model, attr)
+canload(model::AbstractModel, attr::MOI.AnyAttribute, IndexType::Type{<:MOI.Index}) = MOI.supports(model, attr, IndexType)
 function loadconstraint!(::AbstractModel, ::CI, ::MOI.AbstractFunction, ::MOI.AbstractSet) end
 
 # Can be used to access constraints of a model

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -55,7 +55,6 @@ getconstrloc(model::AbstractModel, ci::CI) = model.constrmap[ci.value]
 
 # Variables
 MOI.get(model::AbstractModel, ::MOI.NumberOfVariables) = length(model.varindices)
-MOI.canaddvariable(model::AbstractModel) = true
 function MOI.addvariable!(model::AbstractModel)
     v = VI(model.nextvariableid += 1)
     push!(model.varindices, v)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -102,6 +102,9 @@ function _removevar!(constrs::Vector{<:C{MOI.SingleVariable}}, vi::VI)
     rm
 end
 function MOI.delete!(model::AbstractModel, vi::VI)
+    if !MOI.isvalid(model, vi)
+        throw(MOI.InvalidIndex(vi))
+    end
     model.objective = removevariable(model.objective, vi)
     rm = broadcastvcat(constrs -> _removevar!(constrs, vi), model)
     for ci in rm
@@ -273,8 +276,10 @@ function MOI.addconstraint!(model::AbstractModel, f::F, s::S) where {F<:MOI.Abst
     end
 end
 
-MOI.candelete(model::AbstractModel, i::MOI.Index) = MOI.isvalid(model, i)
 function MOI.delete!(model::AbstractModel, ci::CI)
+    if !MOI.isvalid(model, ci)
+        throw(MOI.InvalidIndex(ci))
+    end
     for (ci_next, _, _) in _delete!(model, ci, getconstrloc(model, ci))
         model.constrmap[ci_next.value] -= 1
     end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -287,13 +287,6 @@ end
 
 # Constraints
 MOI.supportsconstraint(uf::UniversalFallback, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet} = true
-function MOI.canaddconstraint(uf::UniversalFallback, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
-    if MOI.supportsconstraint(uf.model, F, S)
-        return MOI.canaddconstraint(uf.model, F, S)
-    else
-        return true
-    end
-end
 function MOI.addconstraint!(uf::UniversalFallback, f::MOI.AbstractFunction, s::MOI.AbstractSet)
     F = typeof(f)
     S = typeof(s)

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -369,6 +369,5 @@ MOI.canmodify(uf::UniversalFallback, obj::MOI.ObjectiveFunction, ::Type{M}) wher
 MOI.modify!(uf::UniversalFallback, obj::MOI.ObjectiveFunction, change::MOI.AbstractFunctionModification) = MOI.modify!(uf.model, obj, change)
 
 # Variables
-MOI.canaddvariable(uf::UniversalFallback) = MOI.canaddvariable(uf.model)
 MOI.addvariable!(uf::UniversalFallback) = MOI.addvariable!(uf.model)
 MOI.addvariables!(uf::UniversalFallback, n) = MOI.addvariables!(uf.model, n)

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -57,18 +57,13 @@ function MOI.isvalid(uf::UniversalFallback, idx::CI{F, S}) where {F, S}
         haskey(uf.constraints, (F, S)) && haskey(uf.constraints[(F, S)], idx)
     end
 end
-MOI.candelete(uf::UniversalFallback, idx::VI) = MOI.candelete(uf.model, idx)
-function MOI.candelete(uf::UniversalFallback, idx::CI{F, S}) where {F, S}
-    if MOI.supportsconstraint(uf.model, F, S)
-        MOI.candelete(uf.model, idx)
-    else
-        MOI.isvalid(uf, idx)
-    end
-end
 function MOI.delete!(uf::UniversalFallback, ci::CI{F, S}) where {F, S}
     if MOI.supportsconstraint(uf.model, F, S)
         MOI.delete!(uf.model, ci)
     else
+        if !MOI.isvalid(uf, ci)
+            throw(MOI.InvalidIndex(ci))
+        end
         MOI.delete!(uf.constraints[(F, S)], ci)
         if haskey(uf.connames, ci)
             delete!(uf.namescon, uf.connames[ci])

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -294,14 +294,7 @@ function MOI.addconstraint!(uf::UniversalFallback, f::MOI.AbstractFunction, s::M
         return ci
     end
 end
-function MOI.canmodify(uf::UniversalFallback, ::Type{CI{F, S}}, change) where {F, S}
-    if MOI.supportsconstraint(uf.model, F, S)
-        MOI.canmodify(uf.model, CI{F, S}, change)
-    else
-        true
-    end
-end
-function MOI.modify!(uf::UniversalFallback, ci::CI{F, S}, change) where {F, S}
+function MOI.modify!(uf::UniversalFallback, ci::CI{F, S}, change::MOI.AbstractFunctionModification) where {F, S}
     if MOI.supportsconstraint(uf.model, F, S)
         MOI.modify!(uf.model, ci, change)
     else
@@ -350,7 +343,6 @@ function MOI.set!(uf::UniversalFallback, ::MOI.ConstraintSet, ci::CI{F,S}, set::
 end
 
 # Objective
-MOI.canmodify(uf::UniversalFallback, obj::MOI.ObjectiveFunction, ::Type{M}) where M<:MOI.AbstractFunctionModification = MOI.canmodify(uf.model, obj, M)
 MOI.modify!(uf::UniversalFallback, obj::MOI.ObjectiveFunction, change::MOI.AbstractFunctionModification) = MOI.modify!(uf.model, obj, change)
 
 # Variables

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -49,6 +49,7 @@ end
 """
     struct CannotSetAttribute{AttrType} <: CannotError
         attr::AttrType
+        message::String # Human-friendly explanation why the attribute cannot be set
     end
 
 An error indicating that setting attribute `attr` is supported but cannot be
@@ -56,9 +57,11 @@ added in the current state of the model.
 """
 struct CannotSetAttribute{AttrType<:AnyAttribute} <: CannotError
     attr::AttrType
+	message::String # Human-friendly explanation why the attribute cannot be set
 end
 
 operation_name(err::Union{UnsupportedAttribute, CannotSetAttribute}) = "Setting attribute $(err.attr)"
+message(err::CannotAttConstraint) = err.message
 
 """
     supports(model::ModelLike, attr::AbstractOptimizerAttribute)::Bool

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -59,6 +59,7 @@ struct CannotSetAttribute{AttrType<:AnyAttribute} <: CannotError
     attr::AttrType
 	message::String # Human-friendly explanation why the attribute cannot be set
 end
+CannotSetAttribute(attr::AnyAttribute) = CannotSetAttribute(attr, "")
 
 operation_name(err::Union{UnsupportedAttribute, CannotSetAttribute}) = "Setting attribute $(err.attr)"
 message(err::CannotSetAttribute) = err.message

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -40,7 +40,7 @@ const AnyAttribute = Union{AbstractOptimizerAttribute, AbstractModelAttribute, A
         attr::AttrType
     end
 
-Setting attribute `attr` is not supported by the model.
+An error indicating that setting attribute `attr` is not supported by the model.
 """
 struct UnsupportedAttribute{AttrType<:AnyAttribute} <: UnsupportedError
     attr::AttrType
@@ -51,8 +51,8 @@ end
         attr::AttrType
     end
 
-Setting attribute `attr` is supported but cannot be added in the current state
-of the model.
+An error indicating that setting attribute `attr` is supported but cannot be
+added in the current state of the model.
 """
 struct CannotSetAttribute{AttrType<:AnyAttribute} <: CannotError
     attr::AttrType

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -45,8 +45,6 @@ Setting attribute `attr` is not supported by the model.
 struct UnsupportedAttribute{AttrType<:AnyAttribute} <: UnsupportedError
     attr::AttrType
 end
-# old message:
-# "ModelLike of type $(typeof(model)) does not support setting the attribute $attr"
 
 """
     struct CannotSetAttribute{AttrType} <: CannotError

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -61,7 +61,7 @@ struct CannotSetAttribute{AttrType<:AnyAttribute} <: CannotError
 end
 
 operation_name(err::Union{UnsupportedAttribute, CannotSetAttribute}) = "Setting attribute $(err.attr)"
-message(err::CannotAttConstraint) = err.message
+message(err::CannotSetAttribute) = err.message
 
 """
     supports(model::ModelLike, attr::AbstractOptimizerAttribute)::Bool
@@ -227,6 +227,11 @@ Assign a value to the attribute `attr` of constraint `c` in model `model`.
     set!(model::ModelLike, attr::AbstractConstraintAttribute, c::Vector{ConstraintIndex{F,S}}, vector_of_values)
 
 Assign a value respectively to the attribute `attr` of each constraint in the collection `c` in model `model`.
+
+An [`UnsupportedAttribute`](@ref) error is thrown if `model` does not support
+setting attributes `attr` and a [`CannotSetAttribute`](@ref) error is thrown if
+it supports setting attributes `attr` but it cannot set this attribute the
+current state of the model.
 
 ### Replace set in a constraint
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -30,7 +30,7 @@ struct CannotAddConstraint{F<:AbstractFunction, S<:AbstractSet} <: CannotError
 end
 
 operation_name(::Union{UnsupportedConstraint{F, S}, CannotAddConstraint{F, S}}) where {F, S} = "Adding `$F`-in-`$S` constraints"
-message(err::CannotAttConstraint) = err.message
+message(err::CannotAddConstraint) = err.message
 
 """
     addconstraint!(model::ModelLike, func::F, set::S)::ConstraintIndex{F,S} where {F,S}
@@ -41,6 +41,11 @@ Add the constraint ``f(x) \\in \\mathcal{S}`` where ``f`` is defined by `func`, 
     addconstraint!(model::ModelLike, vec::Vector{VariableIndex}, set::S)::ConstraintIndex{VectorOfVariables,S} where {S}
 
 Add the constraint ``v \\in \\mathcal{S}`` where ``v`` is the variable (or vector of variables) referenced by `v` and ``\\mathcal{S}`` is defined by `set`.
+
+An [`UnsupportedConstraint`](@ref) error is thrown if `model` does not support
+`F`-in-`S` constraints and a [`CannotAddConstraint`](@ref) error is thrown if
+it supports `F`-in-`S` constraints but it cannot add the constraint(s) in its
+current state.
 """
 function addconstraint!(model::ModelLike, func::AbstractFunction, set::AbstractSet)
     throw(UnsupportedConstraint{typeof(func), typeof(set)}())

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -18,14 +18,19 @@ the model.
 struct UnsupportedConstraint{F<:AbstractFunction, S<:AbstractSet} <: UnsupportedError end
 
 """
-    CannotAddConstraint{F, S} <: CannotError
+    struct CannotAddConstraint{F<:AbstractFunction, S<:AbstractSet} <: CannotError
+        message::String # Human-friendly explanation why the attribute cannot be set
+    end
 
 An error indicating that constraints of type `F`-in-`S` are supported but
 cannot be added in the current state of the model.
 """
-struct CannotAddConstraint{F<:AbstractFunction, S<:AbstractSet} <: CannotError end
+struct CannotAddConstraint{F<:AbstractFunction, S<:AbstractSet} <: CannotError
+    message::String # Human-friendly explanation why the attribute cannot be set
+end
 
 operation_name(::Union{UnsupportedConstraint{F, S}, CannotAddConstraint{F, S}}) where {F, S} = "Adding `$F`-in-`$S` constraints"
+message(err::CannotAttConstraint) = err.message
 
 """
     addconstraint!(model::ModelLike, func::F, set::S)::ConstraintIndex{F,S} where {F,S}

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -10,11 +10,11 @@ If `F`-in-`S` constraints are only not supported in specific circumstances, e.g.
 supportsconstraint(model::ModelLike, ::Type{<:AbstractFunction}, ::Type{<:AbstractSet}) = false
 
 """
-    UnsupportedConstraint{F, S} <: CannotError
+    UnsupportedConstraint{F, S} <: UnsupportedError
 
 Constraints of type `F`-in-`S` are not supported by the model.
 """
-struct UnsupportedConstraint{F<:AbstractFunction, S<:AbstractSet} <: CannotError end
+struct UnsupportedConstraint{F<:AbstractFunction, S<:AbstractSet} <: UnsupportedError end
 
 """
     CannotAddConstraint{F, S} <: CannotError

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -28,6 +28,7 @@ cannot be added in the current state of the model.
 struct CannotAddConstraint{F<:AbstractFunction, S<:AbstractSet} <: CannotError
     message::String # Human-friendly explanation why the attribute cannot be set
 end
+CannotAddConstraint{F, S}() where {F, S} = CannotAddConstraint{F, S}("")
 
 operation_name(::Union{UnsupportedConstraint{F, S}, CannotAddConstraint{F, S}}) where {F, S} = "Adding `$F`-in-`$S` constraints"
 message(err::CannotAddConstraint) = err.message

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -77,33 +77,3 @@ function transform!(model::ModelLike, c::ConstraintIndex, newset)
     delete!(model, c)
     addconstraint!(model, f, newset)
 end
-
-"""
-## Transform Constraint Set
-
-    cantransform(model::ModelLike, c::ConstraintIndex{F,S1}, ::Type{S2})::Bool where S2<:AbstractSet
-
-Return a `Bool` indicating whether the set of type `S1` in constraint `c` can be
-replaced by a set of type `S2`.
-
-### Examples
-
-If `c` is a `ConstraintIndex{ScalarAffineFunction{Float64},LessThan{Float64}}`,
-
-```julia
-cantransform(model, c, GreaterThan(0.0)) # true
-cantransform(model, c, ZeroOne())        # it is expected that most solvers will
-                                         # return false, but this does not
-                                         # preclude solvers from supporting
-                                         # constraints such as this.
-```
-"""
-function cantransform end
-
-# default fallback
-function cantransform(model::ModelLike, c::ConstraintIndex{F,S1}, ::Type{S2}) where {F<:AbstractFunction, S1<:AbstractSet, S2<:AbstractSet}
-    if S1 == S2
-        return false
-    end
-    canget(model, ConstraintFunction(), typeof(c)) && candelete(model, c) && canaddconstraint(model, F, S2)
-end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -12,15 +12,16 @@ supportsconstraint(model::ModelLike, ::Type{<:AbstractFunction}, ::Type{<:Abstra
 """
     UnsupportedConstraint{F, S} <: UnsupportedError
 
-Constraints of type `F`-in-`S` are not supported by the model.
+An error indicating that constraints of type `F`-in-`S` are not supported by
+the model.
 """
 struct UnsupportedConstraint{F<:AbstractFunction, S<:AbstractSet} <: UnsupportedError end
 
 """
     CannotAddConstraint{F, S} <: CannotError
 
-Constraints of type `F`-in-`S` are supported but cannot be added in the current
-state of the model.
+An error indicating that constraints of type `F`-in-`S` are supported but
+cannot be added in the current state of the model.
 """
 struct CannotAddConstraint{F<:AbstractFunction, S<:AbstractSet} <: CannotError end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -10,14 +10,14 @@ If `F`-in-`S` constraints are only not supported in specific circumstances, e.g.
 supportsconstraint(model::ModelLike, ::Type{<:AbstractFunction}, ::Type{<:AbstractSet}) = false
 
 """
-    UnsupportedConstraint{F,S} <: CannotError
+    UnsupportedConstraint{F, S} <: CannotError
 
 Constraints of type `F`-in-`S` are not supported by the model.
 """
 struct UnsupportedConstraint{F<:AbstractFunction, S<:AbstractSet} <: CannotError end
 
 """
-    CannotAddConstraint{F,S} <: CannotError
+    CannotAddConstraint{F, S} <: CannotError
 
 Constraints of type `F`-in-`S` are supported but cannot be added in the current
 state of the model.

--- a/src/error.jl
+++ b/src/error.jl
@@ -1,0 +1,29 @@
+"""
+    operation_name(err::Union{UnsupportedError, CannotError})
+
+Return the name of the operation throwing the error in a gerund (i.e. -ing form).
+"""
+function operation_name end
+
+"""
+    UnsupportedError <: Exception
+
+Abstract type for error thrown when an operation is not supported by the model.
+"""
+abstract type UnsupportedError <: Exception end
+
+function Base.showerror(io::IO, err::UnsupportedError)
+    print(io, typeof(err), ": ", operation_name(err), " is not supported by the the model.")
+end
+
+"""
+    CannotError <: Exception
+
+Abstract type for error thrown when an operation is supported but cannot be
+applied in the current state of the model.
+"""
+abstract type CannotError <: Exception end
+
+function Base.showerror(io::IO, err::CannotError)
+    print(io, typeof(err), ": ", operation_name(err), " cannot be done in the current state of the model even if the operation is supported. You may want to use a `CachingOptimizer` in `Automatic` mode or you may need to call `resetoptimizer!` before doing this operation if the `CachingOptimizer` in `Manual` mode.")
+end

--- a/src/error.jl
+++ b/src/error.jl
@@ -6,6 +6,14 @@ Return the name of the operation throwing the error in a gerund (i.e. -ing form)
 function operation_name end
 
 """
+    message(err::CannotError)
+
+Return a `String` containing a human-friendly explanation why the operation
+cannot be performed. It is printed in the error message if it is not empty.
+"""
+function message end
+
+"""
     UnsupportedError <: Exception
 
 Abstract type for error thrown when an operation is not supported by the model.
@@ -25,5 +33,12 @@ applied in the current state of the model.
 abstract type CannotError <: Exception end
 
 function Base.showerror(io::IO, err::CannotError)
-    print(io, typeof(err), ": ", operation_name(err), " cannot be performed in the current state of the model even if the operation is supported. You may want to use a `CachingOptimizer` in `Automatic` mode or you may need to call `resetoptimizer!` before doing this operation if the `CachingOptimizer` is in `Manual` mode.")
+    print(io, typeof(err), ": ", operation_name(err), " cannot be performed in the current state of the model even if the operation is supported")
+    message = message(err)
+    if isempty(message)
+        print(io, ".")
+    else
+        print(io, ": ", message)
+    end
+    print(io, " You may want to use a `CachingOptimizer` in `Automatic` mode or you may need to call `resetoptimizer!` before doing this operation if the `CachingOptimizer` is in `Manual` mode.")
 end

--- a/src/error.jl
+++ b/src/error.jl
@@ -25,5 +25,5 @@ applied in the current state of the model.
 abstract type CannotError <: Exception end
 
 function Base.showerror(io::IO, err::CannotError)
-    print(io, typeof(err), ": ", operation_name(err), " cannot be done in the current state of the model even if the operation is supported. You may want to use a `CachingOptimizer` in `Automatic` mode or you may need to call `resetoptimizer!` before doing this operation if the `CachingOptimizer` is in `Manual` mode.")
+    print(io, typeof(err), ": ", operation_name(err), " cannot be performed in the current state of the model even if the operation is supported. You may want to use a `CachingOptimizer` in `Automatic` mode or you may need to call `resetoptimizer!` before doing this operation if the `CachingOptimizer` is in `Manual` mode.")
 end

--- a/src/error.jl
+++ b/src/error.jl
@@ -25,5 +25,5 @@ applied in the current state of the model.
 abstract type CannotError <: Exception end
 
 function Base.showerror(io::IO, err::CannotError)
-    print(io, typeof(err), ": ", operation_name(err), " cannot be done in the current state of the model even if the operation is supported. You may want to use a `CachingOptimizer` in `Automatic` mode or you may need to call `resetoptimizer!` before doing this operation if the `CachingOptimizer` in `Manual` mode.")
+    print(io, typeof(err), ": ", operation_name(err), " cannot be done in the current state of the model even if the operation is supported. You may want to use a `CachingOptimizer` in `Automatic` mode or you may need to call `resetoptimizer!` before doing this operation if the `CachingOptimizer` is in `Manual` mode.")
 end

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -26,6 +26,13 @@ end
 
 const Index = Union{ConstraintIndex,VariableIndex}
 
+"""
+    struct InvalidIndex{IndexType<:Index} <: Exception
+        index::IndexType
+    end
+
+The index `index` is invalid.
+"""
 struct InvalidIndex{IndexType<:Index} <: Exception
     index::IndexType
 end

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -31,7 +31,7 @@ const Index = Union{ConstraintIndex,VariableIndex}
         index::IndexType
     end
 
-The index `index` is invalid.
+An error indicating that the index `index` is invalid.
 """
 struct InvalidIndex{IndexType<:Index} <: Exception
     index::IndexType
@@ -51,7 +51,8 @@ isvalid(model::ModelLike, ref::Index) = false
 """
     UnsupportedDeletion{IndexType} <: UnsupportedError
 
-Deleting indices of type `IndexType` is not supported by the model.
+An error indicating that deleting indices of type `IndexType` is not supported
+by the model.
 """
 struct UnsupportedDeletion{IndexType<:Index} <: UnsupportedError end
 

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -4,7 +4,8 @@
         change::C
     end
 
-Constraints of type `F`-in-`S` do not support the constraint modification `change`.
+An error indicating that constraints of type `F`-in-`S` do not support the
+constraint modification `change`.
 """
 struct UnsupportedConstraintModification{F<:AbstractFunction, S<:AbstractSet,
                                          C<:AbstractFunctionModification} <: UnsupportedError
@@ -21,7 +22,8 @@ operation_name(err::UnsupportedConstraintModification{F, S}) where {F, S} = "Mod
         change::C
     end
 
-The objective function dos not support the constraint modification `change`.
+An error indicating that the objective function dos not support the constraint
+modification `change`.
 """
 struct UnsupportedObjectiveModification{C<:AbstractFunctionModification} <: UnsupportedError
     change::C

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -38,6 +38,9 @@ operation_name(err::UnsupportedObjectiveModification) = "Modifying the objective
 
 Apply the modification specified by `change` to the function of constraint `ci`.
 
+An [`UnsupportedConstraintModification`](@ref) error is thrown if modifying
+constraints is not supported by the model `model`.
+
 ### Examples
 
 ```julia
@@ -50,6 +53,9 @@ modify!(model, ci, ScalarConstantChange(10.0))
 
 Apply the modification specified by `change` to the objective function of
 `model`. To change the function completely, call `set!` instead.
+
+An [`UnsupportedObjectiveModification`](@ref) error is thrown if modifying
+objectives is not supported by the model `model`.
 
 ### Examples
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,14 +1,19 @@
 # Variables
 
 """
-    CannotAddVariable <: CannotError
+    struct CannotAddVariable <: CannotError
+        message::String # Human-friendly explanation why the attribute cannot be set
+    end
 
 An error indicating that variables cannot be added in the current state of the
 model.
 """
-struct CannotAddVariable <: CannotError end
+struct CannotAddVariable <: CannotError
+    message::String # Human-friendly explanation why the attribute cannot be set
+end
 
 operation_name(::CannotAddVariable) = "Adding variables"
+message(err::CannotAttConstraint) = err.message
 
 """
     addvariables!(model::ModelLike, n::Int)::Vector{VariableIndex}

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,22 +1,24 @@
 # Variables
 
 """
-    canaddvariable(model::ModelLike)::Bool
+    CannotAddVariable <: CannotError
 
-Return a `Bool` indicating whether it is possible to add a variable to the model `model`.
+Variables cannot be added in the current state of the model.
 """
-function canaddvariable end
+struct CannotAddVariable <: CannotError end
+
+operation_name(::CannotAddVariable) = "Adding variables"
 
 """
     addvariables!(model::ModelLike, n::Int)::Vector{VariableIndex}
 
 Add `n` scalar variables to the model, returning a vector of variable indices.
 """
-function addvariables! end
+addvariables!(model::ModelLike, n) = throw(CannotAddVariable())
 
 """
     addvariable!(model::ModelLike)::VariableIndex
 
 Add a scalar variable to the model, returning a variable index.
 """
-function addvariable! end
+addvariable!(model::ModelLike) = throw(CannotAddVariable())

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -3,7 +3,8 @@
 """
     CannotAddVariable <: CannotError
 
-Variables cannot be added in the current state of the model.
+An error indicating that variables cannot be added in the current state of the
+model.
 """
 struct CannotAddVariable <: CannotError end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -13,12 +13,15 @@ struct CannotAddVariable <: CannotError
 end
 
 operation_name(::CannotAddVariable) = "Adding variables"
-message(err::CannotAttConstraint) = err.message
+message(err::CannotAddVariable) = err.message
 
 """
     addvariables!(model::ModelLike, n::Int)::Vector{VariableIndex}
 
 Add `n` scalar variables to the model, returning a vector of variable indices.
+
+A [`CannotAddVariable`](@ref) error is thrown if adding variables cannot be
+done in the current state of the model `model`.
 """
 addvariables!(model::ModelLike, n) = throw(CannotAddVariable())
 
@@ -26,5 +29,8 @@ addvariables!(model::ModelLike, n) = throw(CannotAddVariable())
     addvariable!(model::ModelLike)::VariableIndex
 
 Add a scalar variable to the model, returning a variable index.
+
+A [`CannotAddVariable`](@ref) error is thrown if adding variables cannot be
+done in the current state of the model `model`.
 """
 addvariable!(model::ModelLike) = throw(CannotAddVariable())

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -11,6 +11,7 @@ model.
 struct CannotAddVariable <: CannotError
     message::String # Human-friendly explanation why the attribute cannot be set
 end
+CannotAddVariable() = CannotAddVariable("")
 
 operation_name(::CannotAddVariable) = "Adding variables"
 message(err::CannotAddVariable) = err.message

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -18,8 +18,13 @@ function test_delete_bridge(m::MOIB.AbstractBridgeOptimizer, ci::MOI.ConstraintI
         test_noc(m, noc...)
     end
     @test MOI.isvalid(m, ci)
-    @test MOI.candelete(m, ci)
     MOI.delete!(m, ci)
+    @test_throws MOI.InvalidIndex{typeof(ci)} MOI.delete!(m, ci)
+    try
+        MOI.delete!(m, ci)
+    catch err
+        @test err.index == ci
+    end
     @test !MOI.isvalid(m, ci)
     @test isempty(m.bridges)
     test_noc(m, F, S, 0)
@@ -75,7 +80,6 @@ end
         @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}}())) == [c2]
 
         @test MOI.isvalid(model, c2)
-        @test MOI.candelete(model, c2)
         MOI.delete!(model, c2)
 
         @test MOI.canget(model, MOI.ListOfConstraints())

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -134,8 +134,8 @@ MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, No
         @test !MOI.canget(fullbridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle})
         ci = first(MOI.get(fullbridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
         @test !MOI.canmodify(fullbridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
-        @test !MOI.canset(fullbridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.canset(fullbridgedmock, MOI.ConstraintFunction(), typeof(ci))
+        @test !MOI.supports(fullbridgedmock, MOI.ConstraintSet(), typeof(ci))
+        @test !MOI.supports(fullbridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(fullbridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
                                                     (MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone, 0),
                                                     (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0)))
@@ -188,8 +188,8 @@ end
         MOIT.rotatedsoc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}()))
         @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
-        @test !MOI.canset(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.canset(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 2, ((MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone, 0),))
     end
 
@@ -202,8 +202,8 @@ end
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.GeometricMeanCone})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
         @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
-        @test !MOI.canset(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.canset(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
                                                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64},      1)))
     end
@@ -217,8 +217,8 @@ end
         MOIT.soc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone}()))
         @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
-        @test !MOI.canset(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.canset(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 3, ((MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0),))
     end
 
@@ -233,8 +233,8 @@ end
         MOIT.rotatedsoc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}()))
         @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
-        @test !MOI.canset(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.canset(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 2, ((MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0),))
     end
 
@@ -247,8 +247,8 @@ end
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle}()))
         @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
-        @test !MOI.canset(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.canset(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone, 0), (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0)))
     end
 
@@ -261,8 +261,8 @@ end
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
         @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
-        @test !MOI.canset(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.canset(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
+        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
                                                 (MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone, 0),
                                                 (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0)))

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -133,7 +133,6 @@ MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, No
         # Dual is not yet implemented for RootDet and GeoMean bridges
         @test !MOI.canget(fullbridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle})
         ci = first(MOI.get(fullbridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
-        @test !MOI.canmodify(fullbridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
         @test !MOI.supports(fullbridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(fullbridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(fullbridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
@@ -168,7 +167,6 @@ end
         bridgedmock = MOIB.SplitInterval{Float64}(mock)
         MOIT.linear10test(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}}()))
-        @test MOI.canmodify(bridgedmock, typeof(ci), MOI.ScalarConstantChange{Float64})
         newf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], MOI.get(bridgedmock, MOI.ListOfVariableIndices())), 0.0)
         MOI.set!(bridgedmock, MOI.ConstraintFunction(), ci, newf)
         @test MOI.canget(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
@@ -187,7 +185,6 @@ end
                               (MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)  => [[3/2, 1/2, -1.0, -1.0]])
         MOIT.rotatedsoc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}()))
-        @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 2, ((MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone, 0),))
@@ -201,7 +198,6 @@ end
         # Dual is not yet implemented for GeoMean bridge
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.GeometricMeanCone})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
-        @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
@@ -216,7 +212,6 @@ end
         MOIT.soc1vtest(bridgedmock, config)
         MOIT.soc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone}()))
-        @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 3, ((MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0),))
@@ -232,7 +227,6 @@ end
                               (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle) => [[√2, -1/2, √2/8, -1/2, √2/8, √2/8]])
         MOIT.rotatedsoc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}()))
-        @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 2, ((MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0),))
@@ -246,7 +240,6 @@ end
         # Dual is not yet implemented for LogDet bridge
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle}()))
-        @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone, 0), (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0)))
@@ -260,7 +253,6 @@ end
         # Dual is not yet implemented for RootDet bridge
         @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
-        @test !MOI.canmodify(bridgedmock, typeof(ci), MOI.VectorConstantChange{Float64})
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -1,4 +1,3 @@
-
 @MOIU.model ModelForCachingOptimizer (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, ExponentialCone, DualExponentialCone, PositiveSemidefiniteConeTriangle, RootDetConeTriangle, LogDetConeTriangle) () (SingleVariable,) (ScalarAffineFunction,ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
 
 @testset "CachingOptimizer Manual mode" begin
@@ -55,12 +54,12 @@
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), v) == 3.0
 
     # ModelForMock doesn't support RotatedSecondOrderCone
-    @test !MOI.canaddconstraint(m, MOI.VectorOfVariables, MOI.RotatedSecondOrderCone)
+    @test !MOI.supportsconstraint(m, MOI.VectorOfVariables, MOI.RotatedSecondOrderCone)
 
-    @test MOI.canaddconstraint(m.model_cache, MOI.SingleVariable, MOI.LessThan{Float64})
-    @test MOI.canaddconstraint(m.optimizer.inner_model, MOI.SingleVariable, MOI.LessThan{Float64})
-    @test MOI.canaddconstraint(m.optimizer, MOI.SingleVariable, MOI.LessThan{Float64})
-    @test MOI.canaddconstraint(m, MOI.SingleVariable, MOI.LessThan{Float64})
+    @test MOI.supportsconstraint(m.model_cache, MOI.SingleVariable, MOI.LessThan{Float64})
+    @test MOI.supportsconstraint(m.optimizer.inner_model, MOI.SingleVariable, MOI.LessThan{Float64})
+    @test MOI.supportsconstraint(m.optimizer, MOI.SingleVariable, MOI.LessThan{Float64})
+    @test MOI.supportsconstraint(m, MOI.SingleVariable, MOI.LessThan{Float64})
     lb = MOI.addconstraint!(m, MOI.SingleVariable(v), MOI.LessThan(10.0))
     @test MOI.canset(m, MOI.ConstraintSet(), typeof(lb))
     MOI.set!(m, MOI.ConstraintSet(), lb, MOI.LessThan(11.0))
@@ -137,8 +136,10 @@ end
     @test MOI.canget(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), typeof(v))
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), v) == 3.0
 
-    # ModelForMock doesn't support RotatedSecondOrderCone
-    MOI.addconstraint!(m, MOI.VectorOfVariables([v]), MOI.RotatedSecondOrderCone(1))
+    # Simulate that constraints cannot be added
+    s.canaddcon = false
+    MOI.addconstraint!(m, MOI.VectorOfVariables([v]), MOI.SecondOrderCone(1))
+    s.canaddcon = true
     @test MOIU.state(m) == MOIU.EmptyOptimizer
 
     # TODO: test modify! with a change that forces the optimizer to be dropped

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -147,11 +147,10 @@ end
     MOI.empty!(m)
     @test MOIU.state(m) == MOIU.AttachedOptimizer
 
-    m.optimizer.canaddvar = false # Simulate optimizer for which MOI.canaddvariable returns false
+    m.optimizer.canaddvar = false # Simulate optimizer that cannot add variables incrementally
     MOI.addvariable!(m)
     @test MOIU.state(m) == MOIU.EmptyOptimizer
-    res = MOIU.attachoptimizer!(m)
-    @test res.status == MOI.CopyOtherError
+    @test_throws MOI.CannotAddVariable MOIU.attachoptimizer!(m)
     @test MOIU.state(m) == MOIU.EmptyOptimizer
 
     m.optimizer.canaddvar = true

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -12,7 +12,7 @@
     v = MOI.addvariable!(m)
     x = MOI.addvariables!(m, 2)
     saf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], [v; x]), 0.0)
-    @test MOI.canset(m, MOI.ObjectiveFunction{typeof(saf)}())
+    @test MOI.supports(m, MOI.ObjectiveFunction{typeof(saf)}())
     MOI.set!(m, MOI.ObjectiveFunction{typeof(saf)}(), saf)
     @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveFunction{typeof(saf)}())) ≈ saf
     @test MOI.get(m, MOI.ObjectiveFunction{typeof(saf)}()) ≈ saf
@@ -24,7 +24,7 @@
     @test MOIU.state(m) == MOIU.AttachedOptimizer
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveFunction{typeof(saf)}())) ≈ saf
 
-    @test MOI.canset(m, MOI.ObjectiveSense())
+    @test MOI.supports(m, MOI.ObjectiveSense())
     MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
     @test MOI.canget(m, MOI.ObjectiveSense())
     @test MOI.canget(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense()))
@@ -33,16 +33,16 @@
     @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense())) == MOI.MaxSense
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense())) == MOI.MaxSense
 
-    @test !MOI.canset(m, MOI.NumberOfVariables())
+    @test !MOI.supports(m, MOI.NumberOfVariables())
     @test !MOI.canget(m, MOIU.AttributeFromModelCache(MOIU.MockModelAttribute()))
     @test MOI.canget(m, MOIU.AttributeFromOptimizer((MOIU.MockModelAttribute())))
 
-    @test MOI.canset(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()))
+    @test MOI.supports(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()))
     MOI.set!(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()), 10)
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute())) == 10
 
     MOI.set!(m, MOIU.AttributeFromOptimizer(MOI.ResultCount()), 1)
-    @test MOI.canset(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), typeof(v))
+    @test MOI.supports(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), typeof(v))
     MOI.set!(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), v, 3.0)
 
     MOI.optimize!(m)
@@ -61,7 +61,7 @@
     @test MOI.supportsconstraint(m.optimizer, MOI.SingleVariable, MOI.LessThan{Float64})
     @test MOI.supportsconstraint(m, MOI.SingleVariable, MOI.LessThan{Float64})
     lb = MOI.addconstraint!(m, MOI.SingleVariable(v), MOI.LessThan(10.0))
-    @test MOI.canset(m, MOI.ConstraintSet(), typeof(lb))
+    @test MOI.supports(m, MOI.ConstraintSet(), typeof(lb))
     MOI.set!(m, MOI.ConstraintSet(), lb, MOI.LessThan(11.0))
     @test MOI.get(m, MOI.ConstraintSet(), lb) == MOI.LessThan(11.0)
     @test MOI.get(m, MOI.ConstraintFunction(), lb) == MOI.SingleVariable(v)
@@ -69,7 +69,7 @@
     MOIU.dropoptimizer!(m)
     @test MOIU.state(m) == MOIU.NoOptimizer
 
-    @test MOI.canset(m, MOI.ConstraintSet(), typeof(lb))
+    @test MOI.supports(m, MOI.ConstraintSet(), typeof(lb))
     MOI.set!(m, MOI.ConstraintSet(), lb, MOI.LessThan(12.0))
     @test MOI.get(m, MOI.ConstraintSet(), lb) == MOI.LessThan(12.0)
 
@@ -87,7 +87,7 @@ end
     @test MOIU.state(m) == MOIU.NoOptimizer
 
     v = MOI.addvariable!(m)
-    @test MOI.canset(m, MOI.VariableName(), typeof(v))
+    @test MOI.supports(m, MOI.VariableName(), typeof(v))
     MOI.set!(m, MOI.VariableName(), v, "v")
     @test MOI.canget(m, MOI.VariableName(), typeof(v))
     @test MOI.get(m, MOI.VariableName(), v) == "v"
@@ -98,7 +98,7 @@ end
     @test MOIU.state(m) == MOIU.EmptyOptimizer
 
     saf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v)], 0.0)
-    @test MOI.canset(m, MOI.ObjectiveFunction{typeof(saf)}())
+    @test MOI.supports(m, MOI.ObjectiveFunction{typeof(saf)}())
     MOI.set!(m, MOI.ObjectiveFunction{typeof(saf)}(), saf)
     @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveFunction{typeof(saf)}())) ≈ saf
 
@@ -113,7 +113,7 @@ end
     # The caching optimizer does not copy names
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.VariableName()), v) == ""
 
-    @test MOI.canset(m, MOI.ObjectiveSense())
+    @test MOI.supports(m, MOI.ObjectiveSense())
     MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
     @test MOI.canget(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense()))
     @test MOI.canget(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense()))
@@ -123,12 +123,12 @@ end
     @test !MOI.canget(m, MOIU.AttributeFromModelCache(MOIU.MockModelAttribute()))
     @test MOI.canget(m, MOIU.AttributeFromOptimizer((MOIU.MockModelAttribute())))
 
-    @test MOI.canset(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()))
+    @test MOI.supports(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()))
     MOI.set!(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()), 10)
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute())) == 10
 
     MOI.set!(m, MOIU.AttributeFromOptimizer(MOI.ResultCount()), 1)
-    @test MOI.canset(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), typeof(v))
+    @test MOI.supports(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), typeof(v))
     MOI.set!(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), v, 3.0)
 
     MOI.optimize!(m)
@@ -154,8 +154,7 @@ end
     @test MOIU.state(m) == MOIU.EmptyOptimizer
 
     m.optimizer.canaddvar = true
-    res = MOIU.attachoptimizer!(m)
-    @test res.status == MOI.CopySuccess
+    MOIU.attachoptimizer!(m)
     @test MOIU.state(m) == MOIU.AttachedOptimizer
     m.optimizer.canaddvar = false
     MOI.addvariables!(m, 2)

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -73,8 +73,8 @@
     MOI.set!(m, MOI.ConstraintSet(), lb, MOI.LessThan(12.0))
     @test MOI.get(m, MOI.ConstraintSet(), lb) == MOI.LessThan(12.0)
 
-    @test MOI.candelete(m, x[2])
     MOI.delete!(m, x[2])
+    @test_throws MOI.InvalidIndex{typeof(x[2])} MOI.delete!(m, x[2])
     @test !MOI.isvalid(m, x[2])
 
     # TODO: test more constraint modifications

--- a/test/mockoptimizer.jl
+++ b/test/mockoptimizer.jl
@@ -4,13 +4,13 @@ end
 
 @testset "Mock optimizer optimizer attributes" begin
     optimizer = MOIU.MockOptimizer(ModelForMock{Float64}())
-    @test MOI.canset(optimizer, MOIU.MockModelAttribute())
+    @test MOI.supports(optimizer, MOIU.MockModelAttribute())
     MOI.set!(optimizer, MOIU.MockModelAttribute(), 10)
     @test MOI.canget(optimizer, MOIU.MockModelAttribute())
     @test MOI.get(optimizer, MOIU.MockModelAttribute()) == 10
 
     v1 = MOI.addvariable!(optimizer)
-    @test MOI.canset(optimizer, MOIU.MockVariableAttribute(), typeof(v1))
+    @test MOI.supports(optimizer, MOIU.MockVariableAttribute(), typeof(v1))
     MOI.set!(optimizer, MOIU.MockVariableAttribute(), v1, 11)
     @test MOI.canget(optimizer, MOIU.MockVariableAttribute(), typeof(v1))
     @test MOI.get(optimizer, MOIU.MockVariableAttribute(), v1) == 11
@@ -19,7 +19,7 @@ end
 
     @test MOI.supportsconstraint(optimizer, MOI.SingleVariable, MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(optimizer, MOI.SingleVariable(v1), MOI.GreaterThan(1.0))
-    @test MOI.canset(optimizer, MOIU.MockConstraintAttribute(), typeof(c1))
+    @test MOI.supports(optimizer, MOIU.MockConstraintAttribute(), typeof(c1))
     MOI.set!(optimizer, MOIU.MockConstraintAttribute(), c1, 12)
     @test MOI.canget(optimizer, MOIU.MockConstraintAttribute(), typeof(c1))
     @test MOI.get(optimizer, MOIU.MockConstraintAttribute(), c1) == 12

--- a/test/mockoptimizer.jl
+++ b/test/mockoptimizer.jl
@@ -17,7 +17,7 @@ end
     MOI.set!(optimizer, MOIU.MockVariableAttribute(), [v1], [-11])
     @test MOI.get(optimizer, MOIU.MockVariableAttribute(), [v1]) == [-11]
 
-    @test MOI.canaddconstraint(optimizer, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supportsconstraint(optimizer, MOI.SingleVariable, MOI.GreaterThan{Float64})
     c1 = MOI.addconstraint!(optimizer, MOI.SingleVariable(v1), MOI.GreaterThan(1.0))
     @test MOI.canset(optimizer, MOIU.MockConstraintAttribute(), typeof(c1))
     MOI.set!(optimizer, MOIU.MockConstraintAttribute(), c1, 12)

--- a/test/model.jl
+++ b/test/model.jl
@@ -12,9 +12,9 @@ end
     MOIT.emptytest(Model{Float64}())
 end
 
-@testset "canaddconstraint test" begin
-    MOIT.canaddconstrainttest(Model{Float64}(), Float64, Int)
-    MOIT.canaddconstrainttest(Model{Int}(), Int, Float64)
+@testset "supportsconstraint test" begin
+    MOIT.supportsconstrainttest(Model{Float64}(), Float64, Int)
+    MOIT.supportsconstrainttest(Model{Int}(), Int, Float64)
 end
 
 @testset "OrderedIndices" begin

--- a/test/model.jl
+++ b/test/model.jl
@@ -137,13 +137,13 @@ struct SetNotSupportedBySolvers <: MOI.AbstractSet end
         c = MOI.addconstraint!(m, MOI.SingleVariable(x), MOI.LessThan(0.0))
         @test !MOI.supportsconstraint(m, FunctionNotSupportedBySolvers, SetNotSupportedBySolvers)
 
-        @test MOI.canset(m, MOI.ConstraintSet(), typeof(c))
+        @test MOI.supports(m, MOI.ConstraintSet(), typeof(c))
         # set of different type
         @test_throws Exception MOI.set!(m, MOI.ConstraintSet(), c, MOI.GreaterThan(0.0))
         # set not implemented
         @test_throws Exception MOI.set!(m, MOI.ConstraintSet(), c, SetNotSupportedBySolvers())
 
-        @test MOI.canset(m, MOI.ConstraintFunction(), typeof(c))
+        @test MOI.supports(m, MOI.ConstraintFunction(), typeof(c))
         # function of different type
         @test_throws Exception MOI.set!(m, MOI.ConstraintFunction(), c, MOI.VectorOfVariables([x]))
         # function not implemented

--- a/test/universalfallback.jl
+++ b/test/universalfallback.jl
@@ -45,10 +45,10 @@ function test_varconattrs(uf, model, attr, listattr, I::Type{<:MOI.Index}, addfu
     @test !MOI.canget(uf, attr, I)
     @test isempty(MOI.get(uf, listattr))
 
-    @test MOI.candelete(uf, u)
     @test MOI.isvalid(uf, u)
     MOI.delete!(uf, u)
     @test !MOI.isvalid(uf, u)
+    @test_throws MOI.InvalidIndex{typeof(u)} MOI.delete!(uf, u)
     @test !MOI.canget(model, attr, I)
     @test !MOI.canget(uf, attr, I)
     @test isempty(MOI.get(uf, listattr))

--- a/test/universalfallback.jl
+++ b/test/universalfallback.jl
@@ -1,6 +1,6 @@
 function test_optmodattrs(uf, model, attr, listattr)
-    @test !MOI.canset(model, attr)
-    @test MOI.canset(uf, attr)
+    @test !MOI.supports(model, attr)
+    @test MOI.supports(uf, attr)
     @test !MOI.canget(model, attr)
     @test !MOI.canget(uf, attr)
     @test isempty(MOI.get(uf, listattr))
@@ -14,8 +14,8 @@ function test_optmodattrs(uf, model, attr, listattr)
     @test MOI.isempty(uf)
 end
 function test_varconattrs(uf, model, attr, listattr, I::Type{<:MOI.Index}, addfun, x, y, z)
-    @test !MOI.canset(model, attr, I)
-    @test MOI.canset(uf, attr, I)
+    @test !MOI.supports(model, attr, I)
+    @test MOI.supports(uf, attr, I)
     @test !MOI.canget(model, attr, I)
     @test !MOI.canget(uf, attr, I)
     @test isempty(MOI.get(uf, listattr))
@@ -123,12 +123,12 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
             listattr = MOI.ListOfConstraintAttributesSet{MOI.SingleVariable, MOI.LessThan{Float64}}()
             test_varconattrs(uf, model, attr, listattr, CI, uf -> MOI.addconstraint!(uf, x, MOI.LessThan(0.)), cx, cy, cz)
 
-            @test MOI.canset(uf, MOI.ConstraintFunction(), typeof(cx))
+            @test MOI.supports(uf, MOI.ConstraintFunction(), typeof(cx))
             MOI.set!(uf, MOI.ConstraintFunction(), cx, MOI.SingleVariable(y))
             @test MOI.canget(uf, MOI.ConstraintFunction(), typeof(cx))
             @test MOI.get(uf, MOI.ConstraintFunction(), cx) == MOI.SingleVariable(y)
 
-            @test MOI.canset(uf, MOI.ConstraintName(), typeof(cx))
+            @test MOI.supports(uf, MOI.ConstraintName(), typeof(cx))
             MOI.set!(uf, MOI.ConstraintName(), cx, "LessThan")
             @test MOI.canget(uf, MOI.ConstraintName(), typeof(cx))
             @test MOI.get(uf, MOI.ConstraintName(), cx) == "LessThan"
@@ -145,12 +145,12 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
             listattr = MOI.ListOfConstraintAttributesSet{MOI.SingleVariable, MOI.EqualTo{Float64}}()
             test_varconattrs(uf, model, attr, listattr, CI, uf -> MOI.addconstraint!(uf, x, MOI.EqualTo(0.)), cx, cy, cz)
 
-            @test MOI.canset(uf, MOI.ConstraintFunction(), typeof(cx))
+            @test MOI.supports(uf, MOI.ConstraintFunction(), typeof(cx))
             MOI.set!(uf, MOI.ConstraintFunction(), cx, MOI.SingleVariable(y))
             @test MOI.canget(uf, MOI.ConstraintFunction(), typeof(cx))
             @test MOI.get(uf, MOI.ConstraintFunction(), cx) == MOI.SingleVariable(y)
 
-            @test MOI.canset(uf, MOI.ConstraintName(), typeof(cx))
+            @test MOI.supports(uf, MOI.ConstraintName(), typeof(cx))
             MOI.set!(uf, MOI.ConstraintName(), cx, "EqualTo")
             @test MOI.canget(uf, MOI.ConstraintName(), typeof(cx))
             @test MOI.get(uf, MOI.ConstraintName(), cx) == "EqualTo"


### PR DESCRIPTION
- [x] Remove `cantransform`
- [x] Remove `canaddconstraint`
- [x] Remove `canaddvariable`
- [x] Remove `canset`
- [x] Remove `canmodify`
- [x] Remove `candelete`
- [x] Add error section in doc

Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/423 
Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/295
Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/218
Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/243