### PR TITLE
Remove canget

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -397,7 +397,7 @@ end
 MOI.optimize!(optimizer)
 
 termination_status = MOI.get(optimizer, MOI.TerminationStatus())
-objvalue = MOI.canget(optimizer, MOI.ObjectiveValue()) ? MOI.get(optimizer, MOI.ObjectiveValue()) : NaN
+objvalue = MOI.get(optimizer, MOI.ObjectiveValue())
 if termination_status != MOI.Success
     error("Solver terminated with status $termination_status")
 end

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -20,7 +20,6 @@ AbstractConstraintAttribute
 Functions for getting and setting attributes.
 
 ```@docs
-canget
 get
 get!
 set!

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -206,28 +206,15 @@ function MOI.set!(b::AbstractBridgeOptimizer,
 end
 
 # Constraint attributes
-## Result constraint attributes
-const ResultConstraintAttribute = Union{MOI.ConstraintPrimalStart,
-                                        MOI.ConstraintDualStart,
-                                        MOI.ConstraintPrimal,
-                                        MOI.ConstraintDual,
-                                        MOI.ConstraintBasisStatus}
-function MOI.get(b::AbstractBridgeOptimizer, attr::ResultConstraintAttribute,
+function MOI.get(b::AbstractBridgeOptimizer,
+                 attr::MOI.AbstractConstraintAttribute,
                  ci::CI)
     if isbridged(b, typeof(ci))
-        MOI.get(b, attr, bridge(b, ci))
-    else
-        MOI.get(b.model, attr, ci)
-    end
-end
-## Model constraint attributes
-const ModelConstraintAttribute = Union{MOI.ConstraintName,
-                                       MOI.ConstraintFunction,
-                                       MOI.ConstraintSet}
-function MOI.get(b::AbstractBridgeOptimizer, attr::ModelConstraintAttribute,
-                 ci::CI)
-    if isbridged(b, typeof(ci))
-        MOI.get(b.bridged, attr, ci)
+        if MOIU.is_result_attribute(attr)
+            MOI.get(b, attr, bridge(b, ci))
+        else
+            MOI.get(b.bridged, attr, ci)
+        end
     else
         MOI.get(b.model, attr, ci)
     end

--- a/src/Bridges/detbridge.jl
+++ b/src/Bridges/detbridge.jl
@@ -130,11 +130,6 @@ function MOI.delete!(model::MOI.ModelLike, c::LogDetBridge)
 end
 
 # Attributes, Bridge acting as a constraint
-function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintPrimal, ::Type{LogDetBridge{T}}) where T
-    MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex) &&
-    MOI.canget(model, a, CI{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}}) &&
-    MOI.canget(model, a, CI{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle})
-end
 function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintPrimal, c::LogDetBridge)
     d = length(c.lcindex)
     Δ = MOI.get(model, MOI.VariablePrimal(), c.Δ)
@@ -142,7 +137,6 @@ function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintPrimal, c::LogDetBridge)
     x = MOI.get(model, MOI.ConstraintPrimal(), c.sdindex)[1:length(c.Δ)]
     [t; x]
 end
-MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{<:LogDetBridge}) = false
 
 # Constraints
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:LogDetBridge}) = false
@@ -201,16 +195,11 @@ function MOI.delete!(model::MOI.ModelLike, c::RootDetBridge)
 end
 
 # Attributes, Bridge acting as a constraint
-function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintPrimal, ::Type{RootDetBridge{T}}) where T
-    MOI.canget(model, a, CI{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}) &&
-    MOI.canget(model, a, CI{MOI.VectorAffineFunction{T}, MOI.GeometricMeanCone})
-end
 function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintPrimal, c::RootDetBridge)
     t = MOI.get(model, MOI.ConstraintPrimal(), c.gmindex)[1]
     x = MOI.get(model, MOI.ConstraintPrimal(), c.sdindex)[1:length(c.Δ)]
     [t; x]
 end
-MOI.canget(model::MOI.ModelLike, ::MOI.ConstraintDual, ::Type{<:RootDetBridge}) = false
 
 # Constraints
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RootDetBridge}) = false

--- a/src/Bridges/geomeanbridge.jl
+++ b/src/Bridges/geomeanbridge.jl
@@ -139,11 +139,6 @@ function MOI.delete!(model::MOI.ModelLike, c::GeoMeanBridge)
 end
 
 # Attributes, Bridge acting as a constraint
-function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintPrimal,
-                    ::Type{GeoMeanBridge{T, F, G}}) where {T, F, G}
-    MOI.canget(model, a, CI{F, MOI.LessThan{T}}) &&
-    MOI.canget(model, a, CI{G, MOI.RotatedSecondOrderCone})
-end
 function _getconstrattr(model, a, c::GeoMeanBridge{T}) where T
     output = Vector{T}(undef, c.d)
     output[1] = MOI.get(model, a, c.tubc)
@@ -163,7 +158,6 @@ function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintPrimal, c::GeoMeanBridge
     output[1] += MOI.get(model, MOI.VariablePrimal(), c.xij[1]) / sqrt(N)
     output
 end
-MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual, ::Type{<:GeoMeanBridge}) = false
 #function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintDual, c::GeoMeanBridge)
 #    output = _getconstrattr(model, a, c)
 #end

--- a/src/Bridges/intervalbridge.jl
+++ b/src/Bridges/intervalbridge.jl
@@ -36,16 +36,9 @@ function MOI.delete!(model::MOI.ModelLike, c::SplitIntervalBridge)
 end
 
 # Attributes, Bridge acting as a constraint
-function MOI.canget(model::MOI.ModelLike, attr::MOI.ConstraintPrimal, ::Type{SplitIntervalBridge{T, F}}) where {T, F}
-    return MOI.canget(model, attr, CI{F, MOI.GreaterThan{T}})
-end
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal, c::SplitIntervalBridge)
     # lower and upper should give the same value
     return MOI.get(model, attr, c.lower)
-end
-function MOI.canget(model::MOI.ModelLike, attr::MOI.ConstraintDual, ::Type{SplitIntervalBridge{T, F}}) where {T, F}
-    return MOI.canget(model, attr, CI{F, MOI.GreaterThan{T}}) &&
-           MOI.canget(model, attr, CI{F, MOI.LessThan{T}})
 end
 function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintDual, c::SplitIntervalBridge)
     # Should be nonnegative

--- a/src/Bridges/rsocbridge.jl
+++ b/src/Bridges/rsocbridge.jl
@@ -79,15 +79,7 @@ function _get(model, attr::Union{MOI.ConstraintPrimal, MOI.ConstraintDual}, c::R
     [x[1]/s2+x[2]/s2; x[1]/s2-x[2]/s2; x[3:end]]
 end
 # Need to define both `get` methods and redirect to `_get` to avoid ambiguity in dispatch
-function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintPrimal,
-                    ::Type{RSOCBridge{T, F}}) where {T, F}
-    MOI.canget(model, a, CI{F, MOI.SecondOrderCone})
-end
 MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal, c::RSOCBridge) = _get(model, attr, c)
-function MOI.canget(model::MOI.ModelLike, a::MOI.ConstraintDual,
-                    ::Type{RSOCBridge{T, F}}) where {T, F}
-    MOI.canget(model, a, CI{F, MOI.SecondOrderCone})
-end
 MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintDual, c::RSOCBridge) = _get(model, attr, c)
 
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCBridge}) = false

--- a/src/Bridges/soctopsdbridge.jl
+++ b/src/Bridges/soctopsdbridge.jl
@@ -67,9 +67,6 @@ _SOCtoPSDCaff(f::MOI.VectorAffineFunction, ::Type) = _SOCtoPSDCaff(f, MOIU.eachs
 MOI.supportsconstraint(::Type{SOCtoPSDCBridge{T}}, ::Type{<:Union{MOI.VectorOfVariables, MOI.VectorAffineFunction{T}}}, ::Type{MOI.SecondOrderCone}) where T = true
 addedconstrainttypes(::Type{SOCtoPSDCBridge{T}}, ::Type{<:Union{MOI.VectorOfVariables, MOI.VectorAffineFunction{T}}}, ::Type{MOI.SecondOrderCone}) where T = [(MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle)]
 
-function MOI.canget(instance::MOI.AbstractOptimizer, a::Union{MOI.ConstraintPrimal, MOI.ConstraintDual}, ::Type{SOCtoPSDCBridge{T}}) where T
-    MOI.canget(instance, a, CI{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle})
-end
 function MOI.get(instance::MOI.AbstractOptimizer, a::MOI.ConstraintPrimal, c::SOCtoPSDCBridge)
     MOI.get(instance, a, c.cr)[trimap.(1:c.dim, 1)]
 end
@@ -134,9 +131,6 @@ function _RSOCtoPSDCaff(f::MOI.VectorAffineFunction, ::Type{T}) where T
     _SOCtoPSDCaff(f_scalars[[1; 3:n]], g)
 end
 
-function MOI.canget(instance::MOI.AbstractOptimizer, a::Union{MOI.ConstraintPrimal, MOI.ConstraintDual}, ::Type{RSOCtoPSDCBridge{T}}) where T
-    MOI.canget(instance, a, CI{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle})
-end
 function MOI.get(instance::MOI.AbstractOptimizer, a::MOI.ConstraintPrimal, c::RSOCtoPSDCBridge)
     x = MOI.get(instance, MOI.ConstraintPrimal(), c.cr)[[trimap(1, 1); trimap(2, 2); trimap.(2:c.dim, 1)]]
     x[2] /= 2 # It is (2u*I)[1,1] so it needs to be divided by 2 to get u

--- a/src/Bridges/squarepsdbridge.jl
+++ b/src/Bridges/squarepsdbridge.jl
@@ -149,10 +149,6 @@ function MOI.delete!(model::MOI.ModelLike, bridge::SquarePSDBridge)
 end
 
 # Attributes, Bridge acting as a constraint
-function MOI.canget(model::MOI.ModelLike, attr::MOI.ConstraintPrimal,
-                    ::Type{<:SquarePSDBridge{T, F}}) where {T, F}
-    return MOI.canget(model, attr, CI{F, MOI.PositiveSemidefiniteConeTriangle})
-end
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal,
                  bridge::SquarePSDBridge{T}) where T
     tri = MOI.get(model, attr, bridge.psd)
@@ -166,11 +162,6 @@ function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal,
         end
     end
     return sqr
-end
-function MOI.canget(model::MOI.ModelLike, attr::MOI.ConstraintDual,
-                    ::Type{SquarePSDBridge{T, F, G}}) where {T, F, G}
-    return MOI.canget(model, attr, CI{F, MOI.PositiveSemidefiniteConeTriangle}) &&
-           MOI.canget(model, attr, CI{G, MOI.EqualTo{T}})
 end
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintDual,
                  bridge::SquarePSDBridge)

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -168,17 +168,12 @@ function basic_constraint_test_helper(model::MOI.ModelLike, config::TestConfig, 
 
     @test MOI.supportsconstraint(model, F, S)
 
-    @testset "NumberOfConstraints" begin
-        @test MOI.canget(model, MOI.NumberOfConstraints{F,S}())
-    end
-
     @testset "addconstraint!" begin
         @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 0
         c = MOI.addconstraint!(model, constraint_function, set)
         @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
 
         @testset "ConstraintName" begin
-            @test MOI.canget(model, MOI.ConstraintName(), typeof(c))
             @test MOI.get(model, MOI.ConstraintName(), c) == ""
             @test MOI.supports(model, MOI.ConstraintName(), typeof(c))
             MOI.set!(model, MOI.ConstraintName(), c, "c")
@@ -187,20 +182,17 @@ function basic_constraint_test_helper(model::MOI.ModelLike, config::TestConfig, 
 
         if get_constraint_function
             @testset "ConstraintFunction" begin
-                @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
                 @test MOI.get(model, MOI.ConstraintFunction(), c) ≈ constraint_function
             end
         end
         if get_constraint_set
             @testset "ConstraintSet" begin
-                @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
                 @test MOI.get(model, MOI.ConstraintSet(), c) == set
             end
         end
     end
 
     @testset "ListOfConstraintIndices" begin
-        @test MOI.canget(model, MOI.ListOfConstraintIndices{F,S}())
         c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         @test length(c_indices) == MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
     end

--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -11,16 +11,14 @@ function getconstraint(model::MOI.ModelLike, config::TestConfig)
         c1: x >= 1.0
         c2: x <= 2.0
     """)
-    @test !MOI.canget(model, MOI.ConstraintIndex, "c3")
-    @test MOI.canget(model, MOI.ConstraintIndex, "c1")
-    @test MOI.canget(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}, "c1")
-    @test !MOI.canget(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}, "c1")
-    @test MOI.canget(model, MOI.ConstraintIndex, "c2")
-    @test !MOI.canget(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}, "c2")
-    @test MOI.canget(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}, "c2")
+    @test MOI.get(model, MOI.ConstraintIndex, "c3") === nothing
+    @test MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}, "c1") === nothing
+    @test MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}, "c2") === nothing
     c1 = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}, "c1")
+    @test MOI.get(model, MOI.ConstraintIndex, "c1") == c1
     @test MOI.isvalid(model, c1)
     c2 = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.LessThan{Float64}}, "c2")
+    @test MOI.get(model, MOI.ConstraintIndex, "c2") == c2
     @test MOI.isvalid(model, c2)
 end
 unittests["getconstraint"]    = getconstraint

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -24,7 +24,6 @@ function solve_set_singlevariable_lessthan(model::MOI.ModelLike, config::TestCon
     )
     @test MOI.supports(model, MOI.ConstraintSet(), typeof(c))
     MOI.set!(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
-    @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
     @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
     test_model_solution(model, config;
         objective_value   = 2.0,
@@ -94,7 +93,6 @@ function solve_set_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConfi
     )
     @test MOI.supports(model, MOI.ConstraintSet(), typeof(c))
     MOI.set!(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
-    @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
     @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
     test_model_solution(model, config;
         objective_value   = 2.0,
@@ -163,7 +161,6 @@ function solve_func_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConf
     MOI.set!(model, MOI.ConstraintFunction(), c,
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(2.0, x)], 0.0)
     )
-    @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
     foo = MOI.get(model, MOI.ConstraintFunction(), c)
     @test foo ≈ MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(2.0, x)], 0.0)
     test_model_solution(model, config;

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -24,7 +24,6 @@ function max_sense(model::MOI.ModelLike, config::TestConfig)
     @test MOI.isempty(model)
     @test MOI.supports(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.canget(model, MOI.ObjectiveSense())
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 end
 unittests["max_sense"] = max_sense
@@ -39,7 +38,6 @@ function min_sense(model::MOI.ModelLike, config::TestConfig)
     @test MOI.isempty(model)
     @test MOI.supports(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MinSense)
-    @test MOI.canget(model, MOI.ObjectiveSense())
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 end
 unittests["min_sense"] = min_sense
@@ -54,7 +52,6 @@ function feasibility_sense(model::MOI.ModelLike, config::TestConfig)
     @test MOI.isempty(model)
     @test MOI.supports(model, MOI.ObjectiveSense())
     MOI.set!(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
-    @test MOI.canget(model, MOI.ObjectiveSense())
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FeasibilitySense
 end
 unittests["feasibility_sense"] = feasibility_sense

--- a/src/Test/UnitTests/unit_tests.jl
+++ b/src/Test/UnitTests/unit_tests.jl
@@ -59,34 +59,26 @@ function test_model_solution(model, config;
     config.solve || return
     atol, rtol = config.atol, config.rtol
     MOI.optimize!(model)
-    @test MOI.canget(model, MOI.TerminationStatus())
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
     if objective_value != nothing
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ objective_value atol=atol rtol=rtol
     end
     if variable_primal != nothing
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         for (index, solution_value) in variable_primal
-            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
             @test MOI.get(model, MOI.VariablePrimal(), index) ≈ solution_value atol=atol rtol=rtol
         end
     end
     if constraint_primal != nothing
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         for (index, solution_value) in constraint_primal
-            @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(index))
             @test MOI.get(model, MOI.ConstraintPrimal(), index) ≈ solution_value atol=atol rtol=rtol
         end
     end
     if config.duals
         if constraint_dual != nothing
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
             for (index, solution_value) in constraint_dual
-                @test MOI.canget(model, MOI.ConstraintDual(), typeof(index))
                 @test MOI.get(model, MOI.ConstraintDual(), index) ≈ solution_value atol=atol rtol=rtol
             end
         end

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -102,8 +102,7 @@ function getvariable(model::MOI.ModelLike, config::TestConfig)
         c1: x >= 1.0
         c2: x <= 2.0
     """)
-    @test MOI.canget(model, MOI.VariableIndex, "x")
-    @test !MOI.canget(model, MOI.VariableIndex, "y")
+    @test MOI.get(model, MOI.VariableIndex, "y") === nothing
     x = MOI.get(model, MOI.VariableIndex, "x")
     @test MOI.isvalid(model, x)
 end

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -47,31 +47,22 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc))
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [1, 0, 2] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ zeros(2) atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc))
             @test MOI.get(model, MOI.ConstraintDual(), vc) ≈ [0, 2, 0] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ [-3, -1] atol=atol rtol=rtol
         end
     end
@@ -150,42 +141,29 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ -4 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -3 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 16 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), s) ≈ 0 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ zeros(3) atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc))
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [-3] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vz))
         @test MOI.get(model, MOI.ConstraintPrimal(), vz) ≈ [16] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vs))
         @test MOI.get(model, MOI.ConstraintPrimal(), vs) ≈ [0] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc))
             @test MOI.get(model, MOI.ConstraintDual(), vc) ≈ [0] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vz))
             @test MOI.get(model, MOI.ConstraintDual(), vz) ≈ [0] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vs))
             @test MOI.get(model, MOI.ConstraintDual(), vs) ≈ [7] atol=atol rtol=rtol
         end
     end
@@ -225,17 +203,16 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         if config.infeas_certificates
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
         else
             @test MOI.get(model, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
         end
-        if MOI.canget(model, MOI.PrimalStatus())
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+        if config.infeas_certificates || MOI.get(model, MOI.ResultCount()) > 0
+            @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
+                                                         MOI.InfeasiblePoint)
         end
         if config.duals && config.infeas_certificates
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
         end
         # TODO test dual feasibility and objective sign
@@ -273,18 +250,16 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         if config.infeas_certificates
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
         else
             @test MOI.get(model, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
         end
-
-        if MOI.canget(model, MOI.PrimalStatus())
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasiblePoint
+        if config.infeas_certificates || MOI.get(model, MOI.ResultCount()) > 0
+            @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
+                                                         MOI.InfeasiblePoint)
         end
         if config.duals && config.infeas_certificates
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
         end
         # TODO test dual feasibility and objective sign
@@ -343,35 +318,24 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1/√2 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 1/√2 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ceq))
         @test MOI.get(model, MOI.ConstraintPrimal(), ceq) ≈ [0.] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(csoc))
         @test MOI.get(model, MOI.ConstraintPrimal(), csoc) ≈ [1., 1/√2, 1/√2] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ceq))
             @test MOI.get(model, MOI.ConstraintDual(), ceq) ≈ [-√2] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(csoc))
             @test MOI.get(model, MOI.ConstraintDual(), csoc) ≈ [√2, -1.0, -1.0] atol=atol rtol=rtol
         end
     end
@@ -426,36 +390,26 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1/√2 atol=atol rtol=rtol
 
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ -1/√2 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1/√2 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cnon))
         @test MOI.get(model, MOI.ConstraintPrimal(), cnon) ≈ [0.0] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ceq))
         @test MOI.get(model, MOI.ConstraintPrimal(), ceq) ≈ [0.0] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(csoc))
         @test MOI.get(model, MOI.ConstraintPrimal(), csoc) ≈ [1., -1/√2, 1/√2] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cnon))
             @test MOI.get(model, MOI.ConstraintDual(), cnon) ≈ [nonneg ? 1.0 : -1.0] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ceq))
             @test MOI.get(model, MOI.ConstraintDual(), ceq) ≈ [√2] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(csoc))
             @test MOI.get(model, MOI.ConstraintDual(), csoc) ≈ [√2, 1.0, -1.0] atol=atol rtol=rtol
         end
     end
@@ -500,14 +454,11 @@ function soc3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        if MOI.canget(model, MOI.PrimalStatus())
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasiblePoint
-        end
+        @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
+                                                     MOI.InfeasiblePoint)
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
         end
 
@@ -552,31 +503,22 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -√5 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [1.0, 2/√5, 1/√5, 2/√5, 1/√5] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ zeros(3) atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ [1.0, 2/√5, 1/√5] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ [-√5, -2.0, -1.0] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ [√5, -2.0, -1.0] atol=atol rtol=rtol
         end
     end
@@ -640,50 +582,36 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol=atol rtol=rtol
 
         if abvars
-            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
             @test MOI.get(model, MOI.VariablePrimal(), a) ≈ 0.5 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
             @test MOI.get(model, MOI.VariablePrimal(), b) ≈ 1.0 atol=atol rtol=rtol
         end
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [1/√2, 1/√2] atol=atol rtol=rtol
 
         if abvars
-            @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc1))
             @test MOI.get(model, MOI.ConstraintPrimal(), vc1) ≈ 0.5
-            @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc2))
             @test MOI.get(model, MOI.ConstraintPrimal(), vc2) ≈ 1.0
         end
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(rsoc))
         @test MOI.get(model, MOI.ConstraintPrimal(), rsoc) ≈ [0.5, 1.0, 1/√2, 1/√2] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus(1))
             @test MOI.get(model, MOI.DualStatus(1)) == MOI.FeasiblePoint
 
             if abvars
-                @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
                 @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ -√2 atol=atol rtol=rtol
-                @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
                 @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ -1/√2 atol=atol rtol=rtol
             end
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(rsoc))
             @test MOI.get(model, MOI.ConstraintDual(), rsoc) ≈ [√2, 1/√2, -1.0, -1.0] atol=atol rtol=rtol
         end
     end
@@ -740,21 +668,16 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
 
         if MOI.get(model, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleOrUnbounded] && config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) in [MOI.InfeasibilityCertificate, MOI.NearlyInfeasibilityCertificate]
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
             y1 = MOI.get(model, MOI.ConstraintDual(), vc1)
             @test y1 < -atol # Should be strictly negative
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
             y2 = MOI.get(model, MOI.ConstraintDual(), vc2)
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc3))
             y3 = MOI.get(model, MOI.ConstraintDual(), vc3)
             @test y3 > atol # Should be strictly positive
 
@@ -821,56 +744,37 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √ub atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [1.0; zeros(n-1)] atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), u) ≈ ub atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ √ub atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ ones(2) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cx))
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ [1.0; zeros(n-1)] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cu1))
         @test MOI.get(model, MOI.ConstraintPrimal(), cu1) ≈ ub atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cu2))
         @test MOI.get(model, MOI.ConstraintPrimal(), cu2) ≈ ub atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ct1))
         @test MOI.get(model, MOI.ConstraintPrimal(), ct1) ≈ 1.0 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ct2))
         @test MOI.get(model, MOI.ConstraintPrimal(), ct2) ≈ 1.0 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ [1/√2; 1/√2; 1.0; zeros(n-1)] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ [1/√2, ub/√2, √ub] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cx))
             @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ zeros(n) atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cu1))
             @test MOI.get(model, MOI.ConstraintDual(), cu1) ≈ 0.0 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cu2))
             @test MOI.get(model, MOI.ConstraintDual(), cu2) ≈ -1/(2*√ub) atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ct1))
             @test MOI.get(model, MOI.ConstraintDual(), ct1) ≈ -√ub/4 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ct2))
             @test MOI.get(model, MOI.ConstraintDual(), ct2) ≈ -√ub/4 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ [√ub/(2*√2); √ub/(2*√2); -√ub/2; zeros(n-1)] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ [√ub/√2, 1/√(2*ub), -1.0] atol=atol rtol=rtol
         end
     end
@@ -932,32 +836,23 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ ones(n) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(gmc))
         @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ ones(n+1) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ n atol=atol rtol=rtol
 
     #    if config.duals
-    #        @test MOI.canget(model, MOI.DualStatus())
     #        @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
     #
-    #        @test MOI.canget(model, MOI.ConstraintDual(), typeof(gmc))
     #        @show MOI.get(model, MOI.ConstraintDual(), gmc)
     #
-    #        @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
     #        @show MOI.get(model, MOI.ConstraintDual(), c)
     #    end
     end
@@ -1011,39 +906,28 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 + 2exp(1/2) atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1., 2., 2exp(1/2)] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc))
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [1., 2., 2exp(1/2)] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cx))
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ 1 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cy))
         @test MOI.get(model, MOI.ConstraintPrimal(), cy) ≈ 2 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc))
             u, v, w = MOI.get(model, MOI.ConstraintDual(), vc)
             @test u ≈ -exp(1/2) atol=atol rtol=rtol
             @test v ≈ -exp(1/2)/2 atol=atol rtol=rtol
             @test w ≈ 1 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cx))
             @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ 1 + exp(1/2) atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cy))
             @test MOI.get(model, MOI.ConstraintDual(), cy) ≈ 1 + exp(1/2)/2 atol=atol rtol=rtol
         end
     end
@@ -1085,53 +969,34 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ exp(-0.3) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0., -0.3, 0., exp(-0.3), exp(-0.3), exp(-0.3), 0., 1.0, 0.] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ec1))
         @test MOI.get(model, MOI.ConstraintPrimal(), ec1) ≈ [-0.3, 1.0, exp(-0.3)] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ec2))
         @test MOI.get(model, MOI.ConstraintPrimal(), ec2) ≈ [-0.3, 1.0, exp(-0.3)] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ 0. atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ zeros(3) atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c3))
         @test MOI.get(model, MOI.ConstraintPrimal(), c3) ≈ [0., 0.6, 0.] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c4))
         @test MOI.get(model, MOI.ConstraintPrimal(), c4) ≈ 1. atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c5))
         @test MOI.get(model, MOI.ConstraintPrimal(), c5) ≈ 0. atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ec1))
             @test MOI.get(model, MOI.ConstraintDual(), ec1) ≈ [-exp(-0.3)/2, -1.3exp(-0.3)/2, 0.5] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ec2))
             @test MOI.get(model, MOI.ConstraintDual(), ec2) ≈ [-exp(-0.3)/2, -1.3exp(-0.3)/2, 0.5] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ -1 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c5))
             d5 = MOI.get(model, MOI.ConstraintDual(), c5) # degree of freedom
             d23 = (exp(-0.3)*0.3 - d5) / 0.6 # dual constraint corresponding to v[7]
             @test d23 >= -atol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ [d23, exp(-0.3), exp(-0.3)/2] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c3))
             @test MOI.get(model, MOI.ConstraintDual(), c3) ≈ [d23, 0.0, exp(-0.3)/2] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c4))
             @test MOI.get(model, MOI.ConstraintDual(), c4) ≈ -exp(-0.3)*0.3 atol=atol rtol=rtol
         end
     end
@@ -1166,37 +1031,25 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ log(5) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ log(5) atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 5. atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(xc))
         @test MOI.get(model, MOI.ConstraintPrimal(), xc) ≈ 2log(5) atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(yc))
         @test MOI.get(model, MOI.ConstraintPrimal(), yc) ≈ 5 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(ec))
         @test MOI.get(model, MOI.ConstraintPrimal(), ec) ≈ [log(5), 1., 5.] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(xc))
             @test MOI.get(model, MOI.ConstraintDual(), xc) ≈ 0. atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(yc))
             @test MOI.get(model, MOI.ConstraintDual(), yc) ≈ -1/5 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(ec))
             @test MOI.get(model, MOI.ConstraintDual(), ec) ≈ [-1., log(5)-1, 1/5] atol=atol rtol=rtol
         end
     end
@@ -1254,31 +1107,23 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
         Xv = square ? ones(4) : ones(3)
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), X) ≈ Xv atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cX))
         @test MOI.get(model, MOI.ConstraintPrimal(), cX) ≈ Xv atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 2 atol=atol rtol=rtol
 
             cXv = square ? [1, -2, 0, 1] : [1, -1, 1]
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cX))
             @test MOI.get(model, MOI.ConstraintDual(), cX) ≈ cXv atol=atol rtol=rtol
         end
     end
@@ -1404,22 +1249,17 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ obj atol=atol rtol=rtol
 
         Xv = square ? [α^2, α*β, α^2, α*β, β^2, α*β, α^2, α*β, α^2] : [α^2, α*β, β^2, α^2, α*β, α^2]
         xv = [√2*x2, x2, x2]
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), X) ≈ Xv atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ xv atol=atol rtol=rtol
 
@@ -1433,13 +1273,9 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
             cX1 = 1-y2
             cX2 = -y2
             cXv = square ? [cX0, cX1, cX2, cX1, cX0, cX1, cX2, cX1, cX0] : [cX0, cX1, cX0, cX2, cX1, cX0]
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cX))
             @test MOI.get(model, MOI.ConstraintDual(), cX) ≈ cXv atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cx))
             @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ [1-y1, -y2, -y2] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ y1 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ y2 atol=atol rtol=rtol
         end
     end
@@ -1492,34 +1328,23 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [2η/3, 0, η/3, 0, 0, 0, η*δ*(1 - 1/√3)/2] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ [-2η/3, 0, -η/3, 0, 0, 0] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c3))
         @test MOI.get(model, MOI.ConstraintPrimal(), c3) ≈ [η*δ*(1/√3+1/3)/2, -η*δ/(3*√2), η*δ*(1/√3-1/3)/2] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c4))
         @test MOI.get(model, MOI.ConstraintPrimal(), c4) ≈ 0.0 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ δ*(1-1/√3)/2 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c2))
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ [0, -α/√3+δ/(2*√6)*(2*√2-1), 0, -3δ*(1-1/√3)/8, -3δ*(1-1/√3)/8, -δ*(3 - 2*√3 + 1/√3)/8] atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c3))
             @test MOI.get(model, MOI.ConstraintDual(), c3) ≈ [(1-1/√3)/2, 1/√6, (1+1/√3)/2] atol=atol rtol=rtol
             # Dual of c4 could be anything
         end
@@ -1600,20 +1425,15 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         expectedobjval = logdet ? 0. : 1.
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ expectedobjval atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ expectedobjval atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         Qv = MOI.get(model, MOI.VariablePrimal(), Q)
         @test Qv[1] ≈ 1. atol=atol rtol=rtol
         @test Qv[2] ≈ 0. atol=atol rtol=rtol
@@ -1622,12 +1442,10 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
         end
         @test Qv[end] ≈ 1. atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cX))
         tQv = MOI.get(model, MOI.ConstraintPrimal(), cX)
         @test tQv[1] ≈ expectedobjval atol=atol rtol=rtol
         @test tQv[2:end] ≈ Qv atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ [0., 0.] atol=atol rtol=rtol
     end
 end

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -205,15 +205,16 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
 
         if config.infeas_certificates
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.ResultCount()) > 0
         else
             @test MOI.get(model, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
         end
-        if config.infeas_certificates || MOI.get(model, MOI.ResultCount()) > 0
+        if MOI.get(model, MOI.ResultCount()) > 0
             @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
                                                          MOI.InfeasiblePoint)
-        end
-        if config.duals && config.infeas_certificates
-            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            if config.duals && config.infeas_certificates
+                @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            end
         end
         # TODO test dual feasibility and objective sign
     end
@@ -252,15 +253,16 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
 
         if config.infeas_certificates
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.ResultCount()) > 0
         else
             @test MOI.get(model, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
         end
-        if config.infeas_certificates || MOI.get(model, MOI.ResultCount()) > 0
+        if MOI.get(model, MOI.ResultCount()) > 0
             @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
                                                          MOI.InfeasiblePoint)
-        end
-        if config.duals && config.infeas_certificates
-            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            if config.duals && config.infeas_certificates
+                @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            end
         end
         # TODO test dual feasibility and objective sign
     end

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -849,14 +849,6 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
         @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ ones(n+1) atol=atol rtol=rtol
 
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ n atol=atol rtol=rtol
-
-    #    if config.duals
-    #        @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-    #
-    #        @show MOI.get(model, MOI.ConstraintDual(), gmc)
-    #
-    #        @show MOI.get(model, MOI.ConstraintDual(), c)
-    #    end
     end
 end
 

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -44,26 +44,19 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 
     if config.query
-        @test MOI.canget(model, MOI.ListOfVariableIndices())
         vrs = MOI.get(model, MOI.ListOfVariableIndices())
         @test vrs == v || vrs == reverse(v)
 
-        @test !MOI.canget(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
-        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
 
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
 
-        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
         s = MOI.get(model, MOI.ConstraintSet(), c)
         @test s == MOI.LessThan(1.0)
 
-        @test MOI.canget(model, MOI.ConstraintSet(), typeof(vc1))
         s = MOI.get(model, MOI.ConstraintSet(), vc1)
         @test s == MOI.GreaterThan(0.0)
 
-        @test MOI.canget(model, MOI.ConstraintSet(), typeof(vc2))
         s = MOI.get(model, MOI.ConstraintSet(), vc2)
         @test s == MOI.GreaterThan(0.0)
     end
@@ -71,31 +64,22 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
             @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
         end
     end
@@ -107,7 +91,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.query
-        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     end
 
@@ -116,27 +99,19 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
             @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
         end
     end
@@ -152,10 +127,8 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
     if config.query
         # Test that the modification of v has not affected the model
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
         vars = map(t -> t.variable_index, MOI.get(model, MOI.ConstraintFunction(), c).terms)
         @test vars == [v[1], v[2]] || vars == [v[2], v[1]]
-        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[1])], 0.0) ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     end
 
@@ -181,35 +154,24 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus(1))
         @test MOI.get(model, MOI.PrimalStatus(1)) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 0, 1] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -2 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 1 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
             @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 2 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc3))
             @test MOI.get(model, MOI.ConstraintDual(), vc3) ≈ 0 atol=atol rtol=rtol
         end
     end
@@ -225,19 +187,14 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [-1, 0, 2] atol=atol rtol=rtol
     end
 
@@ -256,19 +213,14 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0, 0] atol=atol rtol=rtol
     end
 
@@ -286,19 +238,14 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2, 0, 0] atol=atol rtol=rtol
     end
 
@@ -312,26 +259,20 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     MOI.set!(model, MOI.ObjectiveSense(), MOI.MaxSense)
 
     if config.query
-        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     end
 
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 2, 0] atol=atol rtol=rtol
     end
 
@@ -353,55 +294,39 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 1, 0] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 0 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc1))
         @test MOI.get(model, MOI.ConstraintPrimal(), vc1) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc2))
         @test MOI.get(model, MOI.ConstraintPrimal(), vc2) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(vc3))
         @test MOI.get(model, MOI.ConstraintPrimal(), vc3) ≈ 0 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus(1))
             @test MOI.get(model, MOI.DualStatus(1)) == MOI.FeasiblePoint
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1.5 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ 0.5 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
             @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 0 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc3))
             @test MOI.get(model, MOI.ConstraintDual(), vc3) ≈ 1.5 atol=atol rtol=rtol
         end
     end
 
     if config.query
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ cf2
     end
 
@@ -418,10 +343,8 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0, 0.0], [v[2], z]), 0.0)
 
-        @test MOI.canget(model, MOI.ListOfVariableIndices())
         vrs = MOI.get(model, MOI.ListOfVariableIndices())
         @test vrs == [v[2], z] || vrs == [z, v[2]]
-        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()) ≈ MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 0.0], [v[2], z]), 0.0)
     end
 end
@@ -464,34 +387,24 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc1))
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(vc2))
             @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 1 atol=atol rtol=rtol
         end
     end
@@ -532,19 +445,14 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 3 atol=atol rtol=rtol
     end
 
@@ -572,19 +480,14 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0 atol=atol rtol=rtol
     end
 end
@@ -711,16 +614,12 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 8/3 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [4/3, 4/3] atol=atol rtol=rtol
     end
 
@@ -747,16 +646,12 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [2.0, 0.0] atol=atol rtol=rtol
     end
 
@@ -772,16 +667,12 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [4.0, 0.0] atol=atol rtol=rtol
     end
 
@@ -797,16 +688,12 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 2.0 atol=atol rtol=rtol
     end
 end
@@ -987,13 +874,11 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.ResultCount())
         if config.infeas_certificates
             # solver returned an infeasibility ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
             @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             cd = MOI.get(model, MOI.ConstraintDual(), c)
             @test cd < -atol
             # TODO: farkas dual on bounds - see #127
@@ -1006,7 +891,6 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
-            @test MOI.canget(model, MOI.PrimalStatus(1)) == false
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
                 MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
@@ -1041,7 +925,6 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.ResultCount())
         if config.infeas_certificates
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
@@ -1050,7 +933,6 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
-            @test MOI.canget(model, MOI.PrimalStatus(1)) == false
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
                 MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
@@ -1085,20 +967,17 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.ResultCount())
         if config.infeas_certificates
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
-            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
             ray = MOI.get(model, MOI.VariablePrimal(), [x,y])
             @test ray[1] ≈ ray[2] atol=atol rtol=rtol
 
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
-            @test MOI.canget(model, MOI.PrimalStatus(1)) == false
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
                 MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
@@ -1205,14 +1084,11 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
         end
     end
@@ -1226,14 +1102,11 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 5 atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
         end
     end
@@ -1242,7 +1115,6 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     MOI.set!(model, MOI.ConstraintSet(), c, MOI.Interval(2.0, 12.0))
 
     if config.query
-        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
         @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.Interval(2.0, 12.0)
     end
 
@@ -1252,7 +1124,6 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
     end
 
@@ -1265,7 +1136,6 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 12 atol=atol rtol=rtol
     end
 end
@@ -1348,13 +1218,11 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.ResultCount())
         if config.infeas_certificates
             # solver returned an infeasibility ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
             @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
             cd1 = MOI.get(model, MOI.ConstraintDual(), c1)
             cd2 = MOI.get(model, MOI.ConstraintDual(), c2)
             bndxd = MOI.get(model, MOI.ConstraintDual(), bndx)
@@ -1367,7 +1235,6 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
-            @test MOI.canget(model, MOI.PrimalStatus(1)) == false
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
                 MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
@@ -1397,16 +1264,12 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
 
     if config.solve
         MOI.optimize!(model)
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) > 0
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         xsol = MOI.get(model, MOI.VariablePrimal(), x)
         ysol = MOI.get(model, MOI.VariablePrimal(), y)
 
@@ -1414,17 +1277,13 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
         @test c1sol >= 1 || isapprox(c1sol, 1.0, atol=atol, rtol=rtol)
         @test xsol - ysol ≈ 0 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
         c1primval = MOI.get(model, MOI.ConstraintPrimal(), c1)
         @test c1primval >= 1 || isapprox(c1sol, 1.0, atol=atol, rtol=rtol)
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 0 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c1))
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ 0 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ 0 atol=atol rtol=rtol
         end
@@ -1462,45 +1321,30 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 8 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1/2 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(clbx))
         @test MOI.get(model, MOI.ConstraintPrimal(), clbx) ≈ 0 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(clby))
         @test MOI.get(model, MOI.ConstraintPrimal(), clby) ≈ 1/2 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(clbz))
         @test MOI.get(model, MOI.ConstraintPrimal(), clbz) ≈ 1 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(cubz))
         @test MOI.get(model, MOI.ConstraintPrimal(), cubz) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(clbx))
             @test MOI.get(model, MOI.ConstraintDual(), clbx) ≈ 2 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(clby))
             @test MOI.get(model, MOI.ConstraintDual(), clby) ≈ 0 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(clbz))
             @test MOI.get(model, MOI.ConstraintDual(), clbz) ≈ 0 atol=atol rtol=rtol
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(cubz))
             @test MOI.get(model, MOI.ConstraintDual(), cubz) ≈ -2 atol=atol rtol=rtol
         end
     end
@@ -1510,31 +1354,22 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 6 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(clby))
         @test MOI.get(model, MOI.ConstraintPrimal(), clby) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
-            @test MOI.canget(model, MOI.ConstraintDual(), typeof(clbx))
             @test MOI.get(model, MOI.ConstraintDual(), clby) ≈ 0 atol=atol rtol=rtol
         end
     end
@@ -1574,16 +1409,12 @@ function linear15test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x[1]) ≈ 0 atol=atol rtol=rtol
     end
 end

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -256,6 +256,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
 
     # try delete quadratic constraint and go back to linear
 
+    # FIXME why is this commented ?
     # MOI.delete!(model, c2)
     #
     # MOI.optimize!(model)

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -31,29 +31,22 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 
     if config.query
-        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
         @test obj ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
 
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c1))
         @test cf1 ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
 
-        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c1))
         @test MOI.GreaterThan(4.0) == MOI.get(model, MOI.ConstraintSet(), c1)
     end
 
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 13/7 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4/7,3/7,6/7] atol=atol rtol=rtol
     end
 end
@@ -91,29 +84,22 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 
     if config.query
-        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
         @test obj ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
 
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c1))
         @test c1f ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
 
-        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c1))
         @test MOI.GreaterThan(4.0) == MOI.get(model, MOI.ConstraintSet(), c1)
     end
 
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 13/7 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4/7,3/7,6/7] atol=atol rtol=rtol
     end
 
@@ -124,23 +110,18 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 
     if config.query
-        @test MOI.canget(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
         @test obj2 ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     end
 
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -2*13/7 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4/7,3/7,6/7] atol=atol rtol=rtol
     end
 end
@@ -182,15 +163,11 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.875 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), [x,y]) ≈ [0.25, 0.75] atol=atol rtol=rtol
     end
 
@@ -206,15 +183,11 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), [x,y]) ≈ [1.0, 0.0] atol=atol rtol=rtol
     end
 end
@@ -263,28 +236,21 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 
     if config.query
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c2))
         @test c2f ≈ MOI.get(model, MOI.ConstraintFunction(), c2)
     end
 
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.25 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), [x,y]) ≈ [0.5,1.75] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c1))
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ [5/4, 9/4] atol=atol rtol=rtol
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 2 atol=atol rtol=rtol
     end
 
@@ -294,13 +260,10 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     #
     # MOI.optimize!(model)
     #
-    # @test MOI.canget(model, MOI.TerminationStatus())
     # @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
     #
-    # @test MOI.canget(model, MOI.PrimalStatus())
     # @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
     #
-    # @test MOI.canget(model, MOI.ObjectiveValue())
     # @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
 end
 
@@ -329,35 +292,27 @@ function qcp2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
 
     if config.query
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
     end
 
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
 
         # TODO - duals
-        # @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
         # @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 0.5/sqrt(2) atol=atol rtol=rtol
     end
 end
@@ -386,35 +341,27 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 
     if config.query
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
     end
 
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         if config.duals
-            @test MOI.canget(model, MOI.DualStatus())
             @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
         end
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -sqrt(2) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ sqrt(2) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
 
         # TODO - duals
-        # @test MOI.canget(model, MOI.ConstraintDual(), typeof(c))
         # @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -0.5/sqrt(2) atol=atol rtol=rtol
     end
 end
@@ -466,29 +413,22 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
 
     if config.query
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c1))
         @test c1f ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
 
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c2))
         @test c2f ≈ MOI.get(model, MOI.ConstraintFunction(), c2)
     end
 
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ sqrt(1/2) atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), [x,y,t]) ≈ [0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), [t,x,y,t]) ≈ [sqrt(1/2),0.5,0.5,sqrt(1/2)] atol=atol rtol=rtol
     end
 end

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -39,16 +39,12 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -2 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 0 atol=atol rtol=rtol

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -55,47 +55,27 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 19.4 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4,5,1] atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c))
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.ConstraintPrimal(), typeof(c2))
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 15 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.DualStatus()) == false
-
-        if MOI.canget(model, MOI.ObjectiveBound())
-            @test MOI.get(model, MOI.ObjectiveBound()) >= 19.4
-        end
-        if MOI.canget(model, MOI.RelativeGap())
-            @test MOI.get(model, MOI.RelativeGap()) >= 0.0
-        end
-        if MOI.canget(model, MOI.SolveTime())
-            @test MOI.get(model, MOI.SolveTime()) >= 0.0
-        end
-        if MOI.canget(model, MOI.SimplexIterations())
-            @test MOI.get(model, MOI.SimplexIterations()) >= 0
-        end
-        if MOI.canget(model, MOI.BarrierIterations())
-            @test MOI.get(model, MOI.BarrierIterations()) >= 0
-        end
-        if MOI.canget(model, MOI.NodeCount())
-            @test MOI.get(model, MOI.NodeCount()) >= 0
-        end
+        @test MOI.get(model, MOI.ObjectiveBound()) >= 19.4
+        # FIXME the following are currently not implemented in MockOptimizer
+#        @test MOI.get(model, MOI.RelativeGap()) >= 0.0
+#        @test MOI.get(model, MOI.SolveTime()) >= 0.0
+#        @test MOI.get(model, MOI.SimplexIterations()) >= 0
+#        @test MOI.get(model, MOI.BarrierIterations()) >= 0
+#        @test MOI.get(model, MOI.NodeCount()) >= 0
     end
 end
 
@@ -125,8 +105,6 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SOS1{Float64}}()) == 2
 
 
-        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c2))
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c2))
         #=
             To allow for permutations in the sets and variable vectors
             we're going to sort according to the weights
@@ -145,22 +123,15 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         if config.solve
             MOI.optimize!(model)
 
-            @test MOI.canget(model, MOI.TerminationStatus())
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.canget(model, MOI.ResultCount())
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.canget(model, MOI.PrimalStatus())
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-            @test MOI.canget(model, MOI.ObjectiveValue())
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,1,2] atol=atol rtol=rtol
-
-            @test MOI.canget(model, MOI.DualStatus()) == false
         end
 
         MOI.delete!(model, c1)
@@ -169,19 +140,14 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         if config.solve
             MOI.optimize!(model)
 
-            @test MOI.canget(model, MOI.TerminationStatus())
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.canget(model, MOI.ResultCount())
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.canget(model, MOI.PrimalStatus())
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-            @test MOI.canget(model, MOI.ObjectiveValue())
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1,1,2] atol=atol rtol=rtol
         end
     end
@@ -224,8 +190,6 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         sos2 = MOI.SOS2([5.0, 4.0, 7.0, 2.0, 1.0])
         c = MOI.addconstraint!(model, vv, sos2)
 
-        @test MOI.canget(model, MOI.ConstraintSet(), typeof(c))
-        @test MOI.canget(model, MOI.ConstraintFunction(), typeof(c))
         #=
             To allow for permutations in the sets and variable vectors
             we're going to sort according to the weights
@@ -244,22 +208,15 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         if config.solve
             MOI.optimize!(model)
 
-            @test MOI.canget(model, MOI.TerminationStatus())
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.canget(model, MOI.ResultCount())
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.canget(model, MOI.PrimalStatus())
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-            @test MOI.canget(model, MOI.ObjectiveValue())
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 15.0 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 3.0, 12.0] atol=atol rtol=rtol
-
-            @test MOI.canget(model, MOI.DualStatus()) == false
         end
 
         for cref in bin_constraints
@@ -269,22 +226,15 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         if config.solve
             MOI.optimize!(model)
 
-            @test MOI.canget(model, MOI.TerminationStatus())
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-            @test MOI.canget(model, MOI.ResultCount())
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.canget(model, MOI.PrimalStatus())
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-            @test MOI.canget(model, MOI.ObjectiveValue())
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 30.0 atol=atol rtol=rtol
 
-            @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0.0, 0.0, 2.0, 2.0, 0.0, 2.0, 0.0, 0.0, 6.0, 24.0] atol=atol rtol=rtol
-
-            @test MOI.canget(model, MOI.DualStatus()) == false
         end
     end
 end
@@ -327,25 +277,19 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
         # test for CPLEX.jl #76
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
     end
 end
@@ -389,16 +333,12 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 16 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0, 0, 1, 1] atol=atol rtol=rtol
     end
 end

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -6,15 +6,12 @@ function nametest(model::MOI.ModelLike)
     @testset "Name test" begin
         @test MOI.supports(model, MOI.Name())
         @test !(MOI.Name() in MOI.get(model, MOI.ListOfModelAttributesSet()))
-        @test MOI.canget(model, MOI.Name())
         @test MOI.get(model, MOI.Name()) == ""
         MOI.set!(model, MOI.Name(), "Name1")
         @test MOI.Name() in MOI.get(model, MOI.ListOfModelAttributesSet())
-        @test MOI.canget(model, MOI.Name())
         @test MOI.get(model, MOI.Name()) == "Name1"
         MOI.set!(model, MOI.Name(), "Name2")
         @test MOI.Name() in MOI.get(model, MOI.ListOfModelAttributesSet())
-        @test MOI.canget(model, MOI.Name())
         @test MOI.get(model, MOI.Name()) == "Name2"
 
         @test MOI.get(model, MOI.NumberOfVariables()) == 0
@@ -22,7 +19,6 @@ function nametest(model::MOI.ModelLike)
 
         @test MOI.supports(model, MOI.VariableName(), MOI.VariableIndex)
         v = MOI.addvariables!(model, 2)
-        @test MOI.canget(model, MOI.VariableName(), typeof(v[1]))
         @test MOI.get(model, MOI.VariableName(), v[1]) == ""
 
         MOI.set!(model, MOI.VariableName(), v[1], "")
@@ -32,12 +28,9 @@ function nametest(model::MOI.ModelLike)
         @test_throws Exception MOI.set!(model, MOI.VariableName(), v[2], "Var1")
         MOI.set!(model, MOI.VariableName(), v[2], "Var2")
 
-        @test MOI.canget(model, MOI.VariableIndex, "Var1")
-        @test !MOI.canget(model, MOI.VariableIndex, "Var3")
-
         @test MOI.get(model, MOI.VariableIndex, "Var1") == v[1]
         @test MOI.get(model, MOI.VariableIndex, "Var2") == v[2]
-        @test_throws KeyError MOI.get(model, MOI.VariableIndex, "Var3")
+        @test MOI.get(model, MOI.VariableIndex, "Var3") === nothing
 
         MOI.set!(model, MOI.VariableName(), v, ["VarX","Var2"])
         @test MOI.get(model, MOI.VariableName(), v) == ["VarX", "Var2"]
@@ -46,7 +39,6 @@ function nametest(model::MOI.ModelLike)
         c = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.LessThan(1.0))
         @test MOI.supportsconstraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
         c2 = MOI.addconstraint!(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0,1.0], v), 0.0), MOI.EqualTo(0.0))
-        @test MOI.canget(model, MOI.ConstraintName(), typeof(c))
         @test MOI.get(model, MOI.ConstraintName(), c) == ""
 
         @test MOI.supports(model, MOI.ConstraintName(), typeof(c))
@@ -61,38 +53,28 @@ function nametest(model::MOI.ModelLike)
         MOI.set!(model, MOI.ConstraintName(), [c], ["Con1"])
         @test MOI.get(model, MOI.ConstraintName(), [c]) == ["Con1"]
 
-        @test MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
-        @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con2")
-        @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}, "Con1")
-        @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}, "Con1")
-        @test MOI.canget(model, MOI.ConstraintIndex, "Con1")
-        @test !MOI.canget(model, MOI.ConstraintIndex, "Con2")
-
         @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1") == c
-        @test_throws KeyError MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con2")
+        @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}, "Con1") === nothing
+        @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}, "Con1") === nothing
+        @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con2") === nothing
         @test MOI.get(model, MOI.ConstraintIndex, "Con1") == c
-        @test_throws KeyError MOI.get(model, MOI.ConstraintIndex, "Con2")
+        @test MOI.get(model, MOI.ConstraintIndex, "Con2") === nothing
 
         MOI.set!(model, MOI.ConstraintName(), c2, "Con0")
-        @test MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
-        @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con0")
-        @test MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}, "Con0")
-        @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}, "Con1")
-        @test MOI.canget(model, MOI.ConstraintIndex, "Con0")
-        @test MOI.canget(model, MOI.ConstraintIndex, "Con1")
 
+        @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con0") === nothing
+        @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}, "Con1") === nothing
         @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1") == c
         @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}, "Con0") == c2
+        @test MOI.get(model, MOI.ConstraintIndex, "Con0") == c2
+        @test MOI.get(model, MOI.ConstraintIndex, "Con1") == c
 
         MOI.delete!(model, v[2])
-        @test !MOI.canget(model, MOI.VariableIndex, "Var2")
-        @test_throws KeyError MOI.get(model, MOI.VariableIndex, "Var2")
+        @test MOI.get(model, MOI.VariableIndex, "Var2") === nothing
 
         MOI.delete!(model, c)
-        @test !MOI.canget(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
-        @test !MOI.canget(model, MOI.ConstraintIndex, "Con1")
-        @test_throws KeyError MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1")
-        @test_throws KeyError MOI.get(model, MOI.ConstraintIndex, "Con1")
+        @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1") === nothing
+        @test MOI.get(model, MOI.ConstraintIndex, "Con1") === nothing
     end
 end
 
@@ -142,17 +124,14 @@ function emptytest(model::MOI.ModelLike)
 end
 
 abstract type BadModel <: MOI.ModelLike end
-MOI.canget(::BadModel, ::MOI.ListOfModelAttributesSet) = true
 MOI.get(::BadModel, ::MOI.ListOfModelAttributesSet) = MOI.AbstractModelAttribute[]
 MOI.get(::BadModel, ::MOI.NumberOfVariables) = 1
 MOI.get(::BadModel, ::MOI.ListOfVariableIndices) = [MOI.VariableIndex(1)]
-MOI.canget(::BadModel, ::MOI.ListOfVariableAttributesSet) = true
 MOI.get(::BadModel, ::MOI.ListOfVariableAttributesSet) = MOI.AbstractVariableAttribute[]
 MOI.get(::BadModel, ::MOI.ListOfConstraints) = [(MOI.SingleVariable, MOI.EqualTo{Float64})]
 MOI.get(::BadModel, ::MOI.ListOfConstraintIndices{F,S}) where {F,S} = [MOI.ConstraintIndex{F,S}(1)]
 MOI.get(::BadModel, ::MOI.ConstraintFunction, ::MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Float64}}) = MOI.SingleVariable(MOI.VariableIndex(1))
 MOI.get(::BadModel, ::MOI.ConstraintSet, ::MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Float64}}) = MOI.EqualTo(0.0)
-MOI.canget(::BadModel, ::MOI.ListOfConstraintAttributesSet) = true
 MOI.get(::BadModel, ::MOI.ListOfConstraintAttributesSet) = MOI.AbstractConstraintAttribute[]
 
 struct BadConstraintModel <: BadModel end
@@ -162,19 +141,16 @@ MOI.get(::BadModel, ::MOI.ConstraintSet, ::MOI.ConstraintIndex{MOI.SingleVariabl
 
 struct UnknownModelAttribute <: MOI.AbstractModelAttribute end
 struct BadModelAttributeModel <: BadModel end
-MOI.canget(::BadModelAttributeModel, ::UnknownModelAttribute) = true
 MOI.get(src::BadModelAttributeModel, ::UnknownModelAttribute) = 0
 MOI.get(::BadModelAttributeModel, ::MOI.ListOfModelAttributesSet) = MOI.AbstractModelAttribute[UnknownModelAttribute()]
 
 struct UnknownVariableAttribute <: MOI.AbstractVariableAttribute end
 struct BadVariableAttributeModel <: BadModel end
-MOI.canget(::BadVariableAttributeModel, ::UnknownVariableAttribute, ::Type{MOI.VariableIndex}) = true
 MOI.get(::BadVariableAttributeModel, ::UnknownVariableAttribute, ::MOI.VariableIndex) = 0
 MOI.get(::BadVariableAttributeModel, ::MOI.ListOfVariableAttributesSet) = MOI.AbstractVariableAttribute[UnknownVariableAttribute()]
 
 struct UnknownConstraintAttribute <: MOI.AbstractConstraintAttribute end
 struct BadConstraintAttributeModel <: BadModel end
-MOI.canget(::BadConstraintAttributeModel, ::UnknownConstraintAttribute, ::Type{<:MOI.ConstraintIndex}) = true
 MOI.get(::BadConstraintAttributeModel, ::UnknownConstraintAttribute, ::MOI.ConstraintIndex) = 0
 MOI.get(::BadConstraintAttributeModel, ::MOI.ListOfConstraintAttributesSet) = MOI.AbstractConstraintAttribute[UnknownConstraintAttribute()]
 
@@ -218,9 +194,9 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
 
     dict = MOI.copy!(dest, src, copynames=false)
 
-    @test !MOI.canget(dest, MOI.Name()) || MOI.get(dest, MOI.Name()) == ""
+    @test !MOI.supports(dest, MOI.Name()) || MOI.get(dest, MOI.Name()) == ""
     @test MOI.get(dest, MOI.NumberOfVariables()) == 3
-    @test !MOI.canget(dest, MOI.VariableName(), MOI.VariableIndex) || MOI.get(dest, MOI.VariableName(), v) == ["", "", ""]
+    @test !MOI.supports(dest, MOI.VariableName(), MOI.VariableIndex) || MOI.get(dest, MOI.VariableName(), v) == ["", "", ""]
     @test MOI.get(dest, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 1
     @test MOI.get(dest, MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == [dict[csv]]
     @test MOI.get(dest, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
@@ -236,30 +212,20 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
     @test (MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}) in loc
     @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
 
-    @test !MOI.canget(dest, MOI.ConstraintName(), typeof(csv)) || MOI.get(dest, MOI.ConstraintName(), csv) == ""
-    @test MOI.canget(dest, MOI.ConstraintFunction(), typeof(dict[csv]))
+    @test !MOI.supports(dest, MOI.ConstraintName(), typeof(csv)) || MOI.get(dest, MOI.ConstraintName(), csv) == ""
     @test MOI.get(dest, MOI.ConstraintFunction(), dict[csv]) == MOI.SingleVariable(dict[v[2]])
-    @test MOI.canget(dest, MOI.ConstraintSet(), typeof(dict[csv]))
     @test MOI.get(dest, MOI.ConstraintSet(), dict[csv]) == MOI.EqualTo(2.)
-    @test !MOI.canget(dest, MOI.ConstraintName(), typeof(cvv)) || MOI.get(dest, MOI.ConstraintName(), cvv) == ""
-    @test MOI.canget(dest, MOI.ConstraintFunction(), typeof(dict[cvv]))
+    @test !MOI.supports(dest, MOI.ConstraintName(), typeof(cvv)) || MOI.get(dest, MOI.ConstraintName(), cvv) == ""
     @test MOI.get(dest, MOI.ConstraintFunction(), dict[cvv]) == MOI.VectorOfVariables(getindex.(Ref(dict), v))
-    @test MOI.canget(dest, MOI.ConstraintSet(), typeof(dict[cvv]))
     @test MOI.get(dest, MOI.ConstraintSet(), dict[cvv]) == MOI.Nonnegatives(3)
-    @test !MOI.canget(dest, MOI.ConstraintName(), typeof(csa)) || MOI.get(dest, MOI.ConstraintName(), csa) == ""
-    @test MOI.canget(dest, MOI.ConstraintFunction(), typeof(dict[csa]))
+    @test !MOI.supports(dest, MOI.ConstraintName(), typeof(csa)) || MOI.get(dest, MOI.ConstraintName(), csa) == ""
     @test MOI.get(dest, MOI.ConstraintFunction(), dict[csa]) ≈ MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1., 3.], [dict[v[3]], dict[v[1]]]), 2.)
-    @test MOI.canget(dest, MOI.ConstraintSet(), typeof(dict[csa]))
     @test MOI.get(dest, MOI.ConstraintSet(), dict[csa]) == MOI.LessThan(2.)
-    @test !MOI.canget(dest, MOI.ConstraintName(), typeof(cva)) || MOI.get(dest, MOI.ConstraintName(), cva) == ""
-    @test MOI.canget(dest, MOI.ConstraintFunction(), typeof(dict[cva]))
+    @test !MOI.supports(dest, MOI.ConstraintName(), typeof(cva)) || MOI.get(dest, MOI.ConstraintName(), cva) == ""
     @test MOI.get(dest, MOI.ConstraintFunction(), dict[cva]) ≈ MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 2], MOI.ScalarAffineTerm.(1.0, [dict[v[3]], dict[v[2]]])), [-3.0,-2.0])
-    @test MOI.canget(dest, MOI.ConstraintSet(), typeof(dict[cva]))
     @test MOI.get(dest, MOI.ConstraintSet(), dict[cva]) == MOI.Zeros(2)
 
-    @test MOI.canget(dest, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.get(dest, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()) ≈ MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-3.0, -2.0, -4.0], [dict[v[1]], dict[v[2]], dict[v[3]]]), 0.0)
-    @test MOI.canget(dest, MOI.ObjectiveSense())
     @test MOI.get(dest, MOI.ObjectiveSense()) == MOI.MinSense
 end
 

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -136,21 +136,16 @@ function hs071test_template(model::MOI.ModelLike, config::TestConfig, evaluator:
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 17.014017145179164 atol=atol rtol=rtol
 
         optimal_v = [1.0, 4.7429996418092970, 3.8211499817883077, 1.3794082897556983]
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ optimal_v atol=atol rtol=rtol
 
         # TODO: Duals? Maybe better to test on a convex instance.
@@ -246,19 +241,14 @@ function feasibility_sense_test_template(model::MOI.ModelLike,
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.canget(model, MOI.TerminationStatus())
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
 
-        @test MOI.canget(model, MOI.ResultCount())
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.canget(model, MOI.PrimalStatus())
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
-        @test MOI.canget(model, MOI.ObjectiveValue())
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
 
-        @test MOI.canget(model, MOI.VariablePrimal(), MOI.VariableIndex)
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1.0 atol=atol rtol=rtol
     end
 end

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -435,6 +435,11 @@ end
 
 Return a `Bool` indicating whether the value of the attribute is determined
 during [`MOI.optimize!`](@ref) hence is part of the result of the optimization.
+
+## Important note when defining new attributes
+
+This function returns `false` by default so it should be implemented for all
+result attributes.
 """
 function is_result_attribute end
 

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -456,7 +456,7 @@ function is_result_attribute(::Union{MOI.ObjectiveValue,
                                      MOI.PrimalStatus,
                                      MOI.DualStatus,
                                      MOI.VariablePrimal,
-                                     MOI.ConstraintBasisStatus,
+                                     MOI.VariableBasisStatus,
                                      MOI.ConstraintPrimal,
                                      MOI.ConstraintDual,
                                      MOI.ConstraintBasisStatus})

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -36,20 +36,17 @@ function passattributes! end
 
 function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, passattr!::Function=MOI.set!)
     # Copy model attributes
-    @assert MOI.canget(src, MOI.ListOfModelAttributesSet())
     attrs = MOI.get(src, MOI.ListOfModelAttributesSet())
     _passattributes!(dest, src, copynames, idxmap, attrs, tuple(), tuple(), tuple(), passattr!)
 end
 function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, vis_src::Vector{VI}, passattr!::Function=MOI.set!)
     # Copy variable attributes
-    @assert MOI.canget(src, MOI.ListOfVariableAttributesSet())
     attrs = MOI.get(src, MOI.ListOfVariableAttributesSet())
     vis_dest = map(vi -> idxmap[vi], vis_src)
     _passattributes!(dest, src, copynames, idxmap, attrs, (VI,), (vis_src,), (vis_dest,), passattr!)
 end
 function passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, cis_src::Vector{CI{F, S}}, passattr!::Function=MOI.set!) where {F, S}
     # Copy constraint attributes
-    @assert MOI.canget(src, MOI.ListOfConstraintAttributesSet{F, S}())
     attrs = MOI.get(src, MOI.ListOfConstraintAttributesSet{F, S}())
     cis_dest = map(ci -> idxmap[ci], cis_src)
     _passattributes!(dest, src, copynames, idxmap, attrs, (CI{F, S},), (cis_src,), (cis_dest,), passattr!)
@@ -57,7 +54,7 @@ end
 
 function _passattributes!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool, idxmap::IndexMap, attrs, canargs, getargs, setargs, passattr!::Function=MOI.set!)
     for attr in attrs
-        if (copynames || !(attr isa MOI.Name || attr isa MOI.VariableName || attr isa MOI.ConstraintName)) && MOI.canget(src, attr, canargs...)
+        if (copynames || !(attr isa MOI.Name || attr isa MOI.VariableName || attr isa MOI.ConstraintName))
             passattr!(dest, attr, setargs..., attribute_value_map(idxmap, MOI.get(src, attr, getargs...)))
         end
     end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -422,9 +422,7 @@ function test_models_equal(model1::MOI.ModelLike, model2::MOI.ModelLike, variabl
     attrs2 = MOI.get(model2, MOI.ListOfModelAttributesSet())
     attr_list = attrs1 ∪ attrs2
     for attr in attr_list
-        @test MOI.canget(model1, attr)
         value1 = MOI.get(model1, attr)
-        @test MOI.canget(model2, attr)
         value2 = MOI.get(model2, attr)
         if value1 isa MOI.AbstractFunction
             @test value2 isa MOI.AbstractFunction

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -175,52 +175,6 @@ function get!(output, model::ModelLike, attr::AnyAttribute, args...)
 end
 
 """
-    canget(optimizer::AbstractOptimizer, attr::AbstractOptimizerAttribute)::Bool
-
-Return a `Bool` indicating whether `optimizer` currently has a value for the attribute specified by attr type `attr`.
-
-    canget(model::ModelLike, attr::AbstractModelAttribute)::Bool
-
-Return a `Bool` indicating whether `model` currently has a value for the attribute specified by attribute type `attr`.
-
-    canget(model::ModelLike, attr::AbstractVariableAttribute, ::Type{VariableIndex})::Bool
-
-Return a `Bool` indicating whether `model` currently has a value for the attribute specified by attribute type `attr` applied to *every* variable of the model.
-
-    canget(model::ModelLike, attr::AbstractConstraintAttribute, ::Type{ConstraintIndex{F,S}})::Bool where {F<:AbstractFunction,S<:AbstractSet}
-
-Return a `Bool` indicating whether `model` currently has a value for the attribute specified by attribute type `attr` applied to *every* `F`-in-`S` constraint.
-
-    canget(model::ModelLike, ::Type{VariableIndex}, name::String)::Bool
-
-Return a `Bool` indicating if a variable with the name `name` exists in `model`.
-
-    canget(model::ModelLike, ::Type{ConstraintIndex{F,S}}, name::String)::Bool where {F<:AbstractFunction,S<:AbstractSet}
-
-Return a `Bool` indicating if an `F`-in-`S` constraint with the name `name` exists in `model`.
-
-    canget(model::ModelLike, ::Type{ConstraintIndex}, name::String)::Bool
-
-Return a `Bool` indicating if a constraint of any kind with the name `name` exists in `model`.
-
-
-### Examples
-
-```julia
-canget(model, ObjectiveValue())
-canget(model, VariablePrimalStart(), VariableIndex)
-canget(model, VariablePrimal(), VariableIndex)
-canget(model, ConstraintPrimal(), ConstraintIndex{SingleVariable,EqualTo{Float64}})
-canget(model, VariableIndex, "var1")
-canget(model, ConstraintIndex{ScalarAffineFunction{Float64},LessThan{Float64}}, "con1")
-canget(model, ConstraintIndex, "con1")
-```
-"""
-function canget end
-canget(::ModelLike, ::Union{AbstractModelAttribute, AbstractOptimizerAttribute}) = false
-canget(::ModelLike, ::Union{AbstractVariableAttribute, AbstractConstraintAttribute}, ::Type{<:Index}) = false
-
-"""
     set!(optimizer::AbstractOptimizer, attr::AbstractOptimizerAttribute, value)
 
 Assign `value` to the attribute `attr` of the optimizer `optimizer`.
@@ -710,6 +664,7 @@ To be documented: `NumericalError`, `InvalidModel`, `InvalidOption`, `Interrupte
 An Enum of possible values for the `PrimalStatus` and `DualStatus` attributes.
 The values indicate how to interpret the result vector.
 
