### PR TITLE
RFC: construct the name to object dicts lazily

### DIFF
--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -25,8 +25,10 @@ function nametest(model::MOI.ModelLike)
         MOI.set(model, MOI.VariableName(), v[2], "") # Shouldn't error with duplicate empty name
 
         MOI.set(model, MOI.VariableName(), v[1], "Var1")
-        @test_throws Exception MOI.set(model, MOI.VariableName(), v[2], "Var1")
         MOI.set(model, MOI.VariableName(), v[2], "Var2")
+
+        # TODO: Models might error in different ways when a duplicate name is
+        # set. Come up with a reasonable way to test this.
 
         @test MOI.get(model, MOI.VariableIndex, "Var1") == v[1]
         @test MOI.get(model, MOI.VariableIndex, "Var2") == v[2]
@@ -48,7 +50,6 @@ function nametest(model::MOI.ModelLike)
 
         MOI.set(model, MOI.ConstraintName(), c, "Con0")
         @test MOI.get(model, MOI.ConstraintName(), c) == "Con0"
-        @test_throws Exception MOI.set(model, MOI.ConstraintName(), c2, "Con0")
 
         MOI.set(model, MOI.ConstraintName(), [c], ["Con1"])
         @test MOI.get(model, MOI.ConstraintName(), [c]) == ["Con1"]

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -25,10 +25,13 @@ function nametest(model::MOI.ModelLike)
         MOI.set(model, MOI.VariableName(), v[2], "") # Shouldn't error with duplicate empty name
 
         MOI.set(model, MOI.VariableName(), v[1], "Var1")
+        @test_throws Exception begin
+            # An implementation may detect duplicate names wither when they're
+            # set or on lookup.
+            MOI.set(model, MOI.VariableName(), v[2], "Var1")
+            MOI.get(model, MOI.VariableIndex, "Var1")
+        end
         MOI.set(model, MOI.VariableName(), v[2], "Var2")
-
-        # TODO: Models might error in different ways when a duplicate name is
-        # set. Come up with a reasonable way to test this.
 
         @test MOI.get(model, MOI.VariableIndex, "Var1") == v[1]
         @test MOI.get(model, MOI.VariableIndex, "Var2") == v[2]
@@ -50,6 +53,12 @@ function nametest(model::MOI.ModelLike)
 
         MOI.set(model, MOI.ConstraintName(), c, "Con0")
         @test MOI.get(model, MOI.ConstraintName(), c) == "Con0"
+        @test_throws Exception begin
+            # An implementation may detect duplicate names wither when they're
+            # set or on lookup.
+            MOI.set(model, MOI.ConstraintName(), c2, "Con0")
+            MOI.get(model, MOI.ConstraintIndex, "Con1")
+        end
 
         MOI.set(model, MOI.ConstraintName(), [c], ["Con1"])
         @test MOI.get(model, MOI.ConstraintName(), [c]) == ["Con1"]

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -195,13 +195,13 @@ function MOI.get(model::AbstractModel, ::Type{VI}, name::String)
     if model.name_to_var === nothing
         # Rebuild the map.
         model.name_to_var = Dict{String, VI}()
-        for (var, name) in model.var_to_name
-            isempty(name) && continue
-            if haskey(model.name_to_var, name)
-                error("Variable $var and $(model.name_to_var[name]) have the " *
-                      "same name.")
+        for (var, var_name) in model.var_to_name
+            isempty(var_name) && continue
+            if haskey(model.name_to_var, var_name)
+                error("Variable $var and $(model.name_to_var[var_name]) have " *
+                      "the same name.")
             end
-            model.name_to_var[name] = var
+            model.name_to_var[var_name] = var
         end
     end
     return get(model.name_to_var, name, nothing)
@@ -222,13 +222,13 @@ function MOI.get(model::AbstractModel, ConType::Type{<:CI}, name::String)
     if model.name_to_con === nothing
         # Rebuild the map.
         model.name_to_con = Dict{String, CI}()
-        for (con, name) in model.con_to_name
-            isempty(name) && continue
-            if haskey(model.name_to_con, name)
-                error("Constraint $con and $(model.name_to_con[name]) have " *
-                      "the same name.")
+        for (con, con_name) in model.con_to_name
+            isempty(con_name) && continue
+            if haskey(model.name_to_con, con_name)
+                error("Constraint $con and $(model.name_to_con[con_name]) " *
+                      "have the same name.")
             end
-            model.name_to_con[name] = con
+            model.name_to_con[con_name] = con
         end
     end
     ci = get(model.name_to_con, name, nothing)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -111,9 +111,9 @@ function MOI.delete(model::AbstractModel, vi::VI)
         MOI.delete(model, ci)
     end
     delete!(model.varindices, vi)
