### PR TITLE
Rename copy! -> copy_to

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -762,7 +762,7 @@ will additionally support `ScalarAffineFunction`-in-`Interval`.
 [The interface is designed for multiple dispatch, e.g., attributes, combinations of sets and functions.]
 
 Avoid storing extra copies of the problem when possible. This means that solver wrappers should not use
-`CachingOptimizer` as part of the wrapper. Instead, just implement `copy!` if the solver's API
+`CachingOptimizer` as part of the wrapper. Instead, just implement `copy_to` if the solver's API
 does not support an `add_variable`-like API. Let users or JuMP decide to use `CachingOptimizer` instead.
 
 ### JuMP mapping

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -39,7 +39,7 @@ read_from_file
 Copying
 
 ```@docs
-copy!
+copy_to
 ```
 
 List of model attributes

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -86,9 +86,9 @@ function MOI.supports(b::AbstractBridgeOptimizer,
                                   MOI.AbstractOptimizerAttribute})
     return MOI.supports(b.model, attr)
 end
-function MOI.copy!(b::AbstractBridgeOptimizer, src::MOI.ModelLike;
+function MOI.copy_to(b::AbstractBridgeOptimizer, src::MOI.ModelLike;
                    copynames=false)
-    return MOIU.defaultcopy!(b, src, copynames)
+    return MOIU.default_copy_to(b, src, copynames)
 end
 
 # References

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -73,7 +73,7 @@ Empty the model, that is, remove all variables, constraints and model attributes
 function empty! end
 
 """
-    copy!(dest::ModelLike, src::ModelLike; copynames=true, warnattributes=true)
+    copy_to(dest::ModelLike, src::ModelLike; copynames=true, warnattributes=true)
 
 Copy the model from `src` into `dest`. The target `dest` is emptied, and all
 previous indices to variables or constraints in `dest` are invalidated. Returns
@@ -101,12 +101,12 @@ x = add_variable(src)
 is_valid(src, x)   # true
 is_valid(dest, x)  # false (`dest` has no variables)
 
-index_map = copy!(dest, src)
+index_map = copy_to(dest, src)
 is_valid(dest, x) # false (unless index_map[x] == x)
 is_valid(dest, index_map[x]) # true
 ```
 """
-function copy! end
+function copy_to end
 
 include("error.jl")
 include("indextypes.jl")

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -156,19 +156,19 @@ MOI.get(::BadConstraintAttributeModel, ::MOI.ListOfConstraintAttributesSet) = MO
 
 function failcopytestc(dest::MOI.ModelLike)
     @test !MOI.supports_constraint(dest, MOI.SingleVariable, UnknownSet)
-    @test_throws MOI.UnsupportedConstraint MOI.copy!(dest, BadConstraintModel())
+    @test_throws MOI.UnsupportedConstraint MOI.copy_to(dest, BadConstraintModel())
 end
 function failcopytestia(dest::MOI.ModelLike)
     @test !MOI.supports(dest, UnknownModelAttribute())
-    @test_throws MOI.UnsupportedAttribute MOI.copy!(dest, BadModelAttributeModel())
+    @test_throws MOI.UnsupportedAttribute MOI.copy_to(dest, BadModelAttributeModel())
 end
 function failcopytestva(dest::MOI.ModelLike)
     @test !MOI.supports(dest, UnknownVariableAttribute(), MOI.VariableIndex)
-    @test_throws MOI.UnsupportedAttribute MOI.copy!(dest, BadVariableAttributeModel())
+    @test_throws MOI.UnsupportedAttribute MOI.copy_to(dest, BadVariableAttributeModel())
 end
 function failcopytestca(dest::MOI.ModelLike)
     @test !MOI.supports(dest, UnknownConstraintAttribute(), MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}})
-    @test_throws MOI.UnsupportedAttribute MOI.copy!(dest, BadConstraintAttributeModel())
+    @test_throws MOI.UnsupportedAttribute MOI.copy_to(dest, BadConstraintAttributeModel())
 end
 
 function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