+* `NoSolution`
 * `FeasiblePoint`
 * `NearlyFeasiblePoint`
 * `InfeasiblePoint`
@@ -720,7 +675,7 @@ The values indicate how to interpret the result vector.
 * `UnknownResultStatus`
 * `OtherResultStatus`
 """
-@enum ResultStatusCode FeasiblePoint NearlyFeasiblePoint InfeasiblePoint InfeasibilityCertificate NearlyInfeasibilityCertificate ReductionCertificate NearlyReductionCertificate UnknownResultStatus OtherResultStatus
+@enum ResultStatusCode NoSolution FeasiblePoint NearlyFeasiblePoint InfeasiblePoint InfeasibilityCertificate NearlyInfeasibilityCertificate ReductionCertificate NearlyReductionCertificate UnknownResultStatus OtherResultStatus
 
 """
     PrimalStatus(N)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -131,15 +131,19 @@ Return a vector of attributes corresponding to each constraint in the collection
 
     get(model::ModelLike, ::Type{VariableIndex}, name::String)
 
-If a variable with name `name` exists in the model `model`, return the corresponding index, otherwise throw a `KeyError`.
+If a variable with name `name` exists in the model `model`, return the
+corresponding index, otherwise return `nothing`.
 
     get(model::ModelLike, ::Type{ConstraintIndex{F,S}}, name::String) where {F<:AbstractFunction,S<:AbstractSet}
 
