### PR TITLE
Support of bridges with external sets/funcs

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -24,7 +24,7 @@ include("singlebridgeoptimizer.jl")
 include("lazybridgeoptimizer.jl")
 
 # This is used by JuMP and removes the need to update JuMP everytime a bridge is added
-MOIU.@model AllBridgedConstraints () (Interval,) (SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, LogDetConeTriangle, RootDetConeTriangle) () () (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
+MOIU.@model AllBridgedConstraints () (MOI.Interval,) (MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone, MOI.LogDetConeTriangle, MOI.RootDetConeTriangle) () () (MOI.ScalarAffineFunction,) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 """
     fullbridgeoptimizer(model::MOI.ModelLike, ::Type{T}) where T
 
@@ -44,18 +44,18 @@ function fullbridgeoptimizer(model::MOI.ModelLike, ::Type{T}) where T
 end
 
 include("intervalbridge.jl")
-@bridge SplitInterval SplitIntervalBridge () (Interval,) () () (SingleVariable,) (ScalarAffineFunction, ScalarQuadraticFunction) () ()
+@bridge SplitInterval SplitIntervalBridge () (MOI.Interval,) () () (MOI.SingleVariable,) (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction) () ()
 include("rsocbridge.jl")
-@bridge RSOC RSOCBridge () () (RotatedSecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
+@bridge RSOC RSOCBridge () () (MOI.RotatedSecondOrderCone,) () () () (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 include("geomeanbridge.jl")
-@bridge GeoMean GeoMeanBridge () () (GeometricMeanCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
+@bridge GeoMean GeoMeanBridge () () (MOI.GeometricMeanCone,) () () () (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 include("squarepsdbridge.jl")
-@bridge SquarePSD SquarePSDBridge () () (PositiveSemidefiniteConeSquare,) () () () (VectorOfVariables,) (VectorAffineFunction, VectorQuadraticFunction)
+@bridge SquarePSD SquarePSDBridge () () (MOI.PositiveSemidefiniteConeSquare,) () () () (MOI.VectorOfVariables,) (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction)
 include("detbridge.jl")
-@bridge LogDet LogDetBridge () () (LogDetConeTriangle,) () () () (VectorOfVariables,) (VectorAffineFunction,)
-@bridge RootDet RootDetBridge () () (RootDetConeTriangle,) () () () (VectorOfVariables,) (VectorAffineFunction,)
+@bridge LogDet LogDetBridge () () (MOI.LogDetConeTriangle,) () () () (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
+@bridge RootDet RootDetBridge () () (MOI.RootDetConeTriangle,) () () () (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 include("soctopsdbridge.jl")
-@bridge SOCtoPSD SOCtoPSDBridge () () (SecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
-@bridge RSOCtoPSD RSOCtoPSDBridge () () (RotatedSecondOrderCone,) () () () (VectorOfVariables,) (VectorAffineFunction,)
+@bridge SOCtoPSD SOCtoPSDBridge () () (MOI.SecondOrderCone,) () () () (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
+@bridge RSOCtoPSD RSOCtoPSDBridge () () (MOI.RotatedSecondOrderCone,) () () () (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 
 end # module

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -24,7 +24,16 @@ include("singlebridgeoptimizer.jl")
 include("lazybridgeoptimizer.jl")
 
 # This is used by JuMP and removes the need to update JuMP everytime a bridge is added
-MOIU.@model AllBridgedConstraints () (MOI.Interval,) (MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone, MOI.LogDetConeTriangle, MOI.RootDetConeTriangle) () () (MOI.ScalarAffineFunction,) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
+MOIU.@model(AllBridgedConstraints,
+            (),
+            (MOI.Interval,),
+            (MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone,
+             MOI.LogDetConeTriangle, MOI.RootDetConeTriangle),
+            (),
+            (),
+            (MOI.ScalarAffineFunction,),
+            (MOI.VectorOfVariables,),
+            (MOI.VectorAffineFunction,))
 """
     fullbridgeoptimizer(model::MOI.ModelLike, ::Type{T}) where T
 

--- a/src/Bridges/singlebridgeoptimizer.jl
+++ b/src/Bridges/singlebridgeoptimizer.jl
@@ -17,7 +17,7 @@ is_bridged(b::SingleBridgeOptimizer, ::Type{<:MOI.AbstractFunction}, ::Type{<:MO
 bridge_type(b::SingleBridgeOptimizer{BT}, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet}) where BT = BT
 
 # :((Zeros, SecondOrderCone)) -> (:(MOI.Zeros), :(MOI.SecondOrderCone))
-_tuple_prefix_moi(t) = MOIU._moi.(t.args)
+_tuple_prefix_moi(t) = t.args
 
 """
 macro bridge(modelname, bridge, scalarsets, typedscalarsets, vectorsets, typedvectorsets, scalarfunctions, typedscalarfunctions, vectorfunctions, typedvectorfunctions)
@@ -39,8 +39,8 @@ will additionally support `ScalarAffineFunction`-in-`Interval`.
 """
 macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
     bridged_model_name = Symbol(string(modelname) * "Instance")
-    bridged_funs = :(Union{$(_tuple_prefix_moi(sf)...), $(_tuple_prefix_moi(sft)...), $(_tuple_prefix_moi(vf)...), $(_tuple_prefix_moi(vft)...)})
-    bridged_sets = :(Union{$(_tuple_prefix_moi(ss)...), $(_tuple_prefix_moi(sst)...), $(_tuple_prefix_moi(vs)...), $(_tuple_prefix_moi(vst)...)})
+    bridged_funs = :(Union{$((sf.args)...), $((sft.args)...), $((vf.args)...), $((vft.args)...)})
+    bridged_sets = :(Union{$((ss.args)...), $((sst.args)...), $((vs.args)...), $((vst.args)...)})
 
     esc(quote
         $MOIU.@model $bridged_model_name $ss $sst $vs $vst $sf $sft $vf $vft

--- a/src/Bridges/singlebridgeoptimizer.jl
+++ b/src/Bridges/singlebridgeoptimizer.jl
@@ -45,7 +45,7 @@ macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
     esc(quote
         $MOIU.@model $bridged_model_name $ss $sst $vs $vst $sf $sft $vf $vft
         const $modelname{T, OT<:MOI.ModelLike} = $MOIB.SingleBridgeOptimizer{$bridge{T}, $bridged_model_name{T}, OT}
-        is_bridged(::$modelname, ::Type{<:$bridged_funs}, ::Type{<:$bridged_sets}) = true
+        MathOptInterface.Bridges.is_bridged(::$modelname, ::Type{<:$bridged_funs}, ::Type{<:$bridged_sets}) = true
         supports_bridging_constraint(::$modelname, ::Type{<:$bridged_funs}, ::Type{<:$bridged_sets}) = true
     end)
 end

--- a/src/Bridges/singlebridgeoptimizer.jl
+++ b/src/Bridges/singlebridgeoptimizer.jl
@@ -45,7 +45,7 @@ macro bridge(modelname, bridge, ss, sst, vs, vst, sf, sft, vf, vft)
     esc(quote
         $MOIU.@model $bridged_model_name $ss $sst $vs $vst $sf $sft $vf $vft
         const $modelname{T, OT<:MOI.ModelLike} = $MOIB.SingleBridgeOptimizer{$bridge{T}, $bridged_model_name{T}, OT}
-        MathOptInterface.Bridges.is_bridged(::$modelname, ::Type{<:$bridged_funs}, ::Type{<:$bridged_sets}) = true
+        $MOIB.is_bridged(::$modelname, ::Type{<:$bridged_funs}, ::Type{<:$bridged_sets}) = true
         supports_bridging_constraint(::$modelname, ::Type{<:$bridged_funs}, ::Type{<:$bridged_sets}) = true
     end)
 end

--- a/src/Bridges/singlebridgeoptimizer.jl
+++ b/src/Bridges/singlebridgeoptimizer.jl
@@ -17,7 +17,6 @@ is_bridged(b::SingleBridgeOptimizer, ::Type{<:MOI.AbstractFunction}, ::Type{<:MO
 bridge_type(b::SingleBridgeOptimizer{BT}, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet}) where BT = BT
 
 # :((Zeros, SecondOrderCone)) -> (:(MOI.Zeros), :(MOI.SecondOrderCone))
-_tuple_prefix_moi(t) = t.args
 
 """
 macro bridge(modelname, bridge, scalarsets, typedscalarsets, vectorsets, typedvectorsets, scalarfunctions, typedscalarfunctions, vectorfunctions, typedvectorfunctions)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -409,7 +409,7 @@ end
 # Expr(:., MOI, :($(QuoteNode(s)))) is Expr(:., MOI, :(:EqualTo)) <- what we want
 
 # (MOI, :Zeros) -> :(MOI.Zeros)
-_mod(m::Module, s::Symbol) = Expr(:., m, :($(QuoteNode(s))))
+_mod(m::Module, s::Symbol) = s
 # (:Zeros) -> :(MOI.Zeros)
 _moi(s::Symbol) = _mod(MOI, s)
 _set(s::SymbolSet) = _moi(s.s)
@@ -586,7 +586,7 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
                 field = _field(s)
                 code = quote
                     $code
-                    $funct(model::$c, ci::$T{F, <:$set}, args...) where F = $funct(model.$field, ci, args...)
+                    MathOptInterface.Utilities.$funct(model::$c, ci::$T{F, <:$set}, args...) where F = MathOptInterface.Utilities.$funct(model.$field, ci, args...)
                 end
             end
         end
@@ -596,7 +596,7 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
             field = _field(f)
             code = quote
                 $code
-                $funct(model::$modelname, ci::$T{<:$fun}, args...) = $funct(model.$field, ci, args...)
+                MathOptInterface.Utilities.$funct(model::$modelname, ci::$T{<:$fun}, args...) = MathOptInterface.Utilities.$funct(model.$field, ci, args...)
             end
         end
     end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -576,8 +576,7 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
         end
     end
 
-    for (func, T) in ((:_add_constraint, CI), (:_modify, CI), (:_delete, CI), (:_getindex, CI), (:_getfunction, CI), (:_getset, CI), (:_getnoc, MOI.NumberOfConstraints))
-        funct = func
+    for (funct, T) in ((:_add_constraint, CI), (:_modify, CI), (:_delete, CI), (:_getindex, CI), (:_getfunction, CI), (:_getset, CI), (:_getnoc, MOI.NumberOfConstraints))
         for (c, sets) in ((scname, scalarsets), (vcname, vectorsets))
             for s in sets
                 set = _set(s)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -393,12 +393,12 @@ abstract type Constraints{F} end
 
 abstract type SymbolFS end
 struct SymbolFun <: SymbolFS
-    s::Union{Symbol,Expr}
+    s::Union{Symbol, Expr}
     typed::Bool
     cname::Symbol
 end
 struct SymbolSet <: SymbolFS
-    s::Union{Symbol,Expr}
+    s::Union{Symbol, Expr}
     typed::Bool
 end
 
@@ -623,5 +623,5 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
 
         $code
     end
-    esc(code)
+    return esc(code)
 end

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -1,5 +1,5 @@
 # Model not supporting Interval
-MOIU.@model SimpleModel () (EqualTo, GreaterThan, LessThan) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, PositiveSemidefiniteConeTriangle, ExponentialCone) () (SingleVariable,) (ScalarAffineFunction, ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
+MOIU.@model SimpleModel () (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone, MOI.PositiveSemidefiniteConeTriangle, MOI.ExponentialCone) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 
 function test_noc(bridgedmock, F, S, n)
     @test MOI.get(bridgedmock, MOI.NumberOfConstraints{F, S}()) == n
@@ -109,7 +109,7 @@ end
 end
 
 # Model not supporting RotatedSecondOrderCone
-MOIU.@model NoRSOCModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, ExponentialCone, PositiveSemidefiniteConeTriangle) () (SingleVariable,) (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
+MOIU.@model NoRSOCModel () (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.ExponentialCone, MOI.PositiveSemidefiniteConeTriangle) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction,) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 
 @testset "LazyBridgeOptimizer" begin
     mock = MOIU.MockOptimizer(NoRSOCModel{Float64}())

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -1,5 +1,15 @@
 # Model not supporting Interval
-MOIU.@model SimpleModel () (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone, MOI.PositiveSemidefiniteConeTriangle, MOI.ExponentialCone) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
+MOIU.@model(SimpleModel,
+            (),
+            (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan),
+            (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone,
+             MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone,
+             MOI.PositiveSemidefiniteConeTriangle, MOI.ExponentialCone),
+            (),
+            (MOI.SingleVariable,),
+            (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
+            (MOI.VectorOfVariables,),
+            (MOI.VectorAffineFunction,))
 
 function test_noc(bridgedmock, F, S, n)
     @test MOI.get(bridgedmock, MOI.NumberOfConstraints{F, S}()) == n
@@ -109,7 +119,16 @@ end
 end
 
 # Model not supporting RotatedSecondOrderCone
-MOIU.@model NoRSOCModel () (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.ExponentialCone, MOI.PositiveSemidefiniteConeTriangle) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction,) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
+MOIU.@model(NoRSOCModel,
+            (),
+            (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),
+            (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone,
+             MOI.ExponentialCone, MOI.PositiveSemidefiniteConeTriangle),
+            (),
+            (MOI.SingleVariable,),
+            (MOI.ScalarAffineFunction,),
+            (MOI.VectorOfVariables,),
+            (MOI.VectorAffineFunction,))
 
 @testset "LazyBridgeOptimizer" begin
     mock = MOIU.MockOptimizer(NoRSOCModel{Float64}())

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -1,4 +1,4 @@
-@MOIU.model ModelForCachingOptimizer (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, ExponentialCone, DualExponentialCone, PositiveSemidefiniteConeTriangle, RootDetConeTriangle, LogDetConeTriangle) () (SingleVariable,) (ScalarAffineFunction,ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
+@MOIU.model ModelForCachingOptimizer (MOI.ZeroOne, MOI.Integer) (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone, MOI.PositiveSemidefiniteConeTriangle, MOI.RootDetConeTriangle, MOI.LogDetConeTriangle) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 
 @testset "CachingOptimizer Manual mode" begin
     m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), MOIU.Manual)

--- a/test/model.jl
+++ b/test/model.jl
@@ -1,4 +1,4 @@
-MOIU.@model LPModel () (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives) () (SingleVariable,) (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
+MOIU.@model LPModel () (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction,) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 
 @testset "Name test" begin
     MOIT.nametest(Model{Float64}())

--- a/test/model.jl
+++ b/test/model.jl
@@ -1,4 +1,12 @@
-MOIU.@model LPModel () (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction,) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
+MOIU.@model(LPModel,
+            (),
+            (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),
+            (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives),
+            (),
+            (MOI.SingleVariable,),
+            (MOI.ScalarAffineFunction,),
+            (MOI.VectorOfVariables,),
+            (MOI.VectorAffineFunction,))
 
 @testset "Name test" begin
     MOIT.nametest(Model{Float64}())

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -31,7 +31,7 @@ end
     @test MOIU.separatelabel(:(con1: [x,y] in S)) == (:con1, :([x,y] in S))
 end
 
-@MOIU.model GeneralModel (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, PositiveSemidefiniteConeTriangle) () (SingleVariable,) (ScalarAffineFunction,ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
+@MOIU.model GeneralModel (MOI.ZeroOne, MOI.Integer) (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.PositiveSemidefiniteConeTriangle) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 
 @testset "loadfromstring" begin
     @testset "one variable" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,16 +20,16 @@ end
 # Needed by test spread over several files, defining it here make it easier to comment out tests
 # Model supporting every MOI functions and sets
 MOIU.@model(Model,
-               (ZeroOne, Integer),
-               (EqualTo, GreaterThan, LessThan, Interval, Semicontinuous, Semiinteger),
-               (Reals, Zeros, Nonnegatives, Nonpositives, SecondOrderCone, RotatedSecondOrderCone, GeometricMeanCone, ExponentialCone, DualExponentialCone, PositiveSemidefiniteConeTriangle, PositiveSemidefiniteConeSquare, RootDetConeTriangle, RootDetConeSquare, LogDetConeTriangle, LogDetConeSquare),
-               (PowerCone, DualPowerCone, SOS1, SOS2),
-               (SingleVariable,),
-               (ScalarAffineFunction, ScalarQuadraticFunction),
-               (VectorOfVariables,),
-               (VectorAffineFunction, VectorQuadraticFunction))
+               (MOI.ZeroOne, MOI.Integer),
+               (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval, MOI.Semicontinuous, MOI.Semiinteger),
+               (MOI.Reals, MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone, MOI.PositiveSemidefiniteConeTriangle, MOI.PositiveSemidefiniteConeSquare, MOI.RootDetConeTriangle, MOI.RootDetConeSquare, MOI.LogDetConeTriangle, MOI.LogDetConeSquare),
+               (MOI.PowerCone, MOI.DualPowerCone, MOI.SOS1, MOI.SOS2),
+               (MOI.SingleVariable,),
+               (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
+               (MOI.VectorOfVariables,),
+               (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction))
 # Model supporting only SecondOrderCone as non-LP cone.
-@MOIU.model ModelForMock (ZeroOne, Integer) (EqualTo, GreaterThan, LessThan, Interval) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone) () (SingleVariable,) (ScalarAffineFunction, ScalarQuadraticFunction) (VectorOfVariables,) (VectorAffineFunction,)
+@MOIU.model ModelForMock (MOI.ZeroOne, MOI.Integer) (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 
 # Utilities submodule tests
 @testset "MOI.Utilities" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,16 +20,30 @@ end
 # Needed by test spread over several files, defining it here make it easier to comment out tests
 # Model supporting every MOI functions and sets
 MOIU.@model(Model,
-               (MOI.ZeroOne, MOI.Integer),
-               (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval, MOI.Semicontinuous, MOI.Semiinteger),
-               (MOI.Reals, MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone, MOI.PositiveSemidefiniteConeTriangle, MOI.PositiveSemidefiniteConeSquare, MOI.RootDetConeTriangle, MOI.RootDetConeSquare, MOI.LogDetConeTriangle, MOI.LogDetConeSquare),
-               (MOI.PowerCone, MOI.DualPowerCone, MOI.SOS1, MOI.SOS2),
-               (MOI.SingleVariable,),
-               (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
-               (MOI.VectorOfVariables,),
-               (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction))
+            (MOI.ZeroOne, MOI.Integer),
+            (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval,
+             MOI.Semicontinuous, MOI.Semiinteger),
+            (MOI.Reals, MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives,
+             MOI.SecondOrderCone, MOI.RotatedSecondOrderCone,
+             MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone,
+             MOI.PositiveSemidefiniteConeTriangle, MOI.PositiveSemidefiniteConeSquare,
+             MOI.RootDetConeTriangle, MOI.RootDetConeSquare, MOI.LogDetConeTriangle,
+             MOI.LogDetConeSquare),
+            (MOI.PowerCone, MOI.DualPowerCone, MOI.SOS1, MOI.SOS2),
+            (MOI.SingleVariable,),
+            (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
+            (MOI.VectorOfVariables,),
+            (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction))
+            
 # Model supporting only SecondOrderCone as non-LP cone.
-@MOIU.model ModelForMock (MOI.ZeroOne, MOI.Integer) (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
+MOIU.@model(ModelForMock, (MOI.ZeroOne, MOI.Integer),
+            (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),
+            (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone),
+            (),
+            (MOI.SingleVariable,),
+            (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
+            (MOI.VectorOfVariables,),
+            (MOI.VectorAffineFunction,))
 
 # Utilities submodule tests
 @testset "MOI.Utilities" begin

--- a/test/universalfallback.jl
+++ b/test/universalfallback.jl
@@ -47,7 +47,7 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
 
 # A few constraint types are supported to test both the fallback and the
 # delegation to the internal model
-@MOIU.model ModelForUniversalFallback () (LessThan,) () () (SingleVariable,) (ScalarAffineFunction,) () ()
+@MOIU.model ModelForUniversalFallback () (MOI.LessThan,) () () (MOI.SingleVariable,) (MOI.ScalarAffineFunction,) () ()
 
 @testset "UniversalFallback" begin
     model = ModelForUniversalFallback{Float64}()

--- a/test/universalfallback.jl
+++ b/test/universalfallback.jl
@@ -47,7 +47,15 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
 
 # A few constraint types are supported to test both the fallback and the
 # delegation to the internal model
-@MOIU.model ModelForUniversalFallback () (MOI.LessThan,) () () (MOI.SingleVariable,) (MOI.ScalarAffineFunction,) () ()
+@MOIU.model(ModelForUniversalFallback,
+            (),
+            (MOI.LessThan,),
+            (),
+            (),
+            (MOI.SingleVariable,),
+            (MOI.ScalarAffineFunction,),
+            (),
+            ())
 
 @testset "UniversalFallback" begin
     model = ModelForUniversalFallback{Float64}()


### PR DESCRIPTION
Simpler solution as suggested by @blegat. Of course we can now delete _mod function and get rid of its calls.

However even with this solution, we still need to import sets/functions to be used by @bridge

If we want the modules passed to @bridge like `MOI.xxxfunction/MOI.xxxset`, we need more modifications in @model since it uses the names passed to create field names of the new structure. Do we go for that?