@@ -192,7 +192,7 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
     @test MOI.supports_constraint(dest, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supports_constraint(dest, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
 
-    dict = MOI.copy!(dest, src, copynames=false)
+    dict = MOI.copy_to(dest, src, copynames=false)
 
     @test !MOI.supports(dest, MOI.Name()) || MOI.get(dest, MOI.Name()) == ""
     @test MOI.get(dest, MOI.NumberOfVariables()) == 3

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -116,13 +116,13 @@ end
 Attaches the optimizer to `model`, copying all model data into it. Can be called
 only from the `EmptyOptimizer` state. If the copy succeeds, the
 `CachingOptimizer` will be in state `AttachedOptimizer` after the call,
-otherwise an error is thrown; see [`copy!`](@ref) for more details on which
+otherwise an error is thrown; see [`copy_to`](@ref) for more details on which
 errors can be thrown.
 """
 function attachoptimizer!(model::CachingOptimizer)
     @assert model.state == EmptyOptimizer
     # We do not need to copy names because name-related operations are handled by `m.model_cache`
-    indexmap = MOI.copy!(model.optimizer, model.model_cache, copynames=false)
+    indexmap = MOI.copy_to(model.optimizer, model.model_cache, copynames=false)
     model.state = AttachedOptimizer
     # MOI does not define the type of index_map, so we have to copy it into a
     # concrete container. Also load the reverse map.
@@ -134,8 +134,8 @@ function attachoptimizer!(model::CachingOptimizer)
     end
 end
 
-function MOI.copy!(m::CachingOptimizer, src::MOI.ModelLike; copynames=true)
-    return defaultcopy!(m, src, copynames)
+function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; copynames=true)
+    return default_copy_to(m, src, copynames)
 end
 
 function MOI.empty!(m::CachingOptimizer)

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -81,11 +81,11 @@ end
 
 attribute_value_map(idxmap, f::MOI.AbstractFunction) = mapvariables(idxmap, f)
 attribute_value_map(idxmap, attribute_value) = attribute_value
-function defaultcopy!(dest::MOI.ModelLike, src::MOI.ModelLike)
-    Base.depwarn("defaultcopy!(dest, src) is deprecated, use defaultcopy!(dest, src, true) instead or defaultcopy!(dest, src, false) if you do not want to copy names.", :defaultcopy!)
-    defaultcopy!(dest, src, true)
+function default_copy_to(dest::MOI.ModelLike, src::MOI.ModelLike)
+    Base.depwarn("default_copy_to(dest, src) is deprecated, use default_copy_to(dest, src, true) instead or default_copy_to(dest, src, false) if you do not want to copy names.", :default_copy_to)
+    default_copy_to(dest, src, true)
 end
-function defaultcopy!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
+function default_copy_to(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
     MOI.empty!(dest)
 
     idxmap = IndexMap()
@@ -118,14 +118,14 @@ end
 # During the first pass (called allocate) : the model collects the relevant information about the problem so that
 # on the second pass (called load), the constraints can be loaded directly to the solver (in case of SDOI) or written directly into the matrix of constraints (in case of SCS and ECOS).
 
-# To support `MOI.copy!` using this 2-pass mechanism, implement the allocate-load interface defined below and do:
-# MOI.copy!(dest::ModelType, src::MOI.ModelLike) = MOIU.allocateload!(dest, src)
+# To support `MOI.copy_to` using this 2-pass mechanism, implement the allocate-load interface defined below and do:
+# MOI.copy_to(dest::ModelType, src::MOI.ModelLike) = MOIU.allocateload!(dest, src)
 # In the implementation of the allocate-load interface, it can be assumed that the different functions will the called in the following order:
 # 1) `allocatevariables!`
 # 2) `allocate!` and `allocateconstraint!`
 # 3) `loadvariables!` and `allocateconstraint!`
 # 4) `load!` and `loadconstraint!`
-# The interface is not meant to be used to create new constraints with `allocateconstraint!` followed by `loadconstraint!` after a solve, it is only meant for being used in this order to implement `MOI.copy!`.
+# The interface is not meant to be used to create new constraints with `allocateconstraint!` followed by `loadconstraint!` after a solve, it is only meant for being used in this order to implement `MOI.copy_to`.
 
 """
     needsallocateload(model::MOI.ModelLike)::Bool
@@ -226,7 +226,7 @@ end
 """
     allocateload!(dest::MOI.ModelLike, src::MOI.ModelLike)
 
-Implements `MOI.copy!(dest, src)` using the allocate-load interface.
+Implements `MOI.copy_to(dest, src)` using the allocate-load interface.
 """
 function allocateload!(dest::MOI.ModelLike, src::MOI.ModelLike, copynames::Bool)
     MOI.empty!(dest)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -16,7 +16,7 @@ mutable struct MockOptimizer{MT<:MOI.ModelLike} <: MOI.AbstractOptimizer
     attribute::Int # MockModelAttribute
     varattribute::Dict{MOI.VariableIndex,Int} # MockVariableAttribute
     conattribute::Dict{MOI.ConstraintIndex,Int} # MockConstraintAttribute
-    needsallocateload::Bool # Allows to tests the Allocate-Load interface, see copy!
+    needsallocateload::Bool # Allows to tests the Allocate-Load interface, see copy_to
     add_var_allowed::Bool
     add_con_allowed::Bool # If false, the optimizer throws AddConstraintNotAllowed
     modify_allowed::Bool # If false, the optimizer throws Modify...NotAllowed
@@ -269,11 +269,11 @@ end
 # TODO: transform
 
 MOI.supports_constraint(mock::MockOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet}) = MOI.supports_constraint(mock.inner_model, F, S)
-function MOI.copy!(mock::MockOptimizer, src::MOI.ModelLike; copynames=true)
+function MOI.copy_to(mock::MockOptimizer, src::MOI.ModelLike; copynames=true)
     if needsallocateload(mock)
         allocateload!(mock, src, copynames)
     else
-        defaultcopy!(mock, src, copynames)
+        default_copy_to(mock, src, copynames)
     end
 end
 

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -329,10 +329,10 @@ function MOI.isempty(model::AbstractModel)
     iszero(model.nextvariableid) && iszero(model.nextconstraintid)
 end
 
-MOI.copy!(dest::AbstractModel, src::MOI.ModelLike; copynames=true) = defaultcopy!(dest, src, copynames)
+MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; copynames=true) = default_copy_to(dest, src, copynames)
 
 # Allocate-Load Interface