-If an `F`-in-`S` constraint with name `name` exists in the model `model`, return the corresponding index, otherwise throw a `KeyError`.
+If an `F`-in-`S` constraint with name `name` exists in the model `model`, return
+the corresponding index, otherwise return `nothing`.
 
     get(model::ModelLike, ::Type{ConstraintIndex}, name::String)
 
-If *any* constraint with name `name` exists in the model `model`, return the corresponding index, otherwise throw a `KeyError`. This version is available for convenience but may incur a performance penalty because it is not type stable.
+If *any* constraint with name `name` exists in the model `model`, return the
+corresponding index, otherwise return `nothing`. This version is available for
+convenience but may incur a performance penalty because it is not type stable.
 
 ### Examples
 

--- a/test/Test/intlinear.jl
+++ b/test/Test/intlinear.jl
@@ -3,7 +3,10 @@
     config = MOIT.TestConfig()
 
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [4, 5, 1]))
+        (mock::MOIU.MockOptimizer) -> begin
+            MOI.set!(mock, MOI.Objectivebound(), 20.0)
+            MOIU.mock_optimize!(mock, [4, 5, 1])
+        end)
     MOIT.int1test(mock, config)
     MOIU.set_mock_optimize!(mock,
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [0, 1, 2]),

--- a/test/Test/intlinear.jl
+++ b/test/Test/intlinear.jl
@@ -4,7 +4,7 @@
 
     MOIU.set_mock_optimize!(mock,
         (mock::MOIU.MockOptimizer) -> begin
-            MOI.set!(mock, MOI.Objectivebound(), 20.0)
+            MOI.set!(mock, MOI.ObjectiveBound(), 20.0)
             MOIU.mock_optimize!(mock, [4, 5, 1])
         end)
     MOIT.int1test(mock, config)

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -2,11 +2,8 @@
 MOIU.@model SimpleModel () (EqualTo, GreaterThan, LessThan) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, PositiveSemidefiniteConeTriangle, ExponentialCone) () (SingleVariable,) (ScalarAffineFunction, ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
 
 function test_noc(bridgedmock, F, S, n)
-    @test MOI.canget(bridgedmock, MOI.NumberOfConstraints{F, S}())
     @test MOI.get(bridgedmock, MOI.NumberOfConstraints{F, S}()) == n
-    @test MOI.canget(bridgedmock, MOI.ListOfConstraintIndices{F, S}())
     @test length(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{F, S}())) == n
