### PR TITLE
Add some more tests

### DIFF
--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -188,8 +188,7 @@ unittests["solve_with_lowerbound"] = solve_with_lowerbound
 """
     solve_integer_edge_cases(model::MOI.ModelLike, config::TestConfig)
 
-Test setting the lower bound of an integer variable to fractional value and
-confirm that it solves correctly.
+Test a variety of edge cases related to binary and integer variables.
 """
 function solve_integer_edge_cases(model::MOI.ModelLike, config::TestConfig)
     @testset "integer with lower bound" begin

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -20,7 +20,8 @@ end
         "solve_qp_edge_cases",
         "solve_qcp_edge_cases",
         "solve_affine_deletion_edge_cases",
-        "solve_duplicate_terms_obj"
+        "solve_duplicate_terms_obj",
+        "solve_integer_edge_cases"
         ])
 
     @testset "solve_blank_obj" begin
@@ -190,6 +191,23 @@ end
             )
         )
         MOIT.solve_affine_deletion_edge_cases(mock, config)
+    end
+    @testset "solve_integer_edge_cases" begin
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [2.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [1.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [1.0])
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success, (MOI.FeasiblePoint, [0.0])
+            )
+        )
+        MOIT.solve_integer_edge_cases(mock, config)
     end
 end
 


### PR DESCRIPTION
GLPK has issues where it requires integer variables to have integer bounds. So the wrapper has to round the bounds prior to solve, then unround them afterward so they can be queried appropriately.