### PR TITLE
Use MOI.delete instead of Base.delete!

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -119,7 +119,7 @@ v2 = add_variables(model, 3)
 set(model, VariablePrimalStart(), v2, [1.3,6.8,-4.6])
 ```
 
-A variable can be deleted from a model with [`delete!(::ModelLike, ::VariableIndex)`](@ref MathOptInterface.delete!(::MathOptInterface.ModelLike, ::MathOptInterface.Index)).
+A variable can be deleted from a model with [`delete(::ModelLike, ::VariableIndex)`](@ref MathOptInterface.delete(::MathOptInterface.ModelLike, ::MathOptInterface.Index)).
 Not all models support deleting variables; an [`DeleteNotAllowed`](@ref MathOptInterface.DeleteNotAllowed)
 error is thrown if this is not supported.
 

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -127,7 +127,7 @@ BasisStatusCode
 VariableIndex
 ConstraintIndex
 is_valid
-delete!(::ModelLike,::Index)
+delete(::ModelLike, ::Index)
 ```
 
 ### Variables

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -100,17 +100,17 @@ function MOI.is_valid(b::AbstractBridgeOptimizer, ci::CI)
         return MOI.is_valid(b.model, ci)
     end
 end
-MOI.delete!(b::AbstractBridgeOptimizer, vi::VI) = MOI.delete!(b.model, vi)
-function MOI.delete!(b::AbstractBridgeOptimizer, ci::CI)
+MOI.delete(b::AbstractBridgeOptimizer, vi::VI) = MOI.delete(b.model, vi)
+function MOI.delete(b::AbstractBridgeOptimizer, ci::CI)
     if isbridged(b, typeof(ci))
         if !MOI.is_valid(b, ci)
             throw(MOI.InvalidIndex(ci))
         end
-        MOI.delete!(b, bridge(b, ci))
+        MOI.delete(b, bridge(b, ci))
         delete!(b.bridges, ci)
-        MOI.delete!(b.bridged, ci)
+        MOI.delete(b.bridged, ci)
     else
-        MOI.delete!(b.model, ci)
+        MOI.delete(b.model, ci)
     end
 end
 

--- a/src/Bridges/detbridge.jl
+++ b/src/Bridges/detbridge.jl
@@ -122,12 +122,12 @@ MOI.get(b::LogDetBridge{T}, ::MOI.ListOfConstraintIndices{MOI.VectorAffineFuncti
 MOI.get(b::LogDetBridge{T}, ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}}) where T = [b.tlindex]
 
 # References
-function MOI.delete!(model::MOI.ModelLike, c::LogDetBridge)
-    MOI.delete!(model, c.tlindex)
-    MOI.delete!(model, c.lcindex)
-    MOI.delete!(model, c.sdindex)
-    MOI.delete!(model, c.l)
-    MOI.delete!(model, c.Δ)
+function MOI.delete(model::MOI.ModelLike, c::LogDetBridge)
+    MOI.delete(model, c.tlindex)
+    MOI.delete(model, c.lcindex)
+    MOI.delete(model, c.sdindex)
+    MOI.delete(model, c.l)
+    MOI.delete(model, c.Δ)
 end
 
 # Attributes, Bridge acting as a constraint