-    @test MOI.canget(bridgedmock, MOI.ListOfConstraints())
     @test ((F, S) in MOI.get(bridgedmock, MOI.ListOfConstraints())) == !iszero(n)
 end
 
@@ -83,32 +80,26 @@ end
         f1 = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(3, x)], 7)
         c1 = MOI.addconstraint!(model, f1, MOI.Interval(-1, 1))
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
         @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
-        @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
         @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
 
         f2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2, -1], [x, y]), 2)
         c2 = MOI.addconstraint!(model, f1, MOI.GreaterThan(-2))
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
         @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}), (MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 1)
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
-        @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
         @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
         @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}}())) == [c2]
 
         @test MOI.isvalid(model, c2)
         MOI.delete!(model, c2)
 
-        @test MOI.canget(model, MOI.ListOfConstraints())
         @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.Interval{Int}, 1)
-        @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())
         @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.Interval{Int}}())) == [c1]
     end
 
@@ -157,7 +148,6 @@ MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, No
         MOIT.rootdett1vtest(fullbridgedmock, config)
         MOIT.rootdett1ftest(fullbridgedmock, config)
         # Dual is not yet implemented for RootDet and GeoMean bridges
-        @test !MOI.canget(fullbridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle})
         ci = first(MOI.get(fullbridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
         @test !MOI.supports(fullbridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(fullbridgedmock, MOI.ConstraintFunction(), typeof(ci))
@@ -202,7 +192,6 @@ end
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}}()))
         newf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], MOI.get(bridgedmock, MOI.ListOfVariableIndices())), 0.0)
         MOI.set!(bridgedmock, MOI.ConstraintFunction(), ci, newf)
