### PR TITLE
Allow all correct solution for solve_blank_obj

### DIFF
--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -131,10 +131,12 @@ function solve_blank_obj(model::MOI.ModelLike, config::TestConfig)
     c = MOI.get(model, MOI.ConstraintIndex{MOI.SingleVariable, MOI.GreaterThan{Float64}}, "c")
     test_model_solution(model, config;
         objective_value   = 0.0,
-        variable_primal   = [(x, 1.0)],
-        constraint_primal = [(c, 1.0)],
         constraint_dual   = [(c, 0.0)]
     )
+    # The objective is blank so any primal value ≥ 1 is correct
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    @test MOI.get(model, MOI.VariablePrimal(), x) + atol + rtol ≥ 1.0
+    @test MOI.get(model, MOI.ConstraintPrimal(), c) + atol + rtol ≥ 1.0
 end
 unittests["solve_blank_obj"] = solve_blank_obj
 

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -133,10 +133,12 @@ function solve_blank_obj(model::MOI.ModelLike, config::TestConfig)
         objective_value   = 0.0,
         constraint_dual   = [(c, 0.0)]
     )
-    # The objective is blank so any primal value ≥ 1 is correct
-    @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(model, MOI.VariablePrimal(), x) + atol + rtol ≥ 1.0
-    @test MOI.get(model, MOI.ConstraintPrimal(), c) + atol + rtol ≥ 1.0
+    if config.solve
+        # The objective is blank so any primal value ≥ 1 is correct
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.VariablePrimal(), x) + atol + rtol ≥ 1.0
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) + atol + rtol ≥ 1.0
+    end
 end
 unittests["solve_blank_obj"] = solve_blank_obj
 

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -34,6 +34,15 @@ end
             )
         )
         MOIT.solve_blank_obj(mock, config)
+        # The objective is blank so any primal value ≥ 1 is correct
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.Success,
+                (MOI.FeasiblePoint, [2]),
+                MOI.FeasiblePoint
+            )
+        )
+        MOIT.solve_blank_obj(mock, config)
     end
     @testset "solve_constant_obj" begin
         MOIU.set_mock_optimize!(mock,


### PR DESCRIPTION
CSDP, OSQP and ECOS fail this tests because `x` is not 1.0 but there is no reason why `x` should exactly be 1.0