@@ -189,10 +189,10 @@ MOI.get(b::RootDetBridge{T}, ::MOI.ListOfConstraintIndices{MOI.VectorAffineFunct
 MOI.get(b::RootDetBridge{T}, ::MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{T}, MOI.GeometricMeanCone}) where T = [b.gmindex]
 
 # References
-function MOI.delete!(model::MOI.ModelLike, c::RootDetBridge)
-    MOI.delete!(model, c.gmindex)
-    MOI.delete!(model, c.sdindex)
-    MOI.delete!(model, c.Δ)
+function MOI.delete(model::MOI.ModelLike, c::RootDetBridge)
+    MOI.delete(model, c.gmindex)
+    MOI.delete(model, c.sdindex)
+    MOI.delete(model, c.Δ)
 end
 
 # Attributes, Bridge acting as a constraint

--- a/src/Bridges/geomeanbridge.jl
+++ b/src/Bridges/geomeanbridge.jl
@@ -133,10 +133,10 @@ function MOI.get(b::GeoMeanBridge{T, F, G},
 end
 
 # References
-function MOI.delete!(model::MOI.ModelLike, c::GeoMeanBridge)
-    MOI.delete!(model, c.xij)
-    MOI.delete!(model, c.tubc)
-    MOI.delete!(model, c.socrc)
+function MOI.delete(model::MOI.ModelLike, c::GeoMeanBridge)
+    MOI.delete(model, c.xij)
+    MOI.delete(model, c.tubc)
+    MOI.delete(model, c.socrc)
 end
 
 # Attributes, Bridge acting as a constraint

--- a/src/Bridges/intervalbridge.jl
+++ b/src/Bridges/intervalbridge.jl
@@ -30,9 +30,9 @@ MOI.get(b::SplitIntervalBridge{T, F}, ::MOI.ListOfConstraintIndices{F, MOI.Great
 MOI.get(b::SplitIntervalBridge{T, F}, ::MOI.ListOfConstraintIndices{F, MOI.LessThan{T}}) where {T, F} = [b.upper]
 
 # Indices
-function MOI.delete!(model::MOI.ModelLike, c::SplitIntervalBridge)
-    MOI.delete!(model, c.lower)
-    MOI.delete!(model, c.upper)
+function MOI.delete(model::MOI.ModelLike, c::SplitIntervalBridge)
+    MOI.delete(model, c.lower)
+    MOI.delete(model, c.upper)
 end
 
 # Attributes, Bridge acting as a constraint

--- a/src/Bridges/rsocbridge.jl
+++ b/src/Bridges/rsocbridge.jl
@@ -66,8 +66,8 @@ function MOI.get(b::RSOCBridge{T, F},
 end
 
 # References
-function MOI.delete!(model::MOI.ModelLike, c::RSOCBridge)
-    MOI.delete!(model, c.soc)
+function MOI.delete(model::MOI.ModelLike, c::RSOCBridge)
+    MOI.delete(model, c.soc)
 end
 
 # Attributes, Bridge acting as a constraint

--- a/src/Bridges/soctopsdbridge.jl
+++ b/src/Bridges/soctopsdbridge.jl
@@ -79,8 +79,8 @@ end
 MOI.get(::SOCtoPSDBridge{T}, ::MOI.NumberOfConstraints{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}) where T = 1
 MOI.get(b::SOCtoPSDBridge{T}, ::MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}) where T = [b.cr]
 
-function MOI.delete!(instance::MOI.AbstractOptimizer, c::SOCtoPSDBridge)
-    MOI.delete!(instance, c.cr)
+function MOI.delete(instance::MOI.AbstractOptimizer, c::SOCtoPSDBridge)
+    MOI.delete(instance, c.cr)
 end
 
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:SOCtoPSDBridge}) = false
@@ -145,8 +145,8 @@ end
 MOI.get(::RSOCtoPSDBridge{T}, ::MOI.NumberOfConstraints{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}) where T = 1
 MOI.get(b::RSOCtoPSDBridge{T}, ::MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle}) where T = [b.cr]
 
-function MOI.delete!(instance::MOI.AbstractOptimizer, c::RSOCtoPSDBridge)
-    MOI.delete!(instance, c.cr)
+function MOI.delete(instance::MOI.AbstractOptimizer, c::RSOCtoPSDBridge)
+    MOI.delete(instance, c.cr)
 end
 
 MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCtoPSDBridge}) = false

