### PR TITLE
Define convert

### DIFF
--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -78,6 +78,9 @@ function get_objective_function(model::MOI.ModelLike, config::TestConfig)
     end
     obj_fun = MOI.get(model, obj_attr)
     @test obj_fun ≈ expected_obj_fun
+    quad_obj_attr = MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}()
+    quad_obj_fun = MOI.get(model, quad_obj_attr)
+    @test convert(MOI.ScalarAffineFunction{Float64}, quad_obj_fun) ≈ expected_obj_fun
 end
 unittests["get_objective_function"] = get_objective_function
 

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -97,15 +97,6 @@ end
 constant(f::Union{SAF, SQF}) = [f.constant]
 constant(f::Union{VAF, VQF}) = f.constants
 
-# Define conversion SingleVariable -> ScalarAffineFunction and VectorOfVariables -> VectorAffineFunction{T}
-function SAF{T}(f::SVF) where T
-    SAF([MOI.ScalarAffineTerm(one(T), f.variable)], zero(T))
-end
-function VAF{T}(f::VVF) where T
-    n = length(f.variables)
-    return VAF(map(i -> MOI.VectorAffineTerm(i, MOI.ScalarAffineTerm(one(T), f.variables[i])), 1:n), zeros(T, n))
-end
-
 # Implements iterator interface
 """
     scalar_type(F::Type{<:MOI.AbstractVectorFunction})

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -232,14 +232,7 @@ function MOI.get(model::AbstractModel, ::MOI.ObjectiveFunctionType)
     return MOI.typeof(model.objective)
 end
 function MOI.get(model::AbstractModel, ::MOI.ObjectiveFunction{T})::T where T
-    if typeof(model.objective) != T
-        if VERSION >= v"0.7-"
-            throw(InexactError(:get, T, model.objective))
-        else
-            throw(InexactError())
-        end
-    end
-    model.objective
+    return model.objective
 end
 MOI.supports(model::AbstractModel, ::MOI.ObjectiveFunction) = true
 function MOI.set(model::AbstractModel, ::MOI.ObjectiveFunction, f::MOI.AbstractFunction)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -381,6 +381,10 @@ function VectorAffineFunction{T}(f::VectorOfVariables) where T
     return VectorAffineFunction(map(i -> VectorAffineTerm(i, ScalarAffineTerm(one(T), f.variables[i])), 1:n), zeros(T, n))
 end
 
+if VERSION < v"0.7-"
+    isone(x::T) = x == one(T)
+end
+
 # Conversion between scalar functions
 # Conversion to SingleVariable
 function Base.convert(::Type{SingleVariable}, f::ScalarAffineFunction)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -382,7 +382,7 @@ function VectorAffineFunction{T}(f::VectorOfVariables) where T
 end
 
 if VERSION < v"0.7-"
-    isone(x::T) = x == one(T)
+    isone(x) = x == one(x)
 end
 
 # Conversion between scalar functions

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -269,7 +269,7 @@ function MultirowChange(variable::VariableIndex, new_coefficients::Vector{Tuple{
     MultirowChange(variable, [(convert(Int64, i), j) for (i,j) in new_coefficients])
 end
 
-# Implementation of comparison for MOI functions
+# Implementation of comparison for functions
 Base.:(==)(f::VectorOfVariables, g::VectorOfVariables) = f.variables == g.variables
 
 Base.isapprox(f::Union{SingleVariable, VectorOfVariables}, g::Union{SingleVariable, VectorOfVariables}; kwargs...) = f == g
@@ -369,3 +369,59 @@ Return a new quadratic function with a shallow copy of the terms and constant(s)
 from `func`.
 """
 Base.copy(func::F) where {F <: Union{ScalarQuadraticFunction, VectorQuadraticFunction}} = F(copy(func.affine_terms), copy(func.quadratic_terms), copy(_constant(func)))
