### PR TITLE
Rename PSDC -> PSD

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -336,7 +336,7 @@ Bridges.RSOCBridge
 Bridges.GeoMeanBridge
 Bridges.RootDetBridge
 Bridges.LogDetBridge
-Bridges.SOCtoPSDCBridge
-Bridges.RSOCtoPSDCBridge
+Bridges.SOCtoPSDBridge
+Bridges.RSOCtoPSDBridge
 ```
 For each bridge defined in this package, a corresponding bridge optimizer is available with the same name without the "Bridge" suffix, e.g., `SplitInterval` is an `SingleBridgeOptimizer` for the `SplitIntervalBridge`.

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -38,8 +38,8 @@ function fullbridgeoptimizer(model::MOI.ModelLike, ::Type{T}) where T
     addbridge!(bridgedmodel, MOIB.LogDetBridge{T})
     addbridge!(bridgedmodel, MOIB.RootDetBridge{T})
     addbridge!(bridgedmodel, MOIB.RSOCBridge{T})
-    addbridge!(bridgedmodel, MOIB.RSOCtoPSDCBridge{T})
-    addbridge!(bridgedmodel, MOIB.SOCtoPSDCBridge{T})
+    addbridge!(bridgedmodel, MOIB.RSOCtoPSDBridge{T})
+    addbridge!(bridgedmodel, MOIB.SOCtoPSDBridge{T})
     bridgedmodel
 end
 
@@ -55,7 +55,7 @@ include("detbridge.jl")
 @bridge LogDet LogDetBridge () () (LogDetConeTriangle,) () () () (VectorOfVariables,) (VectorAffineFunction,)
 @bridge RootDet RootDetBridge () () (RootDetConeTriangle,) () () () (VectorOfVariables,) (VectorAffineFunction,)
 include("soctopsdbridge.jl")
-@bridge SOCtoPSD SOCtoPSDCBridge () () (SecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
-@bridge RSOCtoPSD RSOCtoPSDCBridge () () (RotatedSecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
+@bridge SOCtoPSD SOCtoPSDBridge () () (SecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
+@bridge RSOCtoPSD RSOCtoPSDBridge () () (RotatedSecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
 
 end # module

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -115,8 +115,8 @@ MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, No
     mock = MOIU.MockOptimizer(NoRSOCModel{Float64}())
     bridgedmock = MOIB.LazyBridgeOptimizer(mock, Model{Float64}())
     MOIB.addbridge!(bridgedmock, MOIB.SplitIntervalBridge{Float64})
-    MOIB.addbridge!(bridgedmock, MOIB.RSOCtoPSDCBridge{Float64})
-    MOIB.addbridge!(bridgedmock, MOIB.SOCtoPSDCBridge{Float64})
+    MOIB.addbridge!(bridgedmock, MOIB.RSOCtoPSDBridge{Float64})
+    MOIB.addbridge!(bridgedmock, MOIB.SOCtoPSDBridge{Float64})
     MOIB.addbridge!(bridgedmock, MOIB.RSOCBridge{Float64})
 
     @testset "Name test" begin
@@ -137,7 +137,7 @@ MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, No
         @test !(MOI.supports_constraint(bridgedmock, MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle))
         x = MOI.add_variables(bridgedmock, 3)
         c = MOI.add_constraint(bridgedmock, MOI.VectorOfVariables(x), MOI.RotatedSecondOrderCone(3))
-        @test MOIB.bridge(bridgedmock, c) isa MOIB.RSOCtoPSDCBridge
+        @test MOIB.bridge(bridgedmock, c) isa MOIB.RSOCtoPSDBridge
         @test bridgedmock.dist[(MathOptInterface.VectorOfVariables, MathOptInterface.RotatedSecondOrderCone)] == 1
     end
 


### PR DESCRIPTION
This was inconsistent with the name of the file containing the bridge and the bridge optimizers `SOCtoPSD`  and `RSOCtoPSD` which did not contain the C.