--- a/src/Bridges/squarepsdbridge.jl
+++ b/src/Bridges/squarepsdbridge.jl
@@ -142,10 +142,10 @@ function MOI.get(bridge::SquarePSDBridge{T, F, G},
 end
 
 # Indices
-function MOI.delete!(model::MOI.ModelLike, bridge::SquarePSDBridge)
-    MOI.delete!(model, bridge.psd)
+function MOI.delete(model::MOI.ModelLike, bridge::SquarePSDBridge)
+    MOI.delete(model, bridge.psd)
     for pair in bridge.sym
-        MOI.delete!(model, pair.second)
+        MOI.delete(model, pair.second)
     end
 end
 

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -217,9 +217,9 @@ function basic_constraint_test_helper(model::MOI.ModelLike, config::TestConfig, 
     end
 
     if delete
-        @testset "delete!" begin
+        @testset "delete" begin
             c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-            MOI.delete!(model, c_indices[1])
+            MOI.delete(model, c_indices[1])
             @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == length(c_indices)-1
             @test !MOI.is_valid(model, c_indices[1])
         end

--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -216,10 +216,10 @@ function solve_affine_deletion_edge_cases(model::MOI.ModelLike, config::TestConf
         constraint_primal = [(c1, [0.0]), (c2, 0.0)]
     )
     # now delete the VectorAffineFunction
-    MOI.delete!(model, c1)
-    @test_throws MOI.InvalidIndex{typeof(c1)} MOI.delete!(model, c1)
+    MOI.delete(model, c1)
+    @test_throws MOI.InvalidIndex{typeof(c1)} MOI.delete(model, c1)
     try
-        MOI.delete!(model, c1)
+        MOI.delete(model, c1)
     catch err
         @test err.index == c1
     end
@@ -232,7 +232,7 @@ function solve_affine_deletion_edge_cases(model::MOI.ModelLike, config::TestConf
         constraint_primal = [(c2, 1.0), (c3, [-1.0])]
     )
     # delete the ScalarAffineFunction
-    MOI.delete!(model, c2)
+    MOI.delete(model, c2)
     test_model_solution(model, config; objective_value = 2.0,
         constraint_primal = [(c3, [0.0])]
     )

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -56,7 +56,7 @@ function delete_variable(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-    MOI.delete!(model, v)
+    MOI.delete(model, v)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
 end
 unittests["delete_variable"] = delete_variable
@@ -72,15 +72,15 @@ function delete_variables(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-    MOI.delete!(model, v)
+    MOI.delete(model, v)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-    MOI.delete!(model, v[1])
+    MOI.delete(model, v[1])
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-    @test_throws MOI.InvalidIndex{MOI.VariableIndex} MOI.delete!(model, v[1])
+    @test_throws MOI.InvalidIndex{MOI.VariableIndex} MOI.delete(model, v[1])
     try
-        MOI.delete!(model, v[1])
+        MOI.delete(model, v[1])
     catch err
         @test err.index == v[1]
     end

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -138,7 +138,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.modify_lhs
         MOI.modify(model, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
     else
-        MOI.delete!(model, c)
+        MOI.delete(model, c)
         cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0,1.0], v), 0.0)
         c = MOI.add_constraint(model, cf, MOI.LessThan(1.0))
     end
@@ -205,7 +205,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     MOI.supports(model, MOI.ConstraintSet(), typeof(vc1))
     MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(0.0))
 
-    MOI.delete!(model, vc3)
+    MOI.delete(model, vc3)
 
     vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
@@ -228,7 +228,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # max x + 2z
     # s.t. x + y + z == 2 (c)
     # x,y >= 0, z = 0
-    MOI.delete!(model, c)
+    MOI.delete(model, c)
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
     cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,0.0,0.0,1.0,1.0,1.0,0.0,0.0,0.0], [v; v; v]), 0.0)
     c = MOI.add_constraint(model, cf, MOI.EqualTo(2.0))
@@ -337,7 +337,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # y >= 0, z = 0
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
-    MOI.delete!(model, v[1])
+    MOI.delete(model, v[1])
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
 
     if config.query
@@ -638,7 +638,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.modify_lhs
         MOI.modify(model, c1, MOI.ScalarCoefficientChange(y, 3.0))
     else
-        MOI.delete!(model, c1)
+        MOI.delete(model, c1)
         cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0)
         c1 = MOI.add_constraint(model, cf1, MOI.LessThan(4.0))
     end
