### PR TITLE
Add errors for Allocate-Load and bad constraint

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -171,8 +171,8 @@ Returns the index for the constraint to be used in `load_constraint` that will b
 """
 function allocate_constraint(model::MOI.ModelLike, func::MOI.AbstractFunction,
                              set::MOI.AbstractSet)
-    MOI.add_constraint_fallback_error(model, func, set;
-                                      error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
+    MOI.throw_add_constraint_error_fallback(model, func, set;
+                                            error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
 end
 
 """
@@ -207,8 +207,8 @@ Sets the constraint function and set for the constraint of index `ci`.
 """
 function load_constraint(model::MOI.ModelLike, func::MOI.AbstractFunction,
                          set::MOI.AbstractSet)
-    MOI.add_constraint_fallback_error(model, func, set;
-                                      error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
+    MOI.throw_add_constraint_error_fallback(model, func, set;
+                                            error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
 end
 
 function allocate_constraints(dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::Bool, idxmap::IndexMap, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -154,8 +154,8 @@ const ALLOCATE_LOAD_NOT_IMPLEMENTED = ErrorException("The Allocate-Load interfac
 Informs `model` that `load` will be called with the same arguments after `load_variables` is called.
 """
 function allocate(model::MOI.ModelLike, args...)
-    MOI.set_fallback_error(model, args...;
-                           error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
+    MOI.throw_set_error_fallback(model, args...;
+                                 error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
 end
 
 function allocate(model::MOI.ModelLike, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector, values::Vector)
@@ -190,8 +190,8 @@ function load_variables end
 This has the same effect that `set` with the same arguments except that `allocate` should be called first before `load_variables`.
 """
 function load(model::MOI.ModelLike, args...)
-    MOI.set_fallback_error(model, args...;
-                           error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
+    MOI.throw_set_error_fallback(model, args...;
+                                 error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
 end
 
 function load(model::MOI.ModelLike, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector, values::Vector)

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -143,6 +143,9 @@ Creates `nvars` variables and returns a vector of `nvars` variable indices.
 """
 function allocate_variables end
 
+const ALLOCATE_LOAD_NOT_IMPLEMENTED = ErrorException("The Allocate-Load interface is" *
+                                                     " not implemented by the model")
+
 """
     allocate(model::ModelLike, attr::ModelLikeAttribute, value)
     allocate(model::ModelLike, attr::AbstractVariableAttribute, v::VariableIndex, value)
@@ -150,7 +153,10 @@ function allocate_variables end
 
 Informs `model` that `load` will be called with the same arguments after `load_variables` is called.
 """
-function allocate end
+function allocate(model::MOI.ModelLike, args...)
+    MOI.set_fallback_error(model, args...;
+                           error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
+end
 
 function allocate(model::MOI.ModelLike, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector, values::Vector)
     for (index, value) in zip(indices, values)
@@ -163,7 +169,11 @@ end
 
 Returns the index for the constraint to be used in `load_constraint` that will be called after `load_variables` is called.
 """
-function allocate_constraint end
+function allocate_constraint(model::MOI.ModelLike, func::MOI.AbstractFunction,
+                             set::MOI.AbstractSet)
+    MOI.add_constraint_fallback_error(model, func, set;
+                                      error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
+end
 
 """
     load_variables(model::MOI.ModelLike, nvars::Integer)
@@ -179,7 +189,10 @@ function load_variables end
 
 This has the same effect that `set` with the same arguments except that `allocate` should be called first before `load_variables`.
 """
-function load end
+function load(model::MOI.ModelLike, args...)
+    MOI.set_fallback_error(model, args...;
+                           error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
+end
 
 function load(model::MOI.ModelLike, attr::Union{MOI.AbstractVariableAttribute, MOI.AbstractConstraintAttribute}, indices::Vector, values::Vector)
     for (index, value) in zip(indices, values)
@@ -192,7 +205,11 @@ end
 
 Sets the constraint function and set for the constraint of index `ci`.
 """
-function load_constraint end
+function load_constraint(model::MOI.ModelLike, func::MOI.AbstractFunction,
+                         set::MOI.AbstractSet)
+    MOI.add_constraint_fallback_error(model, func, set;
+                                      error_if_supported=ALLOCATE_LOAD_NOT_IMPLEMENTED)
+end
 
 function allocate_constraints(dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::Bool, idxmap::IndexMap, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
     # Allocate constraints

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -285,21 +285,23 @@ end
 # examples, see ConstraintSet and ConstraintFunction. set_fallback_error should
 # not be overloaded by users of MOI.
 function set_fallback_error(model::ModelLike,
-                             attr::Union{AbstractModelAttribute,
-                                         AbstractOptimizerAttribute},
-                             value)
+                            attr::Union{AbstractModelAttribute,
+                                        AbstractOptimizerAttribute},
+                            value;
+                            error_if_supported = SetAttributeNotAllowed(attr))
     if supports(model, attr)
-        throw(SetAttributeNotAllowed(attr))
+        throw(error_if_supported)
     else
         throw(UnsupportedAttribute(attr))
     end
 end
 function set_fallback_error(model::ModelLike,
-                             attr::Union{AbstractVariableAttribute,
-                                         AbstractConstraintAttribute},
-                             index::Index, value)
+                            attr::Union{AbstractVariableAttribute,
+                                        AbstractConstraintAttribute},
+                            index::Index, value;
+                            error_if_supported = SetAttributeNotAllowed(attr))
     if supports(model, attr, typeof(index))
-        throw(SetAttributeNotAllowed(attr))
+        throw(error_if_supported)
     else
         throw(UnsupportedAttribute(attr))
     end
@@ -628,13 +630,14 @@ It is guaranteed to be equivalent but not necessarily identical to the function 
 struct ConstraintFunction <: AbstractConstraintAttribute end
 
 function set_fallback_error(::ModelLike, attr::ConstraintFunction,
-                     ::ConstraintIndex{F, S}, ::F) where {F <: AbstractFunction,
-                                                          S}
-    throw(SetAttributeNotAllowed(attr))
+                            ::ConstraintIndex{F, S}, ::F;
+                            error_if_supported = SetAttributeNotAllowed(attr)) where {F <: AbstractFunction, S}
+    throw(error_if_supported)
 end
 func_type(c::ConstraintIndex{F, S}) where {F, S} = F
 function set_fallback_error(::ModelLike, ::ConstraintFunction,
-                     constraint_index::ConstraintIndex, func::AbstractFunction)
+                            constraint_index::ConstraintIndex, func::AbstractFunction;
+                            kwargs...)
     throw(ArgumentError("""Cannot modify functions of different types.
     Constraint type is $(func_type(constraint_index)) while the replacement
     function is of type $(typeof(func))."""))