+
+# Define shortcuts for
+# SingleVariable -> ScalarAffineFunction
+function ScalarAffineFunction{T}(f::SingleVariable) where T
+    ScalarAffineFunction([ScalarAffineTerm(one(T), f.variable)], zero(T))
+end
+# VectorOfVariables -> VectorAffineFunction
+function VectorAffineFunction{T}(f::VectorOfVariables) where T
+    n = length(f.variables)
+    return VectorAffineFunction(map(i -> VectorAffineTerm(i, ScalarAffineTerm(one(T), f.variables[i])), 1:n), zeros(T, n))
+end
+
+# Conversion between scalar functions
+# Conversion to SingleVariable
+function Base.convert(::Type{SingleVariable}, f::ScalarAffineFunction)
+    if !iszero(f.constant) || !isone(length(f.terms)) || !isone(f.terms[1].coefficient)
+        if VERSION >= v"0.7-"
+            throw(InexactError(:convert, SingleVariable, f))
+        else
+            throw(InexactError())
+        end
+    end
+    return SingleVariable(f.terms[1].variable_index)
+end
+function Base.convert(::Type{SingleVariable},
+                      f::ScalarQuadraticFunction{T}) where T
+    return convert(SingleVariable, convert(ScalarAffineFunction{T}, f))
+end
+
+# Conversion to ScalarAffineFunction
+function Base.convert(::Type{ScalarAffineFunction{T}},
+                      f::SingleVariable) where T
+    return ScalarAffineFunction{T}(f)
+end
+function Base.convert(::Type{ScalarAffineFunction{T}},
+                      f::ScalarQuadraticFunction{T}) where T
+    if !Base.isempty(f.quadratic_terms)
+        if VERSION >= v"0.7-"
+            throw(InexactError(:convert, ScalarAffineFunction{T}, f))
+        else
+            throw(InexactError())
+        end
+    end
+    return ScalarAffineFunction{T}(f.affine_terms, f.constant)
+end
+
+# Conversion to ScalarQuadraticFunction
+function Base.convert(::Type{ScalarQuadraticFunction{T}},
+                      f::SingleVariable) where T
+    convert(ScalarQuadraticFunction{T}, convert(ScalarAffineFunction{T}, f))
+end
+function Base.convert(::Type{ScalarQuadraticFunction{T}},
+                      f::ScalarAffineFunction{T}) where T
+    return ScalarQuadraticFunction{T}(f.terms, ScalarQuadraticTerm{T}[],
+                                      f.constant)
+end

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -191,6 +191,15 @@
             end
             f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2, 4], [x, y]),
                                          5)
+            @testset "convert" begin
+                @test_throws InexactError convert(MOI.SingleVariable, f)
+                quad_f = MOI.ScalarQuadraticFunction(f.terms,
+                                                     MOI.ScalarQuadraticTerm{Int}[],
+                                                     f.constant)
+                @test convert(MOI.ScalarQuadraticFunction{Int}, f) ≈ quad_f
+                g = convert(MOI.ScalarAffineFunction{Float64}, MOI.SingleVariable(x))
+                @test convert(MOI.SingleVariable, g) == MOI.SingleVariable(x)
+            end
             @testset "operate" begin
                 f = MOIU.canonical(MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1, 3, 1, 2, -3, 2],
                                                                                   [w, y, w, x,  x, z]), 2) +
@@ -252,6 +261,13 @@
                 MOIU.canonicalize!(g)
                 @test MOIU.isapprox_zero(g, 1e-5)
                 @test !MOIU.isapprox_zero(g, 1e-7)
+            end
+            @testset "convert" begin
+                @test_throws InexactError convert(MOI.SingleVariable, f)
+                @test_throws InexactError convert(MOI.ScalarAffineFunction{Int},
+                                                  f)
+                g = convert(MOI.ScalarQuadraticFunction{Float64}, fx)
+                @test convert(MOI.SingleVariable, g) == fx
             end
             @testset "operate" begin
                 @test f ≈ 7 + (fx + 2fy) * (1fx + fy) + 3fx


### PR DESCRIPTION
It will be quite hard to implement `MOI.get(::OptimizerType, ::ObjectiveFunction{T})` passing the unit test added in https://github.com/JuliaOpt/MathOptInterface.jl/pull/502 without the convert functions added in this PR.

The two conversions that were present in MOIU were moved to MOI as they do not add utilites but rather define constructor of MOI types.