-    if haskey(model.varnames, vi)
-        delete!(model.namesvar, model.varnames[vi])
-        delete!(model.varnames, vi)
+    model.name_to_var = nothing
+    if haskey(model.var_to_name, vi)
+        delete!(model.var_to_name, vi)
     end
 end
 
@@ -168,48 +168,70 @@ function check_can_assign_name(model::MOI.ModelLike, IndexType::Type{<:MOI.Index
 end
 
 """
-    setname(index_to_names::Dict{<:MOI.Index, String}, names_to_index::Dict{String, <:MOI.Index}, idx::MOI.Index, name::String, idxtype::Symbol)
+    setname(index_to_name::Dict{<:MOI.Index, String}, name_to_index::Dict{String, <:MOI.Index}, idx::MOI.Index, name::String, idxtype::Symbol)
 
-Sets the name of the index `idx` to the name `name` in the maps `index_to_names` and `names_to_index`.
+Sets the name of the index `idx` to the name `name` in the maps `index_to_name` and `name_to_index`.
 If `name` is empty, and `idx` already has a name, it is removed.
 """
-function setname(index_to_names::Dict{<:MOI.Index, String}, names_to_index::Dict{String, <:MOI.Index}, idx::MOI.Index, name::String)
-    if haskey(index_to_names, idx)
-        delete!(names_to_index, index_to_names[idx])
+function setname(index_to_name::Dict{<:MOI.Index, String}, name_to_index::Dict{String, <:MOI.Index}, idx::MOI.Index, name::String)
+    if haskey(index_to_name, idx)
+        delete!(name_to_index, index_to_name[idx])
     end
-    index_to_names[idx] = name
+    index_to_name[idx] = name
     if !isempty(name)
-        names_to_index[name] = idx
+        name_to_index[name] = idx
     end
     return
 end
 
 MOI.supports(::AbstractModel, ::MOI.VariableName, vi::Type{VI}) = true
 function MOI.set(model::AbstractModel, ::MOI.VariableName, vi::VI, name::String)
-    if check_can_assign_name(model, VI, vi, name)
-        setname(model.varnames, model.namesvar, vi, name)
-    end
+    model.var_to_name[vi] = name
+    model.name_to_var = nothing # Invalidate the name map.
 end
-MOI.get(model::AbstractModel, ::MOI.VariableName, vi::VI) = get(model.varnames, vi, EMPTYSTRING)
+MOI.get(model::AbstractModel, ::MOI.VariableName, vi::VI) = get(model.var_to_name, vi, EMPTYSTRING)
 
 function MOI.get(model::AbstractModel, ::Type{VI}, name::String)
-    return get(model.namesvar, name, nothing)
+    if model.name_to_var === nothing
+        # Rebuild the map.
+        model.name_to_var = Dict{String, VI}()
+        for (var, name) in model.var_to_name
+            isempty(name) && continue
+            if haskey(model.name_to_var, name)
+                error("Variable $var and $(model.name_to_var[name]) have the " *
+                      "same name.")
+            end
+            model.name_to_var[name] = var
+        end
+    end
+    return get(model.name_to_var, name, nothing)
 end
 
 function MOI.get(model::AbstractModel, ::MOI.ListOfVariableAttributesSet)::Vector{MOI.AbstractVariableAttribute}
-    isempty(model.varnames) ? [] : [MOI.VariableName()]
+    isempty(model.var_to_name) ? [] : [MOI.VariableName()]
 end
 
 MOI.supports(model::AbstractModel, ::MOI.ConstraintName, ::Type{<:CI}) = true
 function MOI.set(model::AbstractModel, ::MOI.ConstraintName, ci::CI, name::String)
-    if check_can_assign_name(model, CI, ci, name)
-        setname(model.connames, model.namescon, ci, name)
-    end
+    model.con_to_name[ci] = name
+    model.name_to_con = nothing # Invalidate the name map.
 end
-MOI.get(model::AbstractModel, ::MOI.ConstraintName, ci::CI) = get(model.connames, ci, EMPTYSTRING)
+MOI.get(model::AbstractModel, ::MOI.ConstraintName, ci::CI) = get(model.con_to_name, ci, EMPTYSTRING)
 
 function MOI.get(model::AbstractModel, ConType::Type{<:CI}, name::String)
-    ci = get(model.namescon, name, nothing)
+    if model.name_to_con === nothing
+        # Rebuild the map.
+        model.name_to_con = Dict{String, CI}()
+        for (con, name) in model.con_to_name
+            isempty(name) && continue
+            if haskey(model.name_to_con, name)
+                error("Constraint $con and $(model.name_to_con[name]) have " *
+                      "the same name.")
+            end
+            model.name_to_con[name] = con
+        end
+    end
+    ci = get(model.name_to_con, name, nothing)
     if ci isa ConType
         return ci
     else
@@ -218,7 +240,7 @@ function MOI.get(model::AbstractModel, ConType::Type{<:CI}, name::String)
 end
 
 function MOI.get(model::AbstractModel, ::MOI.ListOfConstraintAttributesSet)::Vector{MOI.AbstractConstraintAttribute}
-    isempty(model.connames) ? [] : [MOI.ConstraintName()]
+    isempty(model.con_to_name) ? [] : [MOI.ConstraintName()]
 end
 
 # Objective
@@ -283,9 +305,9 @@ function MOI.delete(model::AbstractModel, ci::CI)
         model.constrmap[ci_next.value] -= 1
     end
     model.constrmap[ci.value] = 0
-    if haskey(model.connames, ci)
-        delete!(model.namescon, model.connames[ci])
-        delete!(model.connames, ci)
+    model.name_to_con = nothing
+    if haskey(model.con_to_name, ci)
+        delete!(model.con_to_name, ci)
     end
 end
 
@@ -478,11 +500,11 @@ mutable struct LPModel{T} <: MOIU.AbstractModel{T}
     objective::Union{MOI.SingleVariable, MOI.ScalarAffineFunction{T}, MOI.ScalarQuadraticFunction{T}}
     nextvariableid::Int64
     varindices::Set{MOI.VariableIndex}
-    varnames::Dict{MOI.VariableIndex, String}
-    namesvar::Dict{String, MOI.VariableIndex}
+    var_to_name::Dict{MOI.VariableIndex, String}
+    name_to_var::Union{Dict{String, MOI.VariableIndex}, Nothing}
     nextconstraintid::Int64
-    connames::Dict{MOI.ConstraintIndex, String}
-    namescon::Dict{String, MOI.ConstraintIndex}
+    con_to_name::Dict{MOI.ConstraintIndex, String}
+    name_to_con::Union{Dict{String, MOI.ConstraintIndex}, Nothing}
     constrmap::Vector{Int}
     singlevariable::LPModelScalarConstraints{T, MOI.SingleVariable}
     scalaraffinefunction::LPModelScalarConstraints{T, MOI.ScalarAffineFunction{T}}
@@ -521,11 +543,12 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
             objective::Union{$MOI.SingleVariable, $MOI.ScalarAffineFunction{T}, $MOI.ScalarQuadraticFunction{T}}
             nextvariableid::Int64
             varindices::Set{$VI}
-            varnames::Dict{$VI, String}
-            namesvar::Dict{String, $VI}
+            var_to_name::Dict{$VI, String}
+            # If nothing, the dictionary hasn't been constructed yet.
+            name_to_var::Union{Dict{String, $VI}, Nothing}
             nextconstraintid::Int64
-            connames::Dict{$CI, String}
-            namescon::Dict{String, $CI}
+            con_to_name::Dict{$CI, String}
+            name_to_con::Union{Dict{String, $CI}, Nothing}
             constrmap::Vector{Int} # Constraint Reference value ci -> index in array in Constraints
         end
     end
@@ -550,11 +573,11 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
             model.objective = $SAF{T}(MOI.ScalarAffineTerm{T}[], zero(T))
             model.nextvariableid = 0
             empty!(model.varindices)
-            empty!(model.varnames)
-            empty!(model.namesvar)
+            empty!(model.var_to_name)
+            model.name_to_var = nothing
             model.nextconstraintid = 0
-            empty!(model.connames)
-            empty!(model.namescon)
+            empty!(model.con_to_name)
+            model.name_to_con = nothing
             empty!(model.constrmap)
             $(Expr(:block, _callfield.(Ref(:($MOI.empty!)), funs)...))
         end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -198,6 +198,7 @@ function MOI.get(model::AbstractModel, ::Type{VI}, name::String)
         for (var, var_name) in model.var_to_name
             isempty(var_name) && continue
             if haskey(model.name_to_var, var_name)
+                model.name_to_var = nothing
                 error("Variable $var and $(model.name_to_var[var_name]) have " *
                       "the same name.")
             end
@@ -225,6 +226,7 @@ function MOI.get(model::AbstractModel, ConType::Type{<:CI}, name::String)
         for (con, con_name) in model.con_to_name
             isempty(con_name) && continue
             if haskey(model.name_to_con, con_name)
+                model.name_to_con = nothing
                 error("Constraint $con and $(model.name_to_con[con_name]) " *
                       "have the same name.")
             end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -633,8 +633,8 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
         $modeldef
         function $modelname{T}() where T
             $modelname{T}("", false, $MOI.FeasibilitySense, false, $SAF{T}($MOI.ScalarAffineTerm{T}[], zero(T)),
-                   0, Set{$VI}(), Dict{$VI, String}(), Dict{String, $VI}(),
-                   0, Dict{$CI, String}(), Dict{String, $CI}(), Int[],
+                   0, Set{$VI}(), Dict{$VI, String}(), nothing,
+                   0, Dict{$CI, String}(), nothing, Int[],
                    $(_getCV.(funs)...))
         end
 

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -179,6 +179,7 @@ end
 # Name
 # The names of constraints not supported by `uf.model` need to be handled
 function MOI.set(uf::UniversalFallback, attr::MOI.ConstraintName, ci::CI{F, S}, name::String) where {F, S}
+    # TODO: Switch to lazily building the name-to-con dict like Model does.
     if check_can_assign_name(uf, CI, ci, name)
         if MOI.supports_constraint(uf.model, F, S)
             MOI.set(uf.model, attr, ci, name)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -160,18 +160,24 @@ Return a vector of attributes corresponding to each constraint in the collection
     get(model::ModelLike, ::Type{VariableIndex}, name::String)
 
 If a variable with name `name` exists in the model `model`, return the
-corresponding index, otherwise return `nothing`.
+corresponding index, otherwise return `nothing`. Errors if two variables
+have the same name and the model implementation does not check for duplicates
+when the names are set.
 
     get(model::ModelLike, ::Type{ConstraintIndex{F,S}}, name::String) where {F<:AbstractFunction,S<:AbstractSet}
 
 If an `F`-in-`S` constraint with name `name` exists in the model `model`, return
-the corresponding index, otherwise return `nothing`.
+the corresponding index, otherwise return `nothing`. Errors if two constraints
+have the same name and the model implementation does not check for duplicates
+when the names are set.
 
     get(model::ModelLike, ::Type{ConstraintIndex}, name::String)
 
 If *any* constraint with name `name` exists in the model `model`, return the
 corresponding index, otherwise return `nothing`. This version is available for
 convenience but may incur a performance penalty because it is not type stable.
+Errors if two constraints have the same name and the model implementation does
+not check for duplicates when the names are set.
 
 ### Examples
 
@@ -503,7 +509,15 @@ struct ListOfVariableAttributesSet <: AbstractModelAttribute end
 """
     VariableName()
 
-A variable attribute for the string identifying the variable. It is invalid for two variables to have the same name.
+A variable attribute for the string identifying the variable. It is invalid for
+two variables to have the same name.
+
+## Note
+
+An implementation may but is not required to check for duplicate names when the
+`VariableName` attribute is set. If this check is not performed when the name
+is set, then looking up a variable by name must throw an error when more than
+one variable has the same name.
 """
 struct VariableName <: AbstractVariableAttribute end
 
@@ -566,7 +580,15 @@ struct ListOfConstraintAttributesSet{F,S} <: AbstractModelAttribute end
 """
     ConstraintName()
 
-A constraint attribute for the string identifying the constraint. It is invalid for two constraints of any kind to have the same name.
+A constraint attribute for the string identifying the constraint. It is invalid
+for two constraints of any kind to have the same name.
+
+## Note
+
+An implementation may but is not required to check for duplicate names when the
+`ConstraintName` attribute is set. If this check is not performed when the name
+is set, then looking up a constraint by name must throw an error when more than
+one constraint (of any type) has the same name.
 """
 struct ConstraintName <: AbstractConstraintAttribute end
 


### PR DESCRIPTION
Following up on the discussion in https://github.com/JuliaOpt/JuMP.jl/issues/1402. This change avoids creating the `names_to_var` dictionary until it's needed.

Using @IainNZ's script that benchmarks variable creation time,

Before:
```
10^1:  0.000 s, 3981.300000 ns/var, 286 a, 28.600000 a/var
10^2:  0.000 s, 1016.850000 ns/var, 844 a, 8.440000 a/var
10^3:  0.001 s, 703.424000 ns/var, 6756 a, 6.756000 a/var
10^4:  0.007 s, 664.980500 ns/var, 69774 a, 6.977400 a/var
10^5:  0.100 s, 1003.817160 ns/var, 699808 a, 6.998080 a/var
10^6:  1.558 s, 1558.397552 ns/var, 6999859 a, 6.999859 a/var
```

After:
```
10^1:  0.000 s, 3638.900000 ns/var, 286 a, 28.600000 a/var
10^2:  0.000 s, 829.310000 ns/var, 838 a, 8.380000 a/var
10^3:  0.001 s, 520.511000 ns/var, 6742 a, 6.742000 a/var
10^4:  0.005 s, 491.230300 ns/var, 69754 a, 6.975400 a/var
10^5:  0.077 s, 766.043240 ns/var, 699776 a, 6.997760 a/var
10^6:  1.005 s, 1004.825593 ns/var, 6999809 a, 6.999809 a/var
```
so we get the ~0.5 seconds back as predicted.

These results are with an immutable `VariableInfo` struct (https://github.com/JuliaOpt/JuMP.jl/issues/1525).

Closes #536 