-# Even if the model does not need it and use defaultcopy!, it could be used by a layer that needs it
+# Even if the model does not need it and use default_copy_to, it could be used by a layer that needs it
 needsallocateload(model::AbstractModel) = false
 
 allocatevariables!(model::AbstractModel, nvars) = MOI.add_variables(model, nvars)

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -46,7 +46,7 @@ function MOI.empty!(uf::UniversalFallback)
     empty!(uf.varattr)
     empty!(uf.conattr)
 end
-MOI.copy!(uf::UniversalFallback, src::MOI.ModelLike; copynames=true) = MOIU.defaultcopy!(uf, src, copynames)
+MOI.copy_to(uf::UniversalFallback, src::MOI.ModelLike; copynames=true) = MOIU.default_copy_to(uf, src, copynames)
 
 # References
 MOI.is_valid(uf::UniversalFallback, idx::VI) = MOI.is_valid(uf.model, idx)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -7,7 +7,7 @@ Abstract supertype for attribute objects that can be used to set or get attribut
 
 ### Note
 
-The difference between `AbstractOptimizerAttribute` and `AbstractModelAttribute` lies in the behavior of `isempty`, `empty!` and `copy!`.
+The difference between `AbstractOptimizerAttribute` and `AbstractModelAttribute` lies in the behavior of `isempty`, `empty!` and `copy_to`.
 Typically optimizer attributes only affect how the model is solved.
 """
 abstract type AbstractOptimizerAttribute end
@@ -73,28 +73,28 @@ message(err::SetAttributeNotAllowed) = err.message
     supports(model::ModelLike, attr::AbstractOptimizerAttribute)::Bool
 
 Return a `Bool` indicating whether `model` supports the optimizer attribute
-`attr`. That is, it returns `false` if `copy!(model, src)` shows a warning in
+`attr`. That is, it returns `false` if `copy_to(model, src)` shows a warning in
 case `attr` is in the [`ListOfOptimizerAttributesSet`](@ref) of `src`; see
-[`copy!`](@ref) for more details on how unsupported optimizer attributes are
+[`copy_to`](@ref) for more details on how unsupported optimizer attributes are
 handled in copy.
 
     supports(model::ModelLike, attr::AbstractModelAttribute)::Bool
 
 Return a `Bool` indicating whether `model` supports the model attribute `attr`.
-That is, it returns `false` if `copy!(model, src)` cannot be performed in case
+That is, it returns `false` if `copy_to(model, src)` cannot be performed in case
 `attr` is in the [`ListOfModelAttributesSet`](@ref) of `src`.
 
     supports(model::ModelLike, attr::AbstractVariableAttribute, ::Type{VariableIndex})::Bool
 
 Return a `Bool` indicating whether `model` supports the variable attribute
-`attr`. That is, it returns `false` if `copy!(model, src)` cannot be performed
+`attr`. That is, it returns `false` if `copy_to(model, src)` cannot be performed
 in case `attr` is in the [`ListOfVariableAttributesSet`](@ref) of `src`.
 
     supports(model::ModelLike, attr::AbstractConstraintAttribute, ::Type{ConstraintIndex{F,S}})::Bool where {F,S}
 
 Return a `Bool` indicating whether `model` supports the constraint attribute
 `attr` applied to an `F`-in-`S` constraint. That is, it returns `false` if
-`copy!(model, src)` cannot be performed in case `attr` is in the
+`copy_to(model, src)` cannot be performed in case `attr` is in the
 [`ListOfConstraintAttributesSet`](@ref) of `src`.
 
 For all four methods, if the attribute is only not supported in specific

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -4,7 +4,7 @@
     supports_constraint(model::ModelLike, ::Type{F}, ::Type{S})::Bool where {F<:AbstractFunction,S<:AbstractSet}
 
 Return a `Bool` indicating whether `model` supports `F`-in-`S` constraints, that is,
-`copy!(model, src)` does not return `CopyUnsupportedConstraint` when `src` contains `F`-in-`S` constraints.
+`copy_to(model, src)` does not return `CopyUnsupportedConstraint` when `src` contains `F`-in-`S` constraints.
 If `F`-in-`S` constraints are only not supported in specific circumstances, e.g. `F`-in-`S` constraints cannot be combined with another type of constraint, it should still return `true`.
 """
 supports_constraint(model::ModelLike, ::Type{<:AbstractFunction}, ::Type{<:AbstractSet}) = false


### PR DESCRIPTION
Also rename `defaultcopy!` to `default_copy_to`.

Related to https://github.com/JuliaOpt/MathOptInterface.jl/issues/475