@@ -647,13 +650,15 @@ A constraint attribute for the `AbstractSet` object used to define the constrain
 """
 struct ConstraintSet <: AbstractConstraintAttribute end
 
-function set_fallback_error(::ModelLike, attr::ConstraintSet, ::ConstraintIndex{F, S},
-                     ::S) where {F, S <: AbstractSet}
-    throw(SetAttributeNotAllowed(attr))
+function set_fallback_error(::ModelLike, attr::ConstraintSet,
+                            ::ConstraintIndex{F, S}, ::S;
+                            error_if_supported = SetAttributeNotAllowed(attr)) where {F, S <: AbstractSet}
+    throw(error_if_supported)
 end
 set_type(::ConstraintIndex{F, S}) where {F, S} = S
 function set_fallback_error(::ModelLike, ::ConstraintSet,
-                     constraint_index::ConstraintIndex, set::AbstractSet)
+                            constraint_index::ConstraintIndex, set::AbstractSet;
+                            kwargs...)
     throw(ArgumentError("""Cannot modify sets of different types. Constraint
     type is $(set_type(constraint_index)) while the replacement set is of
     type $(typeof(set)). Use `transform` instead."""))

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -56,7 +56,7 @@ current state.
 """
 function add_constraint(model::ModelLike, func::AbstractFunction,
                         set::AbstractSet)
-    add_constraint_fallback_error(model, func, set)
+    throw_add_constraint_error_fallback(model, func, set)
     if supports_constraint(model, typeof(func), typeof(set))
         throw()
     else
