### PR TITLE
Fix method specialization

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -592,11 +592,14 @@ A constraint attribute for the `AbstractSet` object used to define the constrain
 """
 struct ConstraintSet <: AbstractConstraintAttribute end
 
-function hidden_set!(model::ModelLike, attr::ConstraintSet, constraint_index::ConstraintIndex{F,S}, set::S) where {F,S}
+function hidden_set!(model::ModelLike, attr::ConstraintSet,
+                     constraint_index::ConstraintIndex{F, S},
+                     set::S) where {F, S<:AbstractSet}
     throw(UnsupportedAttribute(attr))
 end
-set_type(c::ConstraintIndex{F,S}) where {F, S} = S
-function hidden_set!(model::ModelLike, ::ConstraintSet, ::ConstraintIndex, ::AbstractSet)
+set_type(::ConstraintIndex{F, S}) where {F, S} = S
+function hidden_set!(model::ModelLike, ::ConstraintSet,
+                     constraint_index::ConstraintIndex, set::AbstractSet)
     throw(ArgumentError("""Cannot modify sets of different types. Constraint
     type is $(set_type(constraint_index)) while the replacement set is of
     type $(typeof(set)). Use `transform!` instead."""))

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -273,12 +273,14 @@ function set! end
 # See note with get
 set!(model::ModelLike, attr::Union{AbstractVariableAttribute, AbstractConstraintAttribute}, idxs::Vector, vector_of_values::Vector) = set!.(Ref(model), Ref(attr), idxs, vector_of_values)
 
-set!(model::ModelLike, attr::AnyAttribute, args...) = hidden_set!(model, attr, args...)
-# hidden_set! is included so that we can return type-specific error messages
-# without needing to overload set! and cause ambiguity errors. For examples, see
-# ConstraintSet and ConstraintFunction. hidden_set! should not be overloaded by
-# users of MOI.
-function hidden_set!(model::ModelLike, attr::AnyAttribute, args...)
+function set!(model::ModelLike, attr::AnyAttribute, args...)
+    set!_fallback_error(model, attr, args...)
+end
+# set!_fallback_error is included so that we can return type-specific error
+# messages without needing to overload set! and cause ambiguity errors. For
+# examples, see ConstraintSet and ConstraintFunction. set!_fallback_error should
+# not be overloaded by users of MOI.
+function set!_fallback_error(model::ModelLike, attr::AnyAttribute, args...)
     throw(UnsupportedAttribute(attr))
 end
 
@@ -575,13 +577,13 @@ It is guaranteed to be equivalent but not necessarily identical to the function 
 """
 struct ConstraintFunction <: AbstractConstraintAttribute end
 