@@ -662,7 +662,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #        x >= 0, y >= 0
     #
     #   solution: x = 4, y = 0, objv = 4
-    MOI.delete!(model, c1)
+    MOI.delete(model, c1)
 
     if config.solve
         MOI.optimize!(model)
@@ -683,7 +683,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #           y >= 0
     #
     #   solution: y = 2, objv = 2
-    MOI.delete!(model, x)
+    MOI.delete(model, x)
 
     if config.solve
         MOI.optimize!(model)
@@ -810,7 +810,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     if config.modify_lhs
         MOI.modify(model, c1, MOI.VectorConstantChange([-100.0]))
     else
-        MOI.delete!(model, c1)
+        MOI.delete(model, c1)
         c1 = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-100.0]), MOI.Nonnegatives(1))
     end
 
@@ -831,7 +831,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     if config.modify_lhs
         MOI.modify(model, c2, MOI.VectorConstantChange([100.0]))
     else
-        MOI.delete!(model, c2)
+        MOI.delete(model, c2)
         c2 = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [100.0]), MOI.Nonpositives(1))
     end
 
@@ -1349,7 +1349,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
         end
     end
 
-    MOI.delete!(model, [x, z])
+    MOI.delete(model, [x, z])
 
     if config.solve
         MOI.optimize!(model)

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -257,7 +257,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     # try delete quadratic constraint and go back to linear
 
     # FIXME why is this commented ?
-    # MOI.delete!(model, c2)
+    # MOI.delete(model, c2)
     #
     # MOI.optimize!(model)
     #

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -134,8 +134,8 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,1,2] atol=atol rtol=rtol
         end
 
-        MOI.delete!(model, c1)
-        MOI.delete!(model, c2)
+        MOI.delete(model, c1)
+        MOI.delete(model, c2)
 
         if config.solve
             MOI.optimize!(model)
@@ -220,7 +220,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         end
 
         for cref in bin_constraints
-            MOI.delete!(model, cref)
+            MOI.delete(model, cref)
         end
 
         if config.solve

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -69,10 +69,10 @@ function nametest(model::MOI.ModelLike)
         @test MOI.get(model, MOI.ConstraintIndex, "Con0") == c2
         @test MOI.get(model, MOI.ConstraintIndex, "Con1") == c
 
-        MOI.delete!(model, v[2])
+        MOI.delete(model, v[2])
         @test MOI.get(model, MOI.VariableIndex, "Var2") === nothing
 
-        MOI.delete!(model, c)
+        MOI.delete(model, c)
         @test MOI.get(model, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}, "Con1") === nothing
         @test MOI.get(model, MOI.ConstraintIndex, "Con1") === nothing
     end
@@ -85,7 +85,7 @@ function validtest(model::MOI.ModelLike)
     @test MOI.is_valid(model, v[2])
     x = MOI.add_variable(model)
     @test MOI.is_valid(model, x)
-    MOI.delete!(model, x)
+    MOI.delete(model, x)
     @test !MOI.is_valid(model, x)
     cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0)
     @test MOI.supports_constraint(model, typeof(cf), MOI.LessThan{Float64})
@@ -256,7 +256,7 @@ function orderedindicestest(model::MOI.ModelLike)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v1]
     v2 = MOI.add_variable(model)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v1, v2]
-    MOI.delete!(model, v1)
+    MOI.delete(model, v1)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v2]
     v3 = MOI.add_variable(model)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v2, v3]
@@ -269,7 +269,7 @@ function orderedindicestest(model::MOI.ModelLike)
     @test MOI.get(model, MOI.ListOfConstraintIndices{MOI.SingleVariable, MOI.LessThan{Float64}}()) == [c1]
     c2 = MOI.add_constraint(model, MOI.SingleVariable(v3), MOI.LessThan(2.0))
     @test MOI.get(model, MOI.ListOfConstraintIndices{MOI.SingleVariable, MOI.LessThan{Float64}}()) == [c1, c2]