-        @test MOI.canget(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         @test MOI.get(bridgedmock, MOI.ConstraintFunction(), ci) ≈ newf
         test_delete_bridge(bridgedmock, ci, 2, ((MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}, 0),
                                                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64},    0)))
@@ -248,7 +237,6 @@ end
         MOIT.geomean1vtest(bridgedmock, config)
         MOIT.geomean1ftest(bridgedmock, config)
         # Dual is not yet implemented for GeoMean bridge
-        @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.GeometricMeanCone})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
@@ -290,7 +278,6 @@ end
         MOIT.logdett1vtest(bridgedmock, config)
         MOIT.logdett1ftest(bridgedmock, config)
         # Dual is not yet implemented for LogDet bridge
-        @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle}()))
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
@@ -303,7 +290,6 @@ end
         MOIT.rootdett1vtest(bridgedmock, config)
         MOIT.rootdett1ftest(bridgedmock, config)
         # Dual is not yet implemented for RootDet bridge
-        @test !MOI.canget(bridgedmock, MOI.ConstraintDual(), MOI.ConstraintIndex{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle})
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
         @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
         @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -16,7 +16,6 @@
     MOI.set!(m, MOI.ObjectiveFunction{typeof(saf)}(), saf)
     @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveFunction{typeof(saf)}())) ≈ saf
     @test MOI.get(m, MOI.ObjectiveFunction{typeof(saf)}()) ≈ saf
