### PR TITLE
Remove implementation and testing of supports for ConstraintSet

### DIFF
--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -237,16 +237,6 @@ function MOI.set(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
     end
 end
 ## Setting functions and sets
-function MOI.supports(b::AbstractBridgeOptimizer,
-                      attr::Union{MOI.ConstraintFunction, MOI.ConstraintSet},
-                      ::Type{CI{F, S}}) where {F, S}
-    if is_bridged(b, CI{F, S})
-        return MOI.supports(b.bridged, attr, CI{F, S}) &&
-            MOI.supports(b, attr, concrete_bridge_type(b, F, S))
-    else
-        return MOI.supports(b.model, attr, CI{F, S})
-    end
-end
 function MOI.set(b::AbstractBridgeOptimizer, ::MOI.ConstraintSet,
                   constraint_index::CI{F, S}, set::S) where {F, S}
     if is_bridged(b, typeof(constraint_index))

--- a/src/Bridges/detbridge.jl
+++ b/src/Bridges/detbridge.jl
@@ -139,10 +139,6 @@ function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintPrimal, c::LogDetBridge)
     [t; x]
 end
 
-# Constraints
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:LogDetBridge}) = false
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:LogDetBridge}) = false
-
 """
     RootDetBridge{T}
 
@@ -201,7 +197,3 @@ function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintPrimal, c::RootDetBridge
     x = MOI.get(model, MOI.ConstraintPrimal(), c.sdindex)[1:length(c.Δ)]
     [t; x]
 end
-
-# Constraints
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RootDetBridge}) = false
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RootDetBridge}) = false

--- a/src/Bridges/geomeanbridge.jl
+++ b/src/Bridges/geomeanbridge.jl
@@ -162,7 +162,3 @@ end
 #function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintDual, c::GeoMeanBridge)
 #    output = _getconstrattr(model, a, c)
 #end
-
-# Constraints
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:GeoMeanBridge}) = false
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:GeoMeanBridge}) = false

--- a/src/Bridges/intervalbridge.jl
+++ b/src/Bridges/intervalbridge.jl
@@ -54,14 +54,12 @@ function MOI.modify(model::MOI.ModelLike, c::SplitIntervalBridge, change::MOI.Ab
     MOI.modify(model, c.upper, change)
 end
 
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:SplitIntervalBridge}) = true
 function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintFunction,
                   c::SplitIntervalBridge{T, F}, func::F) where {T, F}
     MOI.set(model, MOI.ConstraintFunction(), c.lower, func)
     MOI.set(model, MOI.ConstraintFunction(), c.upper, func)
 end
 
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:SplitIntervalBridge}) = true
 function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintSet, c::SplitIntervalBridge, change::MOI.Interval)
     MOI.set(model, MOI.ConstraintSet(), c.lower, MOI.GreaterThan(change.lower))
     MOI.set(model, MOI.ConstraintSet(), c.upper, MOI.LessThan(change.upper))

--- a/src/Bridges/rsocbridge.jl
+++ b/src/Bridges/rsocbridge.jl
@@ -81,6 +81,3 @@ end
 # Need to define both `get` methods and redirect to `_get` to avoid ambiguity in dispatch
 MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal, c::RSOCBridge) = _get(model, attr, c)
 MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintDual, c::RSOCBridge) = _get(model, attr, c)
-
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCBridge}) = false
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RSOCBridge}) = false

--- a/src/Bridges/soctopsdbridge.jl
+++ b/src/Bridges/soctopsdbridge.jl
@@ -83,9 +83,6 @@ function MOI.delete(instance::MOI.AbstractOptimizer, c::SOCtoPSDBridge)
     MOI.delete(instance, c.cr)
 end
 
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:SOCtoPSDBridge}) = false
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:SOCtoPSDBridge}) = false
-
 """
 The `RSOCtoPSDBridge` transforms the second order cone constraint ``\\lVert x \\rVert \\le 2tu`` with ``u \\ge 0`` into the semidefinite cone constraints
 ```math
@@ -148,6 +145,3 @@ MOI.get(b::RSOCtoPSDBridge{T}, ::MOI.ListOfConstraintIndices{MOI.VectorAffineFun
 function MOI.delete(instance::MOI.AbstractOptimizer, c::RSOCtoPSDBridge)
     MOI.delete(instance, c.cr)
 end
-
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintSet, ::Type{<:RSOCtoPSDBridge}) = false
-MOI.supports(model::MOI.ModelLike, ::MOI.ConstraintFunction, ::Type{<:RSOCtoPSDBridge}) = false

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -22,7 +22,6 @@ function solve_set_singlevariable_lessthan(model::MOI.ModelLike, config::TestCon
         constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, -1.0)]
     )
-    @test MOI.supports(model, MOI.ConstraintSet(), typeof(c))
     MOI.set(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
     @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
     test_model_solution(model, config;
@@ -91,7 +90,6 @@ function solve_set_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConfi
         constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, -1.0)]
     )
-    @test MOI.supports(model, MOI.ConstraintSet(), typeof(c))
     MOI.set(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
     @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
     test_model_solution(model, config;
@@ -157,7 +155,6 @@ function solve_func_scalaraffine_lessthan(model::MOI.ModelLike, config::TestConf
         constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, -1.0)]
     )
-    @test MOI.supports(model, MOI.ConstraintFunction(), typeof(c))
     MOI.set(model, MOI.ConstraintFunction(), c,
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(2.0, x)], 0.0)
     )

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -181,7 +181,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x + y + z <= 1
     # x >= -1
     # y,z >= 0
-    MOI.supports(model, MOI.ConstraintSet(), typeof(vc1))
     MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(-1.0))
 
     if config.solve
@@ -202,7 +201,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # max x + 2z
     # s.t. x + y + z <= 1
     # x, y >= 0, z = 0 (vc3)
-    MOI.supports(model, MOI.ConstraintSet(), typeof(vc1))
     MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(0.0))
 
     MOI.delete(model, vc3)
@@ -532,7 +530,6 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= 0.0
-    MOI.supports(model, MOI.ConstraintSet(), typeof(c1))
     MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(100.0))
     if config.solve
         MOI.optimize!(model)
@@ -547,7 +544,6 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= -100.0
-    MOI.supports(model, MOI.ConstraintSet(), typeof(c2))
     MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan(-100.0))
     if config.solve
         MOI.optimize!(model)
@@ -738,7 +734,6 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= 0.0
-    MOI.supports(model, MOI.ConstraintSet(), typeof(c1))
     MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(100.0))
     if config.solve
         MOI.optimize!(model)
@@ -753,7 +748,6 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     # Min  x - y
     # s.t. 100.0 <= x
     #               y <= -100.0
-    MOI.supports(model, MOI.ConstraintSet(), typeof(c2))
     MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan(-100.0))
     if config.solve
         MOI.optimize!(model)
@@ -1111,7 +1105,6 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         end
     end
 
-    MOI.supports(model, MOI.ConstraintSet(), typeof(c))
     MOI.set(model, MOI.ConstraintSet(), c, MOI.Interval(2.0, 12.0))
 
     if config.query

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -293,11 +293,9 @@ function MOI.modify(model::AbstractModel, ci::CI, change::MOI.AbstractFunctionMo
     _modify(model, ci, getconstrloc(model, ci), change)
 end
 
-MOI.supports(::AbstractModel, ::MOI.ConstraintFunction, ::Type{<:CI}) = true
 function MOI.set(model::AbstractModel, ::MOI.ConstraintFunction, ci::CI, change::MOI.AbstractFunction)
     _modify(model, ci, getconstrloc(model, ci), change)
 end
-MOI.supports(::AbstractModel, ::MOI.ConstraintSet, ::Type{<:CI}) = true
 function MOI.set(model::AbstractModel, ::MOI.ConstraintSet, ci::CI, change::MOI.AbstractSet)
     _modify(model, ci, getconstrloc(model, ci), change)
 end

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -168,8 +168,6 @@ MOIU.@model(NoRSOCModel,
         MOIT.rootdett1ftest(fullbridgedmock, config)
         # Dual is not yet implemented for RootDet and GeoMean bridges
         ci = first(MOI.get(fullbridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
-        @test !MOI.supports(fullbridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.supports(fullbridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(fullbridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
                                                     (MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone, 0),
                                                     (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0)))
@@ -226,8 +224,6 @@ end
                               (MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)  => [[3/2, 1/2, -1.0, -1.0]])
         MOIT.rotatedsoc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}()))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 2, ((MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone, 0),))
     end
 
@@ -257,8 +253,6 @@ end
         MOIT.geomean1ftest(bridgedmock, config)
         # Dual is not yet implemented for GeoMean bridge
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
                                                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64},      1)))
     end
@@ -271,8 +265,6 @@ end
         MOIT.soc1vtest(bridgedmock, config)
         MOIT.soc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone}()))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 3, ((MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0),))
     end
 
@@ -286,8 +278,6 @@ end
                               (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle) => [[√2, -1/2, √2/8, -1/2, √2/8, √2/8]])
         MOIT.rotatedsoc1ftest(bridgedmock, config)
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}()))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 2, ((MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0),))
     end
 
@@ -298,8 +288,6 @@ end
         MOIT.logdett1ftest(bridgedmock, config)
         # Dual is not yet implemented for LogDet bridge
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.LogDetConeTriangle}()))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone, 0), (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0)))
     end
 
@@ -310,8 +298,6 @@ end
         MOIT.rootdett1ftest(bridgedmock, config)
         # Dual is not yet implemented for RootDet bridge
         ci = first(MOI.get(bridgedmock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RootDetConeTriangle}()))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintSet(), typeof(ci))
-        @test !MOI.supports(bridgedmock, MOI.ConstraintFunction(), typeof(ci))
         test_delete_bridge(bridgedmock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
                                                 (MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone, 0),
                                                 (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle, 0)))

--- a/test/cachingoptimizer.jl
+++ b/test/cachingoptimizer.jl
@@ -51,7 +51,6 @@
     @test MOI.supports_constraint(m.optimizer, MOI.SingleVariable, MOI.LessThan{Float64})
     @test MOI.supports_constraint(m, MOI.SingleVariable, MOI.LessThan{Float64})
     lb = MOI.add_constraint(m, MOI.SingleVariable(v), MOI.LessThan(10.0))
-    @test MOI.supports(m, MOI.ConstraintSet(), typeof(lb))
     MOI.set(m, MOI.ConstraintSet(), lb, MOI.LessThan(11.0))
     @test MOI.get(m, MOI.ConstraintSet(), lb) == MOI.LessThan(11.0)
     @test MOI.get(m, MOI.ConstraintFunction(), lb) == MOI.SingleVariable(v)
@@ -59,7 +58,6 @@
     MOIU.dropoptimizer!(m)
     @test MOIU.state(m) == MOIU.NoOptimizer
 
-    @test MOI.supports(m, MOI.ConstraintSet(), typeof(lb))
     MOI.set(m, MOI.ConstraintSet(), lb, MOI.LessThan(12.0))
     @test MOI.get(m, MOI.ConstraintSet(), lb) == MOI.LessThan(12.0)
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -142,13 +142,11 @@ struct SetNotSupportedBySolvers <: MOI.AbstractSet end
         c = MOI.add_constraint(m, MOI.SingleVariable(x), MOI.LessThan(0.0))
         @test !MOI.supports_constraint(m, FunctionNotSupportedBySolvers, SetNotSupportedBySolvers)
 
-        @test MOI.supports(m, MOI.ConstraintSet(), typeof(c))
         # set of different type
         @test_throws Exception MOI.set(m, MOI.ConstraintSet(), c, MOI.GreaterThan(0.0))
         # set not implemented
         @test_throws Exception MOI.set(m, MOI.ConstraintSet(), c, SetNotSupportedBySolvers())
 
-        @test MOI.supports(m, MOI.ConstraintFunction(), typeof(c))
         # function of different type
         @test_throws Exception MOI.set(m, MOI.ConstraintFunction(), c, MOI.VectorOfVariables([x]))
         # function not implemented

--- a/test/universalfallback.jl
+++ b/test/universalfallback.jl
@@ -111,7 +111,6 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
             listattr = MOI.ListOfConstraintAttributesSet{MOI.SingleVariable, MOI.LessThan{Float64}}()
             test_varconattrs(uf, model, attr, listattr, CI, uf -> MOI.add_constraint(uf, x, MOI.LessThan(0.)), cx, cy, cz)
 
-            @test MOI.supports(uf, MOI.ConstraintFunction(), typeof(cx))
             MOI.set(uf, MOI.ConstraintFunction(), cx, MOI.SingleVariable(y))
             @test MOI.get(uf, MOI.ConstraintFunction(), cx) == MOI.SingleVariable(y)
 
@@ -134,7 +133,6 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
             listattr = MOI.ListOfConstraintAttributesSet{MOI.SingleVariable, MOI.EqualTo{Float64}}()
             test_varconattrs(uf, model, attr, listattr, CI, uf -> MOI.add_constraint(uf, x, MOI.EqualTo(0.)), cx, cy, cz)
 
-            @test MOI.supports(uf, MOI.ConstraintFunction(), typeof(cx))
             MOI.set(uf, MOI.ConstraintFunction(), cx, MOI.SingleVariable(y))
             @test MOI.get(uf, MOI.ConstraintFunction(), cx) == MOI.SingleVariable(y)
 


### PR DESCRIPTION
`ConstraintSet` and `ConstraintFunction` are not copyable (see `is_copyable`) so they should not implement `supports`.