-    MOI.delete!(model, c1)
+    MOI.delete(model, c1)
     @test MOI.get(model, MOI.ListOfConstraintIndices{MOI.SingleVariable, MOI.LessThan{Float64}}()) == [c2]
     c3 = MOI.add_constraint(model, MOI.SingleVariable(v4), MOI.LessThan(3.0))
     @test MOI.get(model, MOI.ListOfConstraintIndices{MOI.SingleVariable, MOI.LessThan{Float64}}()) == [c2, c3]

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -317,7 +317,7 @@ end
 
 MOI.is_valid(m::CachingOptimizer, index::MOI.Index) = MOI.is_valid(m.model_cache, index)
 
-function MOI.delete!(m::CachingOptimizer, index::MOI.Index)
+function MOI.delete(m::CachingOptimizer, index::MOI.Index)
     if m.state == AttachedOptimizer
         if !MOI.is_valid(m, index)
             # The index thrown by m.model_cache would be xored
@@ -326,7 +326,7 @@ function MOI.delete!(m::CachingOptimizer, index::MOI.Index)
         index_optimizer = m.model_to_optimizer_map[index]
         if m.mode == Automatic
             try
-                MOI.delete!(m.optimizer, index_optimizer)
+                MOI.delete(m.optimizer, index_optimizer)
             catch err
                 if err isa MOI.NotAllowedError
                     resetoptimizer!(m)
@@ -335,7 +335,7 @@ function MOI.delete!(m::CachingOptimizer, index::MOI.Index)
                 end
             end
         else
-            MOI.delete!(m.optimizer, index_optimizer)
+            MOI.delete(m.optimizer, index_optimizer)
         end
     end
     # The state may have changed in Automatic mode since resetoptimizer! is
@@ -344,7 +344,7 @@ function MOI.delete!(m::CachingOptimizer, index::MOI.Index)
         delete!(m.optimizer_to_model_map, m.model_to_optimizer_map[index])
         delete!(m.model_to_optimizer_map, index)
     end
-    MOI.delete!(m.model_cache, index)
+    MOI.delete(m.model_cache, index)
 end
 
 

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -221,7 +221,7 @@ end
 
 MOI.is_valid(mock::MockOptimizer, idx::MOI.Index) = MOI.is_valid(mock.inner_model, xor_index(idx))
 
-function MOI.delete!(mock::MockOptimizer, index::MOI.VariableIndex)
+function MOI.delete(mock::MockOptimizer, index::MOI.VariableIndex)
     if !mock.delete_allowed
         throw(MOI.DeleteNotAllowed(index))
     end
@@ -229,10 +229,10 @@ function MOI.delete!(mock::MockOptimizer, index::MOI.VariableIndex)
         # The index thrown by `mock.inner_model` would be xored
         throw(MOI.InvalidIndex(index))
     end
-    MOI.delete!(mock.inner_model, xor_index(index))
-    MOI.delete!(mock.varprimal, index)
+    MOI.delete(mock.inner_model, xor_index(index))
+    delete!(mock.varprimal, index)
 end
-function MOI.delete!(mock::MockOptimizer, index::MOI.ConstraintIndex)
+function MOI.delete(mock::MockOptimizer, index::MOI.ConstraintIndex)
     if !mock.delete_allowed
         throw(MOI.DeleteNotAllowed(index))
     end
@@ -240,8 +240,8 @@ function MOI.delete!(mock::MockOptimizer, index::MOI.ConstraintIndex)
         # The index thrown by `mock.inner_model` would be xored
         throw(MOI.InvalidIndex(index))
     end