-function hidden_set!(::ModelLike, attr::ConstraintFunction,
+function set!_fallback_error(::ModelLike, attr::ConstraintFunction,
                      ::ConstraintIndex{F, S}, ::F) where {F <: AbstractFunction,
                                                           S}
     throw(UnsupportedAttribute(attr))
 end
 func_type(c::ConstraintIndex{F, S}) where {F, S} = F
-function hidden_set!(::ModelLike, ::ConstraintFunction,
+function set!_fallback_error(::ModelLike, ::ConstraintFunction,
                      constraint_index::ConstraintIndex, func::AbstractFunction)
     throw(ArgumentError("""Cannot modify functions of different types.
     Constraint type is $(func_type(constraint_index)) while the replacement
@@ -595,12 +597,12 @@ A constraint attribute for the `AbstractSet` object used to define the constrain
 """
 struct ConstraintSet <: AbstractConstraintAttribute end
 
-function hidden_set!(::ModelLike, attr::ConstraintSet, ::ConstraintIndex{F, S},
+function set!_fallback_error(::ModelLike, attr::ConstraintSet, ::ConstraintIndex{F, S},
                      ::S) where {F, S <: AbstractSet}
     throw(UnsupportedAttribute(attr))
 end
 set_type(::ConstraintIndex{F, S}) where {F, S} = S
-function hidden_set!(::ModelLike, ::ConstraintSet,
+function set!_fallback_error(::ModelLike, ::ConstraintSet,
                      constraint_index::ConstraintIndex, set::AbstractSet)
     throw(ArgumentError("""Cannot modify sets of different types. Constraint
     type is $(set_type(constraint_index)) while the replacement set is of

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -575,11 +575,14 @@ It is guaranteed to be equivalent but not necessarily identical to the function 
 """
 struct ConstraintFunction <: AbstractConstraintAttribute end
 
-function hidden_set!(model::ModelLike, attr::ConstraintFunction, constraint_index::ConstraintIndex{F,S}, func::F) where {F,S}
+function hidden_set!(::ModelLike, attr::ConstraintFunction,
+                     ::ConstraintIndex{F, S}, ::F) where {F <: AbstractFunction,
+                                                          S}
     throw(UnsupportedAttribute(attr))
 end
-func_type(c::ConstraintIndex{F,S}) where {F, S} = F
-function hidden_set!(model::ModelLike, ::ConstraintFunction, ::ConstraintIndex, ::AbstractFunction)
+func_type(c::ConstraintIndex{F, S}) where {F, S} = F
+function hidden_set!(::ModelLike, ::ConstraintFunction,
+                     constraint_index::ConstraintIndex, func::AbstractFunction)
     throw(ArgumentError("""Cannot modify functions of different types.
     Constraint type is $(func_type(constraint_index)) while the replacement
     function is of type $(typeof(func))."""))
@@ -592,13 +595,12 @@ A constraint attribute for the `AbstractSet` object used to define the constrain
 """
 struct ConstraintSet <: AbstractConstraintAttribute end
 
-function hidden_set!(model::ModelLike, attr::ConstraintSet,
-                     constraint_index::ConstraintIndex{F, S},
-                     set::S) where {F, S<:AbstractSet}
+function hidden_set!(::ModelLike, attr::ConstraintSet, ::ConstraintIndex{F, S},
+                     ::S) where {F, S <: AbstractSet}
     throw(UnsupportedAttribute(attr))
 end
 set_type(::ConstraintIndex{F, S}) where {F, S} = S
-function hidden_set!(model::ModelLike, ::ConstraintSet,
+function hidden_set!(::ModelLike, ::ConstraintSet,
                      constraint_index::ConstraintIndex, set::AbstractSet)
     throw(ArgumentError("""Cannot modify sets of different types. Constraint
     type is $(set_type(constraint_index)) while the replacement set is of

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -1,0 +1,26 @@
+struct DummyModel <: MOI.ModelLike
+end
+
+@testset "Fallbacks for `set!` methods" begin
+    m = DummyModel()
+    ci = MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}(1)
+    @testset "ConstraintFunction" begin
+        vi = MOI.VariableIndex(1)
+        @test_throws MOI.UnsupportedAttribute begin
+            MOI.set!(m, MOI.ConstraintFunction(), ci, MOI.SingleVariable(vi))
+        end
+        @test_throws ArgumentError begin
+            MOI.set!(m, MOI.ConstraintFunction(), ci,
+                     MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, vi)],
+                                              0.0))
+        end
+    end
+    @testset "ConstraintSet" begin
+        @test_throws MOI.UnsupportedAttribute begin
+            MOI.set!(m, MOI.ConstraintSet(), ci, MOI.EqualTo(1.0))
+        end
+        @test_throws ArgumentError begin
+            MOI.set!(m, MOI.ConstraintSet(), ci, MOI.GreaterThan(1.0))
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ using Compat.Test
     include("isbits.jl")
     include("isapprox.jl")
     include("interval.jl")
+    include("attributes.jl")
 end
 
 # Needed by test spread over several files, defining it here make it easier to comment out tests


### PR DESCRIPTION
Without the `S<:AbstractSet` in the first method, julia considers that the signature is less specific.