-    @test !MOI.canget(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense()))
 
     @test_throws AssertionError MOI.optimize!(m)
 
@@ -26,16 +25,11 @@
 
     @test MOI.supports(m, MOI.ObjectiveSense())
     MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.canget(m, MOI.ObjectiveSense())
-    @test MOI.canget(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense()))
-    @test MOI.canget(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense()))
     @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
     @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense())) == MOI.MaxSense
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense())) == MOI.MaxSense
 
     @test !MOI.supports(m, MOI.NumberOfVariables())
-    @test !MOI.canget(m, MOIU.AttributeFromModelCache(MOIU.MockModelAttribute()))
-    @test MOI.canget(m, MOIU.AttributeFromOptimizer((MOIU.MockModelAttribute())))
 
     @test MOI.supports(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()))
     MOI.set!(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()), 10)
@@ -47,10 +41,8 @@
 
     MOI.optimize!(m)
 
-    @test MOI.canget(m, MOI.VariablePrimal(), typeof(v))
     @test MOI.get(m, MOI.VariablePrimal(), v) == 3.0
     @test MOI.get(m, MOI.VariablePrimal(), [v]) == [3.0]
-    @test MOI.canget(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), typeof(v))
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), v) == 3.0
 
     # ModelForMock doesn't support RotatedSecondOrderCone