-    MOI.delete!(mock.inner_model, xor_index(index))
-    MOI.delete!(mock.condual, index)
+    MOI.delete(mock.inner_model, xor_index(index))
+    delete!(mock.condual, index)
 end
 
 function MOI.modify(mock::MockOptimizer, c::CI, change::MOI.AbstractFunctionModification)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -8,7 +8,7 @@ function _add_constraint(constrs::Vector{C{F, S}}, ci::CI, f::F, s::S) where {F,
     length(constrs)
 end
 
-function _delete!(constrs::Vector, ci::CI, i::Int)
+function _delete(constrs::Vector, ci::CI, i::Int)
     deleteat!(constrs, i)
     @view constrs[i:end] # will need to shift it in constrmap
 end
@@ -101,14 +101,14 @@ function _removevar!(constrs::Vector{<:C{MOI.SingleVariable}}, vi::VI)
     end
     rm
 end
-function MOI.delete!(model::AbstractModel, vi::VI)
+function MOI.delete(model::AbstractModel, vi::VI)
     if !MOI.is_valid(model, vi)
         throw(MOI.InvalidIndex(vi))
     end
     model.objective = removevariable(model.objective, vi)
     rm = broadcastvcat(constrs -> _removevar!(constrs, vi), model)
     for ci in rm
-        MOI.delete!(model, ci)
+        MOI.delete(model, ci)
     end
     delete!(model.varindices, vi)
     if haskey(model.varnames, vi)
@@ -278,11 +278,11 @@ function MOI.add_constraint(model::AbstractModel, f::F, s::S) where {F<:MOI.Abst
     end
 end
 
-function MOI.delete!(model::AbstractModel, ci::CI)
+function MOI.delete(model::AbstractModel, ci::CI)
     if !MOI.is_valid(model, ci)
         throw(MOI.InvalidIndex(ci))
     end
-    for (ci_next, _, _) in _delete!(model, ci, getconstrloc(model, ci))
+    for (ci_next, _, _) in _delete(model, ci, getconstrloc(model, ci))
         model.constrmap[ci_next.value] -= 1
     end
     model.constrmap[ci.value] = 0
@@ -575,7 +575,7 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
         end
     end
 
-    for (func, T) in ((:_add_constraint, CI), (:_modify, CI), (:_delete!, CI), (:_getindex, CI), (:_getfunction, CI), (:_getset, CI), (:_getnoc, MOI.NumberOfConstraints))
+    for (func, T) in ((:_add_constraint, CI), (:_modify, CI), (:_delete, CI), (:_getindex, CI), (:_getfunction, CI), (:_getset, CI), (:_getnoc, MOI.NumberOfConstraints))
         funct = _mod(MOIU, func)
         for (c, sets) in ((scname, scalarsets), (vcname, vectorsets))
             for s in sets

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -57,14 +57,14 @@ function MOI.is_valid(uf::UniversalFallback, idx::CI{F, S}) where {F, S}
         haskey(uf.constraints, (F, S)) && haskey(uf.constraints[(F, S)], idx)
     end
 end
-function MOI.delete!(uf::UniversalFallback, ci::CI{F, S}) where {F, S}
+function MOI.delete(uf::UniversalFallback, ci::CI{F, S}) where {F, S}
     if MOI.supports_constraint(uf.model, F, S)
-        MOI.delete!(uf.model, ci)
+        MOI.delete(uf.model, ci)
     else
         if !MOI.is_valid(uf, ci)
             throw(MOI.InvalidIndex(ci))
         end
-        MOI.delete!(uf.constraints[(F, S)], ci)
+        delete!(uf.constraints[(F, S)], ci)
         if haskey(uf.connames, ci)
             delete!(uf.namescon, uf.connames[ci])
             delete!(uf.connames, ci)
@@ -74,8 +74,8 @@ function MOI.delete!(uf::UniversalFallback, ci::CI{F, S}) where {F, S}
         delete!(d, ci)
     end
 end
-function MOI.delete!(uf::UniversalFallback, vi::VI)
-    MOI.delete!(uf.model, vi)
+function MOI.delete(uf::UniversalFallback, vi::VI)
+    MOI.delete(uf.model, vi)
     for d in values(uf.varattr)
         delete!(d, vi)
     end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -108,6 +108,6 @@ function transform end
 # default fallback
 function transform(model::ModelLike, c::ConstraintIndex, newset)
     f = get(model, ConstraintFunction(), c)
-    delete!(model, c)
+    delete(model, c)
     add_constraint(model, f, newset)
 end

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -67,20 +67,20 @@ function operation_name(err::DeleteNotAllowed)
 end
 
 """
-    delete!(model::ModelLike, index::Index)
+    delete(model::ModelLike, index::Index)
 
 Delete the referenced object from the model.
 """
-Base.delete!(model::ModelLike, index::Index) = throw(DeleteNotAllowed(index))
+delete(model::ModelLike, index::Index) = throw(DeleteNotAllowed(index))
 
 """
-    delete!{R}(model::ModelLike, indices::Vector{R<:Index})
+    delete{R}(model::ModelLike, indices::Vector{R<:Index})
 
 Delete the referenced objects in the vector `indices` from the model.
 It may be assumed that `R` is a concrete type.
 """
-function Base.delete!(model::ModelLike, indices::Vector{<:Index})
+function delete(model::ModelLike, indices::Vector{<:Index})
     for index in indices
-        Base.delete!(model, index)
+        delete(model, index)
     end
 end

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -15,10 +15,10 @@ function test_delete_bridge(m::MOIB.AbstractBridgeOptimizer, ci::MOI.ConstraintI
         test_noc(m, noc...)
     end
     @test MOI.is_valid(m, ci)
-    MOI.delete!(m, ci)
-    @test_throws MOI.InvalidIndex{typeof(ci)} MOI.delete!(m, ci)
+    MOI.delete(m, ci)
+    @test_throws MOI.InvalidIndex{typeof(ci)} MOI.delete(m, ci)
     try
-        MOI.delete!(m, ci)
+        MOI.delete(m, ci)
     catch err
         @test err.index == ci
     end
@@ -95,7 +95,7 @@ end
         @test (@inferred MOI.get(model, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Int},MOI.GreaterThan{Int}}())) == [c2]
 
         @test MOI.is_valid(model, c2)
-        MOI.delete!(model, c2)
+        MOI.delete(model, c2)
 
         @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.ScalarAffineFunction{Int},MOI.Interval{Int})]
         test_noc(model, MOI.ScalarAffineFunction{Int}, MOI.GreaterThan{Int}, 0)

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -65,8 +65,8 @@
     MOI.set(m, MOI.ConstraintSet(), lb, MOI.LessThan(12.0))
     @test MOI.get(m, MOI.ConstraintSet(), lb) == MOI.LessThan(12.0)
 
