### PR TITLE
Fix delete fallback

### DIFF
--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -59,6 +59,9 @@ by the model.
 struct UnsupportedDeletion{IndexType<:Index} <: UnsupportedError
     message::String
 end
+function UnsupportedDeletion{IndexType}() where IndexType <: Index
+    UnsupportedDeletion{IndexType}("")
+end
 
 function operation_name(::UnsupportedDeletion{IndexType}) where {IndexType<:Index}
     return "Deleting indices of type `$IndexType`"

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -4,6 +4,9 @@ end
 @testset "Fallbacks for `set!` methods" begin
     model = DummyModel()
     ci = MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}(1)
+
+    @test_throws MOI.UnsupportedDeletion{typeof(ci)} MOI.delete!(model, ci)
+
     @testset "ConstraintFunction" begin
         vi = MOI.VariableIndex(1)
         @test_throws MOI.UnsupportedAttribute begin


### PR DESCRIPTION
We'll have to release a MOI v0.5.1 with this fix as it is blocking for copy-only solver