@@ -89,7 +81,6 @@ end
     v = MOI.addvariable!(m)
     @test MOI.supports(m, MOI.VariableName(), typeof(v))
     MOI.set!(m, MOI.VariableName(), v, "v")
-    @test MOI.canget(m, MOI.VariableName(), typeof(v))
     @test MOI.get(m, MOI.VariableName(), v) == "v"
 
     s = MOIU.MockOptimizer(ModelForMock{Float64}())
@@ -106,22 +97,15 @@ end
     @test MOIU.state(m) == MOIU.AttachedOptimizer
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ResultCount())) == 0
 
-    @test MOI.canget(m, MOI.VariableName(), typeof(v))
     @test MOI.get(m, MOI.VariableName(), v) == "v"
-    @test MOI.canget(m, MOIU.AttributeFromModelCache(MOI.VariableName()), typeof(v))
     @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.VariableName()), v) == "v"
     # The caching optimizer does not copy names
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.VariableName()), v) == ""
 
     @test MOI.supports(m, MOI.ObjectiveSense())
     MOI.set!(m, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.canget(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense()))
-    @test MOI.canget(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense()))
     @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense())) == MOI.MaxSense
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense())) == MOI.MaxSense
-
-    @test !MOI.canget(m, MOIU.AttributeFromModelCache(MOIU.MockModelAttribute()))
-    @test MOI.canget(m, MOIU.AttributeFromOptimizer((MOIU.MockModelAttribute())))
 
     @test MOI.supports(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()))
     MOI.set!(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()), 10)
@@ -133,7 +117,6 @@ end
 
     MOI.optimize!(m)
 
-    @test MOI.canget(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), typeof(v))
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.VariablePrimal()), v) == 3.0
 
     @testset "Modify not allowed" begin

--- a/test/mockoptimizer.jl
+++ b/test/mockoptimizer.jl
@@ -6,13 +6,11 @@ end
     optimizer = MOIU.MockOptimizer(ModelForMock{Float64}())
     @test MOI.supports(optimizer, MOIU.MockModelAttribute())
     MOI.set!(optimizer, MOIU.MockModelAttribute(), 10)
-    @test MOI.canget(optimizer, MOIU.MockModelAttribute())
     @test MOI.get(optimizer, MOIU.MockModelAttribute()) == 10
 
     v1 = MOI.addvariable!(optimizer)
     @test MOI.supports(optimizer, MOIU.MockVariableAttribute(), typeof(v1))
     MOI.set!(optimizer, MOIU.MockVariableAttribute(), v1, 11)
-    @test MOI.canget(optimizer, MOIU.MockVariableAttribute(), typeof(v1))
     @test MOI.get(optimizer, MOIU.MockVariableAttribute(), v1) == 11
     MOI.set!(optimizer, MOIU.MockVariableAttribute(), [v1], [-11])
     @test MOI.get(optimizer, MOIU.MockVariableAttribute(), [v1]) == [-11]