-    MOI.delete!(m, x[2])
-    @test_throws MOI.InvalidIndex{typeof(x[2])} MOI.delete!(m, x[2])
+    MOI.delete(m, x[2])
+    @test_throws MOI.InvalidIndex{typeof(x[2])} MOI.delete(m, x[2])
     @test !MOI.is_valid(m, x[2])
 
     # TODO: test more constraint modifications
@@ -165,7 +165,7 @@ end
     @testset "Delete not allowed" begin
         vi = MOI.add_variable(m)
         s.delete_allowed = false # Simulate optimizer that cannot delete variable
-        MOI.delete!(m, vi)
+        MOI.delete(m, vi)
         s.delete_allowed = true
         @test MOIU.state(m) == MOIU.EmptyOptimizer
         MOIU.attachoptimizer!(m)
@@ -174,7 +174,7 @@ end
         vi = MOI.add_variable(m)
         ci = MOI.add_constraint(m, MOI.SingleVariable(vi), MOI.EqualTo(0.0))
         s.delete_allowed = false # Simulate optimizer that cannot delete constraint
-        MOI.delete!(m, ci)
+        MOI.delete(m, ci)
         s.delete_allowed = true
         @test MOIU.state(m) == MOIU.EmptyOptimizer
         MOIU.attachoptimizer!(m)

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -77,9 +77,9 @@ MOI.supports_constraint(::DummyModel, ::Type{MOI.VectorOfVariables},
     ci = MOI.ConstraintIndex{MOI.SingleVariable, MOI.EqualTo{Float64}}(1)
 
     @testset "DeleteNotAllowed" begin
-        @test_throws MOI.DeleteNotAllowed{typeof(vi)} MOI.delete!(model, vi)
+        @test_throws MOI.DeleteNotAllowed{typeof(vi)} MOI.delete(model, vi)
         try
-            MOI.delete!(model, vi)
+            MOI.delete(model, vi)
         catch err
             @test sprint(showerror, err) == "MathOptInterface.DeleteNotAllowed{MathOptInterface.VariableIndex}:" *
             " Deleting the index MathOptInterface.VariableIndex(1) cannot be" *
@@ -88,9 +88,9 @@ MOI.supports_constraint(::DummyModel, ::Type{MOI.VectorOfVariables},
             " before doing this operation if the `CachingOptimizer` is in" *
             " `Manual` mode."
         end
-        @test_throws MOI.DeleteNotAllowed{typeof(ci)} MOI.delete!(model, ci)
+        @test_throws MOI.DeleteNotAllowed{typeof(ci)} MOI.delete(model, ci)
         try
-            MOI.delete!(model, ci)
+            MOI.delete(model, ci)
         catch err
             @test sprint(showerror, err) == "MathOptInterface.DeleteNotAllowed{MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable,MathOptInterface.EqualTo{Float64}}}:" *
             " Deleting the index MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable,MathOptInterface.EqualTo{Float64}}(1)" *

--- a/test/model.jl
+++ b/test/model.jl
@@ -96,13 +96,13 @@ end
     end
 
     @test MOI.is_valid(model, c4)
-    MOI.delete!(model, c4)
+    MOI.delete(model, c4)
     @test !MOI.is_valid(model, c4)
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Int},MOI.SecondOrderCone}()) == 1
     @test MOI.get(model, MOI.ConstraintFunction(), c6).constants == f6.constants
 
