### PR TITLE
Make models broadcastable without Ref

### DIFF
--- a/src/Bridges/detbridge.jl
+++ b/src/Bridges/detbridge.jl
@@ -80,7 +80,7 @@ function LogDetBridge{T}(model, f::MOI.VectorAffineFunction{T}, s::MOI.LogDetCon
     d = s.side_dimension
     t, D, Δ, sdindex = extract_eigenvalues(model, f, d)
     l = MOI.addvariables!(model, d)
-    lcindex = sublog.(Ref(model), l, D, T)
+    lcindex = sublog.(model, l, D, T)
     tlindex = subsum(model, t, l, T)
 
     LogDetBridge(Δ, l, sdindex, lcindex, tlindex)

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -8,6 +8,9 @@ Abstract supertype for objects that implement the "Model" interface for defining
 an optimization problem.
 """
 abstract type ModelLike end
+@static if VERSION >= v"0.7-"
+    Base.broadcastable(model::ModelLike) = Ref(model)
+end
 
 """
     AbstractOptimizer

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -221,7 +221,7 @@ function basic_constraint_test_helper(model::MOI.ModelLike, config::TestConfig, 
 
     @testset "isvalid" begin
         c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-        @test all(MOI.isvalid.(Ref(model), c_indices))
+        @test all(MOI.isvalid.(model, c_indices))
     end
 
     if delete

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -196,7 +196,7 @@ end
 
 # Used for Vector{Symbol}, Vector{ParsedScalarAffineTerm}, Vector{ParsedVectorAffineTerm},
 # Vector{ParsedScalarQuadraticTerm} and Vector{ParsedVectorQuadraticTerm}
-parsedtoMOI(model, s::Vector) = parsedtoMOI.(Ref(model), s)
+parsedtoMOI(model, s::Vector) = parsedtoMOI.(model, s)
 
 parsedtoMOI(model, s::Union{Float64, Int64}) = s
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -157,7 +157,7 @@ function get end
 # We want to avoid being too specific in the type arguments to avoid method ambiguity.
 # For model, get(::ModelLike, ::AbstractVariableAttribute, ::Vector{VariableIndex}) would not allow
 # to define get(::SomeModel, ::AnyAttribute, ::Vector)
-get(model::ModelLike, attr::AnyAttribute, idxs::Vector) = get.(Ref(model), Ref(attr), idxs)
+get(model::ModelLike, attr::AnyAttribute, idxs::Vector) = get.(model, Ref(attr), idxs)
 
 function get(model::ModelLike, attr::AnyAttribute, args...)
     throw(ArgumentError("ModelLike of type $(typeof(model)) does not support accessing the attribute $attr"))
@@ -284,7 +284,7 @@ set!(model, ConstraintFunction(), c, SingleVariable(v1)) # Error
 """
 function set! end
 # See note with get
-set!(model::ModelLike, attr::Union{AbstractVariableAttribute, AbstractConstraintAttribute}, idxs::Vector, vector_of_values::Vector) = set!.(Ref(model), Ref(attr), idxs, vector_of_values)
+set!(model::ModelLike, attr::Union{AbstractVariableAttribute, AbstractConstraintAttribute}, idxs::Vector, vector_of_values::Vector) = set!.(model, Ref(attr), idxs, vector_of_values)
 
 function set!(model::ModelLike, attr::AnyAttribute, args...)
     set!_fallback_error(model, attr, args...)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -75,7 +75,7 @@ This call is equivalent to `addconstraint!.(model, funcs, sets)` but may be more
 function addconstraints! end
 
 # default fallback
-addconstraints!(model::ModelLike, funcs, sets) = addconstraint!.(Ref(model), funcs, sets)
+addconstraints!(model::ModelLike, funcs, sets) = addconstraint!.(model, funcs, sets)
 
 """
 ## Transform Constraint Set


### PR DESCRIPTION
It is quite clear that a model is zero-dimensional. This PR allows to use broadcast with a model without the need to use `Ref`