@@ -21,7 +19,6 @@ end
     c1 = MOI.addconstraint!(optimizer, MOI.SingleVariable(v1), MOI.GreaterThan(1.0))
     @test MOI.supports(optimizer, MOIU.MockConstraintAttribute(), typeof(c1))
     MOI.set!(optimizer, MOIU.MockConstraintAttribute(), c1, 12)
-    @test MOI.canget(optimizer, MOIU.MockConstraintAttribute(), typeof(c1))
     @test MOI.get(optimizer, MOIU.MockConstraintAttribute(), c1) == 12
     MOI.set!(optimizer, MOIU.MockConstraintAttribute(), [c1], [-12])
     @test MOI.get(optimizer, MOIU.MockConstraintAttribute(), [c1]) == [-12]
@@ -35,15 +32,7 @@ end
     # Load fake solution
     MOI.set!(optimizer, MOI.TerminationStatus(), MOI.InfeasibleNoResult)
 
-    # Attributes are hidden until after optimize!()
-    @test !MOI.canget(optimizer, MOI.TerminationStatus())
-    @test !MOI.canget(optimizer, MOI.ResultCount())
-    @test !MOI.canget(optimizer, MOI.VariablePrimal(), MOI.VariableIndex)
-
     MOI.optimize!(optimizer)
-    @test MOI.canget(optimizer, MOI.TerminationStatus())
-    @test MOI.canget(optimizer, MOI.ResultCount())
-    @test !MOI.canget(optimizer, MOI.VariablePrimal(), typeof(v1))
     @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.InfeasibleNoResult
     @test MOI.get(optimizer, MOI.ResultCount()) == 0
 end
@@ -70,22 +59,7 @@ end
     MOI.set!(optimizer, MOI.ConstraintDual(), c1, 5.9)
     MOI.set!(optimizer, MOI.ConstraintDual(), soc, [1.0,2.0])
 
-    # Attributes are hidden until after optimize!()
-    @test !MOI.canget(optimizer, MOI.TerminationStatus())
-    @test !MOI.canget(optimizer, MOI.ResultCount())
-    @test !MOI.canget(optimizer, MOI.VariablePrimal(), typeof(v[1]))
-    @test !MOI.canget(optimizer, MOI.ConstraintDual(), typeof(c1))
-    @test !MOI.canget(optimizer, MOI.ConstraintDual(), typeof(soc))
-
     MOI.optimize!(optimizer)
-    @test MOI.canget(optimizer, MOI.TerminationStatus())
-    @test MOI.canget(optimizer, MOI.ResultCount())
-    @test MOI.canget(optimizer, MOI.ObjectiveValue())
-    @test MOI.canget(optimizer, MOI.PrimalStatus())
-    @test MOI.canget(optimizer, MOI.DualStatus())
-    @test MOI.canget(optimizer, MOI.VariablePrimal(), typeof(v[1]))
-    @test MOI.canget(optimizer, MOI.ConstraintDual(), typeof(c1))
-    @test MOI.canget(optimizer, MOI.ConstraintDual(), typeof(soc))
     @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Success
     @test MOI.get(optimizer, MOI.ResultCount()) == 1
     @test MOI.get(optimizer, MOI.ObjectiveValue()) == 1.0

--- a/test/model.jl
+++ b/test/model.jl
@@ -42,17 +42,14 @@ end
     c1 = MOI.addconstraint!(model, f1, MOI.Interval(-1, 1))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Int},MOI.Interval{Int}}()) == 1
-    @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.ScalarQuadraticFunction{Int},MOI.Interval{Int}}())
     @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarQuadraticFunction{Int},MOI.Interval{Int}}())) == [c1]
 
     f2 = MOI.VectorQuadraticFunction(MOI.VectorAffineTerm.([1, 2, 2], MOI.ScalarAffineTerm.([3, 1, 2], [x, x, y])), MOI.VectorQuadraticTerm.([1, 1, 2], MOI.ScalarQuadraticTerm.([1, 2, 3], [x, y, x], [x, y, y])), [7, 3, 4])
     c2 = MOI.addconstraint!(model, f2, MOI.PositiveSemidefiniteConeTriangle(3))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorQuadraticFunction{Int},MOI.PositiveSemidefiniteConeTriangle}()) == 1
-    @test MOI.canget(model, MOI.ListOfConstraintIndices{MOI.VectorQuadraticFunction{Int},MOI.PositiveSemidefiniteConeTriangle}())
     @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.VectorQuadraticFunction{Int},MOI.PositiveSemidefiniteConeTriangle}())) == [c2]
 
-    @test MOI.canget(model, MOI.ListOfConstraints())
     loc = MOI.get(model, MOI.ListOfConstraints())
     @test length(loc) == 2
     @test (MOI.VectorQuadraticFunction{Int},MOI.PositiveSemidefiniteConeTriangle) in loc

--- a/test/universalfallback.jl
+++ b/test/universalfallback.jl
@@ -1,12 +1,8 @@
 function test_optmodattrs(uf, model, attr, listattr)
     @test !MOI.supports(model, attr)
     @test MOI.supports(uf, attr)
-    @test !MOI.canget(model, attr)
-    @test !MOI.canget(uf, attr)
     @test isempty(MOI.get(uf, listattr))
     MOI.set!(uf, attr, 0)
-    @test !MOI.canget(model, attr)
-    @test MOI.canget(uf, attr)
     @test MOI.get(uf, attr) == 0
     @test MOI.get(uf, listattr) == [attr]
     @test !MOI.isempty(uf)
@@ -16,46 +12,30 @@ end
 function test_varconattrs(uf, model, attr, listattr, I::Type{<:MOI.Index}, addfun, x, y, z)
     @test !MOI.supports(model, attr, I)
     @test MOI.supports(uf, attr, I)
-    @test !MOI.canget(model, attr, I)
-    @test !MOI.canget(uf, attr, I)
     @test isempty(MOI.get(uf, listattr))
     MOI.set!(uf, attr, [x, y], [2, 0])
     @test !MOI.isempty(uf)
-    @test !MOI.canget(model, attr, I)
-    @test !MOI.canget(uf, attr, I)
-    @test isempty(MOI.get(uf, listattr))
+    @test MOI.get(uf, listattr) == [attr]
     MOI.set!(uf, attr, z, 5)
-    @test !MOI.canget(model, attr, I)
-    @test MOI.canget(uf, attr, I)
     @test MOI.get(uf, attr, y) == 0
     @test MOI.get(uf, attr, [z, x]) == [5, 2]
     @test MOI.get(uf, listattr) == [attr]
 
     u = addfun(uf)
-    @test !MOI.canget(model, attr, I)
-    @test !MOI.canget(uf, attr, I)
-    @test isempty(MOI.get(uf, listattr))
+    @test MOI.get(uf, listattr) == [attr]
     MOI.set!(uf, attr, u, 8)
-    @test !MOI.canget(model, attr, I)
-    @test MOI.canget(uf, attr, I)
     @test MOI.get(uf, listattr) == [attr]
 
     w = addfun(uf)
-    @test !MOI.canget(model, attr, I)
-    @test !MOI.canget(uf, attr, I)
-    @test isempty(MOI.get(uf, listattr))
+    @test MOI.get(uf, listattr) == [attr]
 
     @test MOI.isvalid(uf, u)
     MOI.delete!(uf, u)
     @test !MOI.isvalid(uf, u)
     @test_throws MOI.InvalidIndex{typeof(u)} MOI.delete!(uf, u)
-    @test !MOI.canget(model, attr, I)
-    @test !MOI.canget(uf, attr, I)
-    @test isempty(MOI.get(uf, listattr))
+    @test MOI.get(uf, listattr) == [attr]
 
     MOI.set!(uf, attr, [w, z], [9, 4])
-    @test !MOI.canget(model, attr, I)
-    @test MOI.canget(uf, attr, I)
     @test MOI.get(uf, listattr) == [attr]
     @test MOI.get(uf, attr, w) == 9
     @test MOI.get(uf, attr, x) == 2
@@ -125,18 +105,19 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
 
             @test MOI.supports(uf, MOI.ConstraintFunction(), typeof(cx))
             MOI.set!(uf, MOI.ConstraintFunction(), cx, MOI.SingleVariable(y))
-            @test MOI.canget(uf, MOI.ConstraintFunction(), typeof(cx))
             @test MOI.get(uf, MOI.ConstraintFunction(), cx) == MOI.SingleVariable(y)
 
             @test MOI.supports(uf, MOI.ConstraintName(), typeof(cx))
             MOI.set!(uf, MOI.ConstraintName(), cx, "LessThan")
-            @test MOI.canget(uf, MOI.ConstraintName(), typeof(cx))
             @test MOI.get(uf, MOI.ConstraintName(), cx) == "LessThan"
-            @test MOI.canget(uf, typeof(cx), "LessThan")
             @test MOI.get(uf, typeof(cx), "LessThan") == cx
             MOI.delete!(uf, cx)
-            @test !MOI.canget(uf, typeof(cx), "LessThan")
+            @test MOI.get(uf, typeof(cx), "LessThan") === nothing
         end
+        # To remove the constraint attributes added in the previous testset
+        MOI.empty!(uf)
+        x = MOI.addvariable!(uf)
+        y, z = MOI.addvariables!(uf, 2)
         @testset "Unsupported constraint" begin
             cx = MOI.addconstraint!(uf, x, MOI.EqualTo(0.))
             cy = MOI.addconstraint!(uf, y, MOI.EqualTo(1.))
@@ -147,17 +128,14 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
 
             @test MOI.supports(uf, MOI.ConstraintFunction(), typeof(cx))
             MOI.set!(uf, MOI.ConstraintFunction(), cx, MOI.SingleVariable(y))
-            @test MOI.canget(uf, MOI.ConstraintFunction(), typeof(cx))
             @test MOI.get(uf, MOI.ConstraintFunction(), cx) == MOI.SingleVariable(y)
 
             @test MOI.supports(uf, MOI.ConstraintName(), typeof(cx))
             MOI.set!(uf, MOI.ConstraintName(), cx, "EqualTo")
-            @test MOI.canget(uf, MOI.ConstraintName(), typeof(cx))
             @test MOI.get(uf, MOI.ConstraintName(), cx) == "EqualTo"
-            @test MOI.canget(uf, typeof(cx), "EqualTo")
             @test MOI.get(uf, typeof(cx), "EqualTo") == cx
             MOI.delete!(uf, cx)
-            @test !MOI.canget(uf, typeof(cx), "EqualTo")
+            @test MOI.get(uf, typeof(cx), "EqualTo") === nothing
         end
     end
     config = MOIT.TestConfig(solve=false)


### PR DESCRIPTION
Here are the following changes:

* If a constraint or variable attribute is set to a strict subset of the variables/constraints, it used to return `canget` equal to false and not be included in `ListOf...AttributesSet`. No, it is included in the list independently on the number of variables/constraints with this attribute set.
* To check if a name was already present, one could use `canget` and this was used by the bridgeoptimizer and universalfallback to check whether it is the name of a bridged constraints or of a constraint of the internal model. This required 2 dictionary lookup: 1 for canget and 1 for get. If get is called with a name that does not exists an error was thrown. Now with this PR, `get` returns `nothing` in case the name does not exists. This allows bridges and fallback to have almost no overhead in case the name not the name of a bridged constraint as this is [efficiently handled on Julia v1.0](https://julialang.org/blog/2018/08/union-splitting)
* `NoSolution` has been added as a new result status which specifies that the result has no primal or dual solution, e.g. a result could have only a dual solution in which case the primal status is `NoSolution`.

Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/424
Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/302