-    MOI.delete!(model, y)
+    MOI.delete(model, y)
 
     f = MOI.get(model, MOI.ConstraintFunction(), c2)
     @test f.affine_terms == MOI.VectorAffineTerm.([1, 2], MOI.ScalarAffineTerm.([3, 1], [x, x]))

--- a/test/universalfallback.jl
+++ b/test/universalfallback.jl
@@ -30,9 +30,9 @@ function test_varconattrs(uf, model, attr, listattr, I::Type{<:MOI.Index}, addfu
     @test MOI.get(uf, listattr) == [attr]
 
     @test MOI.is_valid(uf, u)
-    MOI.delete!(uf, u)
+    MOI.delete(uf, u)
     @test !MOI.is_valid(uf, u)
-    @test_throws MOI.InvalidIndex{typeof(u)} MOI.delete!(uf, u)
+    @test_throws MOI.InvalidIndex{typeof(u)} MOI.delete(uf, u)
     @test MOI.get(uf, listattr) == [attr]
 
     MOI.set(uf, attr, [w, z], [9, 4])
@@ -111,7 +111,7 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
             MOI.set(uf, MOI.ConstraintName(), cx, "LessThan")
             @test MOI.get(uf, MOI.ConstraintName(), cx) == "LessThan"
             @test MOI.get(uf, typeof(cx), "LessThan") == cx
-            MOI.delete!(uf, cx)
+            MOI.delete(uf, cx)
             @test MOI.get(uf, typeof(cx), "LessThan") === nothing
         end
         # To remove the constraint attributes added in the previous testset
@@ -134,7 +134,7 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
             MOI.set(uf, MOI.ConstraintName(), cx, "EqualTo")
             @test MOI.get(uf, MOI.ConstraintName(), cx) == "EqualTo"
             @test MOI.get(uf, typeof(cx), "EqualTo") == cx
-            MOI.delete!(uf, cx)
+            MOI.delete(uf, cx)
             @test MOI.get(uf, typeof(cx), "EqualTo") === nothing
         end
     end


### PR DESCRIPTION
Note that `MOIU.IndexMap` still overloads `Base.delete!` as it is a dictionary-like object and not a `ModelLike`.
Since `MOI.delete!` used to be equivalent `Base.delete!` this renaming wasn't just a matter of search and replace :-P It might be a good thing for code readability that these are now different.

Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/475