@@ -64,39 +64,39 @@ function add_constraint(model::ModelLike, func::AbstractFunction,
     end
 end
 
-# add_constraint_fallback_error checks whether func and set are both scalar
-# or both vector. If it is the case, it calls
-# `correct_add_constraint_fallback_error`
-function add_constraint_fallback_error(model::ModelLike,
-                                       func::AbstractScalarFunction,
-                                       set::AbstractScalarSet;
-                                       kwargs...)
-    correct_add_constraint_fallback_error(model, func, set; kwargs...)
+# throw_add_constraint_error_fallback checks whether func and set are both
+# scalar or both vector. If it is the case, it calls
+# `correct_throw_add_constraint_error_fallback`
+function throw_add_constraint_error_fallback(model::ModelLike,
+                                             func::AbstractScalarFunction,
+                                             set::AbstractScalarSet;
+                                             kwargs...)
+    correct_throw_add_constraint_error_fallback(model, func, set; kwargs...)
 end
-function add_constraint_fallback_error(model::ModelLike,
-                                       func::AbstractVectorFunction,
-                                       set::AbstractVectorSet;
-                                       kwargs...)
-    correct_add_constraint_fallback_error(model, func, set; kwargs...)
+function throw_add_constraint_error_fallback(model::ModelLike,
+                                             func::AbstractVectorFunction,
+                                             set::AbstractVectorSet;
+                                             kwargs...)
+    correct_throw_add_constraint_error_fallback(model, func, set; kwargs...)
 end
-function add_constraint_fallback_error(model::ModelLike,
-                                       func::AbstractScalarFunction,
-                                       set::AbstractVectorSet;
-                                       kwargs...)
+function throw_add_constraint_error_fallback(model::ModelLike,
+                                             func::AbstractScalarFunction,
+                                             set::AbstractVectorSet;
+                                             kwargs...)
     error("Cannot add a constraint of the form `ScalarFunction`-in-`VectorSet`")
 end
-function add_constraint_fallback_error(model::ModelLike,
-                                       func::AbstractVectorFunction,
-                                       set::AbstractScalarSet;
-                                       kwargs...)
+function throw_add_constraint_error_fallback(model::ModelLike,
+                                             func::AbstractVectorFunction,
+                                             set::AbstractScalarSet;
+                                             kwargs...)
     error("Cannot add a constraint of the form `VectorFunction`-in-`ScalarSet`")
 end
 
 # func and set are both scalar or both vector
-function correct_add_constraint_fallback_error(model::ModelLike,
-                                               func::AbstractFunction,
-                                               set::AbstractSet;
-                                               error_if_supported=AddConstraintNotAllowed{typeof(func), typeof(set)}())
+function correct_throw_add_constraint_error_fallback(model::ModelLike,
+                                                     func::AbstractFunction,
+                                                     set::AbstractSet;
+                                                     error_if_supported=AddConstraintNotAllowed{typeof(func), typeof(set)}())
     if supports_constraint(model, typeof(func), typeof(set))
         throw(error_if_supported)
     else

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -57,11 +57,6 @@ current state.
 function add_constraint(model::ModelLike, func::AbstractFunction,
                         set::AbstractSet)
     throw_add_constraint_error_fallback(model, func, set)
-    if supports_constraint(model, typeof(func), typeof(set))
-        throw()
-    else
-        throw(UnsupportedConstraint{typeof(func), typeof(set)}())
-    end
 end
 
 # throw_add_constraint_error_fallback checks whether func and set are both

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -7,4 +7,3 @@ MOI.supports_constraint(::DummyModel, ::Type{MOI.SingleVariable},
                        ::Type{MOI.EqualTo{Float64}}) = true
 MOI.supports_constraint(::DummyModel, ::Type{MOI.VectorOfVariables},
                        ::Type{MOI.Zeros}) = true
-

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -26,28 +26,28 @@
             MOI.add_constraint(model, func, MOI.Nonnegatives(2))
         end
     end
-    @testset "UnsupportedConstraint" begin
-        for f in (MOI.add_constraint, MOIU.allocate_constraint, MOIU.load_constraint)
-            @test_throws MOI.UnsupportedConstraint begin
-                MOI.add_constraint(model, func, MOI.EqualTo(0))
-            end
-            try
-                MOI.add_constraint(model, func, MOI.EqualTo(0))
-            catch err
-                @test sprint(showerror, err) == "$MOI.UnsupportedConstraint{$MOI.SingleVariable,$MOI.EqualTo{$Int}}:" *
-                " `$MOI.SingleVariable`-in-`$MOI.EqualTo{$Int}` constraints is" *
-                " not supported by the the model."
-            end
-            @test_throws MOI.UnsupportedConstraint begin
-                MOI.add_constraint(model, vi, MOI.EqualTo(0))
-            end
-            @test_throws MOI.UnsupportedConstraint begin
-                MOI.add_constraint(model, [vi, vi], MOI.Nonnegatives(2))
-            end
-            @test_throws MOI.UnsupportedConstraint begin
-                MOI.add_constraints(model, [vi, vi], [MOI.EqualTo(0),
-                                                      MOI.EqualTo(0)])
-            end
+    @testset "Unsupported constraint with $f" for f in (MOI.add_constraint,
+                                                        MOIU.allocate_constraint,
+                                                        MOIU.load_constraint)
+        @test_throws MOI.UnsupportedConstraint begin
+            MOI.add_constraint(model, func, MOI.EqualTo(0))
+        end
+        try
+            MOI.add_constraint(model, func, MOI.EqualTo(0))
+        catch err
+            @test sprint(showerror, err) == "$MOI.UnsupportedConstraint{$MOI.SingleVariable,$MOI.EqualTo{$Int}}:" *
+            " `$MOI.SingleVariable`-in-`$MOI.EqualTo{$Int}` constraints is" *
+            " not supported by the the model."
+        end
+        @test_throws MOI.UnsupportedConstraint begin
+            MOI.add_constraint(model, vi, MOI.EqualTo(0))
+        end
+        @test_throws MOI.UnsupportedConstraint begin
+            MOI.add_constraint(model, [vi, vi], MOI.Nonnegatives(2))
+        end
+        @test_throws MOI.UnsupportedConstraint begin
+            MOI.add_constraints(model, [vi, vi], [MOI.EqualTo(0),
+                                                  MOI.EqualTo(0)])
         end
     end
     @testset "add_constraint errors" begin
@@ -76,16 +76,15 @@
         end
     end
 
-    for f in (MOIU.allocate_constraint, MOIU.load_constraint)
-        @testset "$f errors" begin
-            @test_throws MOI.ErrorException begin
-                f(model, func, MOI.EqualTo(0.0))
-            end
-            try
-                f(model, func, MOI.EqualTo(0.0))
-            catch err
-                @test err === MOIU.ALLOCATE_LOAD_NOT_IMPLEMENTED
-            end
+    @testset "$f errors" for f in (MOIU.allocate_constraint,
+                                   MOIU.load_constraint)
+        @test_throws MOI.ErrorException begin
+            f(model, func, MOI.EqualTo(0.0))
+        end
+        try
+            f(model, func, MOI.EqualTo(0.0))
+        catch err
+            @test err === MOIU.ALLOCATE_LOAD_NOT_IMPLEMENTED
         end
     end
 
@@ -116,15 +115,14 @@
         end
     end
 
-    @testset "UnsupportedAttribute" begin
-        for f in (MOI.set, MOIU.load, MOIU.allocate)
-            @test_throws MOI.UnsupportedAttribute begin
-                f(model, MOI.ObjectiveFunction{MOI.SingleVariable}(),
-                         MOI.SingleVariable(vi))
-            end
-            @test_throws MOI.UnsupportedAttribute begin
-                f(model, MOI.ConstraintDualStart(), ci, 0.0)
-            end
+    @testset "Unsupported attribute with $f" for f in (MOI.set, MOIU.load,
+                                                       MOIU.allocate)
+        @test_throws MOI.UnsupportedAttribute begin
+            f(model, MOI.ObjectiveFunction{MOI.SingleVariable}(),
+                     MOI.SingleVariable(vi))
+        end
+        @test_throws MOI.UnsupportedAttribute begin
+            f(model, MOI.ConstraintDualStart(), ci, 0.0)
         end
     end
 
@@ -137,19 +135,17 @@
         end
     end
 
-    for f in (MOIU.load, MOIU.allocate)
-        @testset "$f errors" begin
-            @test_throws MOI.ErrorException begin
-                f(model, MOI.ObjectiveSense(), MOI.MaxSense)
-            end
-            try
-                f(model, MOI.ObjectiveSense(), MOI.MaxSense)
-            catch err
-                @test err === MOIU.ALLOCATE_LOAD_NOT_IMPLEMENTED
-            end
-            @test_throws MOI.ErrorException begin
-                f(model, MOI.ConstraintPrimalStart(), ci, 0.0)
-            end
+    @testset "$f errors" for f in (MOIU.load, MOIU.allocate)
+        @test_throws MOI.ErrorException begin
+            f(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        end
+        try
+            f(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        catch err
+            @test err === MOIU.ALLOCATE_LOAD_NOT_IMPLEMENTED
+        end
+        @test_throws MOI.ErrorException begin
+            f(model, MOI.ConstraintPrimalStart(), ci, 0.0)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ MOIU.@model(Model,
             (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
             (MOI.VectorOfVariables,),
             (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction))
-            
+
 # Model supporting only SecondOrderCone as non-LP cone.
 MOIU.@model(ModelForMock, (MOI.ZeroOne, MOI.Integer),
             (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),


### PR DESCRIPTION
This PR brings two improvements to user friendliness:

* Allocate-Load equivalents to `set` and `add_constraint` now returns nice user-facing errors instead of method errors
* `add_constraint` with VectorFunction-in-ScalarSet or ScalarFunction-in-VectorSet now returns an error instead of an UnsupportedError relying on the fact that the model implements `supports_constraint` correctly or an `AddConstraintNotAllowed` otherwise which are both less user-friendly

Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/530