### PR TITLE
Allow duplicate variable names

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -146,44 +146,6 @@ function MOI.set(model::AbstractModel, ::MOI.Name, name::String)
 end
 MOI.get(model::AbstractModel, ::MOI.Name) = model.name
 
-"""
-    check_can_assign_name(model::MOI.ModelLike, IndexType::Type{<:MOI.Index}, idx::MOI.Index, name::String)
-
-Return a `Bool` indicating whether `name` is available to be used by an
-index of type `IndexType` (i.e., it is not already used). If it is already used
-and the index using this name is not `idx` then it throws an error.
-"""
-function check_can_assign_name(model::MOI.ModelLike, IndexType::Type{<:MOI.Index}, idx::MOI.Index, name::String)
-    if !isempty(name)
-        other_idx = MOI.get(model, IndexType, name)
-        if other_idx === nothing
-            return true
-        elseif other_idx != idx
-            error("$(IndexType == VI ? :Variable : :Constraint) name $name is already used by $other_idx)")
-        end
-        return false
-    else
-        return true
-    end
-end
-
-"""
-    setname(index_to_name::Dict{<:MOI.Index, String}, name_to_index::Dict{String, <:MOI.Index}, idx::MOI.Index, name::String, idxtype::Symbol)
-
-Sets the name of the index `idx` to the name `name` in the maps `index_to_name` and `name_to_index`.
-If `name` is empty, and `idx` already has a name, it is removed.
-"""
-function setname(index_to_name::Dict{<:MOI.Index, String}, name_to_index::Dict{String, <:MOI.Index}, idx::MOI.Index, name::String)
-    if haskey(index_to_name, idx)
-        delete!(name_to_index, index_to_name[idx])
-    end
-    index_to_name[idx] = name
-    if !isempty(name)
-        name_to_index[name] = idx
-    end
-    return
-end
-
 MOI.supports(::AbstractModel, ::MOI.VariableName, vi::Type{VI}) = true
 function MOI.set(model::AbstractModel, ::MOI.VariableName, vi::VI, name::String)
     model.var_to_name[vi] = name
@@ -196,16 +158,21 @@ function MOI.get(model::AbstractModel, ::Type{VI}, name::String)
         # Rebuild the map.
         model.name_to_var = Dict{String, VI}()
         for (var, var_name) in model.var_to_name
-            isempty(var_name) && continue
             if haskey(model.name_to_var, var_name)
-                model.name_to_var = nothing
-                error("Variable $var and $(model.name_to_var[var_name]) have " *
-                      "the same name.")
+                # -1 is a special value that means this string does not map to
+                # a unique variable name.
+                model.name_to_var[var_name] = VI(-1)
+            else
+                model.name_to_var[var_name] = var
             end
-            model.name_to_var[var_name] = var
         end
     end
-    return get(model.name_to_var, name, nothing)
+    result = get(model.name_to_var, name, nothing)
+    if result == VI(-1)
+        error("Multiple variables have the name $name.")
+    else
+        return result
+    end
 end
 
 function MOI.get(model::AbstractModel, ::MOI.ListOfVariableAttributesSet)::Vector{MOI.AbstractVariableAttribute}
@@ -224,17 +191,19 @@ function MOI.get(model::AbstractModel, ConType::Type{<:CI}, name::String)
         # Rebuild the map.
         model.name_to_con = Dict{String, CI}()
         for (con, con_name) in model.con_to_name
-            isempty(con_name) && continue
             if haskey(model.name_to_con, con_name)
-                model.name_to_con = nothing
-                error("Constraint $con and $(model.name_to_con[con_name]) " *
-                      "have the same name.")
+                # CI{Nothing, Nothing}(-1) is a special value that means this
+                # string does not map to a unique constraint name.
+                model.name_to_con[con_name] = CI{Nothing, Nothing}(-1)
+            else
+                model.name_to_con[con_name] = con
             end
-            model.name_to_con[con_name] = con
         end
     end
     ci = get(model.name_to_con, name, nothing)
-    if ci isa ConType
+    if ci == CI{Nothing, Nothing}(-1)
+        error("Multiple constraints have the name $name.")
+    elseif ci isa ConType
         return ci
     else
         return nothing

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -14,8 +14,8 @@ mutable struct UniversalFallback{MT} <: MOI.ModelLike
     model::MT
     constraints::Dict{Tuple{DataType, DataType}, Dict} # See https://github.com/JuliaOpt/JuMP.jl/issues/1152
     nextconstraintid::Int64
-    connames::Dict{CI, String}
-    namescon::Dict{String, CI}
+    con_to_name::Dict{CI, String}
+    name_to_con::Union{Dict{String, MOI.ConstraintIndex}, Nothing}
     optattr::Dict{MOI.AbstractOptimizerAttribute, Any}
     modattr::Dict{MOI.AbstractModelAttribute, Any}
     varattr::Dict{MOI.AbstractVariableAttribute, Dict{VI, Any}}
@@ -25,7 +25,7 @@ mutable struct UniversalFallback{MT} <: MOI.ModelLike
                            Dict{Tuple{DataType, DataType}, Dict}(),
                            0,
                            Dict{CI, String}(),
-                           Dict{String, CI}(),
+                           nothing,
                            Dict{MOI.AbstractOptimizerAttribute, Any}(),
                            Dict{MOI.AbstractModelAttribute, Any}(),
                            Dict{MOI.AbstractVariableAttribute, Dict{VI, Any}}(),
@@ -39,8 +39,8 @@ function MOI.empty!(uf::UniversalFallback)
     MOI.empty!(uf.model)
     empty!(uf.constraints)
     uf.nextconstraintid = 0
-    empty!(uf.connames)
-    empty!(uf.namescon)
+    empty!(uf.con_to_name)
+    uf.name_to_con = nothing
     empty!(uf.optattr)
     empty!(uf.modattr)
     empty!(uf.varattr)
@@ -65,10 +65,10 @@ function MOI.delete(uf::UniversalFallback, ci::CI{F, S}) where {F, S}
             throw(MOI.InvalidIndex(ci))
         end
         delete!(uf.constraints[(F, S)], ci)
-        if haskey(uf.connames, ci)
-            delete!(uf.namescon, uf.connames[ci])
-            delete!(uf.connames, ci)
+        if haskey(uf.con_to_name, ci)
+            delete!(uf.con_to_name, ci)
         end
+        uf.name_to_con = nothing
     end
     for d in values(uf.conattr)
         delete!(d, ci)
@@ -173,30 +173,53 @@ end
 # Name
 # The names of constraints not supported by `uf.model` need to be handled
 function MOI.set(uf::UniversalFallback, attr::MOI.ConstraintName, ci::CI{F, S}, name::String) where {F, S}
-    # TODO: Switch to lazily building the name-to-con dict like Model does.
-    if check_can_assign_name(uf, CI, ci, name)
-        if MOI.supports_constraint(uf.model, F, S)
-            MOI.set(uf.model, attr, ci, name)
-        else
-            setname(uf.connames, uf.namescon, ci, name)
-        end
+    if MOI.supports_constraint(uf.model, F, S)
+        MOI.set(uf.model, attr, ci, name)
+    else
+        uf.con_to_name[ci] = name
+        uf.name_to_con = nothing # Invalidate the name map.
     end
+    return
 end
 function MOI.get(uf::UniversalFallback, attr::MOI.ConstraintName, ci::CI{F, S}) where {F, S}
     if MOI.supports_constraint(uf.model, F, S)
         return MOI.get(uf.model, attr, ci)
     else
-        return get(uf.connames, ci, EMPTYSTRING)
+        return get(uf.con_to_name, ci, EMPTYSTRING)
     end
+end
+
+function build_name_to_con_map(uf::UniversalFallback)
+    uf.name_to_con = Dict{String, CI}()
+    for (con, con_name) in uf.con_to_name
+        if haskey(uf.name_to_con, con_name)
+            # -1 is a special value that means this string does not map to
+            # a unique constraint name.
+            uf.name_to_con[con_name] = CI{Nothing, Nothing}(-1)
+        else
+            uf.name_to_con[con_name] = con
+        end
+    end
+    return
 end
 
 MOI.get(uf::UniversalFallback, ::Type{VI}, name::String) = MOI.get(uf.model, VI, name)
 function MOI.get(uf::UniversalFallback, ::Type{CI{F, S}}, name::String) where {F, S}
+    if uf.name_to_con === nothing
+        build_name_to_con_map(uf)
+    end
+
     if MOI.supports_constraint(uf.model, F, S)
-        return MOI.get(uf.model, CI{F, S}, name)
+        ci = MOI.get(uf.model, CI{F, S}, name)
+        if ci !== nothing && haskey(uf.name_to_con, name)
+            error("Multiple constraints have the name $name.")
+        end
+        return ci
     else
-        ci = get(uf.namescon, name, nothing)
-        if ci isa CI{F, S}
+        ci = get(uf.name_to_con, name, nothing)
+        if ci == CI{Nothing, Nothing}(-1)
+            error("Multiple constraints have the name $name.")
+        elseif ci isa CI{F, S}
             return ci
         else
             return nothing
@@ -204,10 +227,22 @@ function MOI.get(uf::UniversalFallback, ::Type{CI{F, S}}, name::String) where {F
     end
 end
 function MOI.get(uf::UniversalFallback, ::Type{CI}, name::String)
+    if uf.name_to_con === nothing
+        build_name_to_con_map(uf)
+    end
+
     ci = MOI.get(uf.model, CI, name)
     if ci === nothing
-        return get(uf.namescon, name, nothing)
+        uf_ci = get(uf.name_to_con, name, nothing)
+        if uf_ci == CI{Nothing, Nothing}(-1)
+            error("Multiple constraints have the name $name.")
+        else
+            return uf_ci
+        end
     else
+        if haskey(uf.name_to_con, name)
+            error("Multiple constraints have the name $name.")
+        end
         return ci
     end
 end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -189,24 +189,10 @@ function MOI.get(uf::UniversalFallback, attr::MOI.ConstraintName, ci::CI{F, S}) 
     end
 end
 
-function build_name_to_con_map(uf::UniversalFallback)
-    uf.name_to_con = Dict{String, CI}()
-    for (con, con_name) in uf.con_to_name
-        if haskey(uf.name_to_con, con_name)
-            # -1 is a special value that means this string does not map to
-            # a unique constraint name.
-            uf.name_to_con[con_name] = CI{Nothing, Nothing}(-1)
-        else
-            uf.name_to_con[con_name] = con
-        end
-    end
-    return
-end
-
 MOI.get(uf::UniversalFallback, ::Type{VI}, name::String) = MOI.get(uf.model, VI, name)
 function MOI.get(uf::UniversalFallback, ::Type{CI{F, S}}, name::String) where {F, S}
     if uf.name_to_con === nothing
-        build_name_to_con_map(uf)
+        uf.name_to_con = build_name_to_con_map(uf.con_to_name)
     end
 
     if MOI.supports_constraint(uf.model, F, S)
@@ -228,7 +214,7 @@ function MOI.get(uf::UniversalFallback, ::Type{CI{F, S}}, name::String) where {F
 end
 function MOI.get(uf::UniversalFallback, ::Type{CI}, name::String)
     if uf.name_to_con === nothing
-        build_name_to_con_map(uf)
+        uf.name_to_con = build_name_to_con_map(uf.con_to_name)
     end
 
     ci = MOI.get(uf.model, CI, name)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -161,23 +161,20 @@ Return a vector of attributes corresponding to each constraint in the collection
 
 If a variable with name `name` exists in the model `model`, return the
 corresponding index, otherwise return `nothing`. Errors if two variables
-have the same name and the model implementation does not check for duplicates
-when the names are set.
+have the same name.
 
     get(model::ModelLike, ::Type{ConstraintIndex{F,S}}, name::String) where {F<:AbstractFunction,S<:AbstractSet}
 
 If an `F`-in-`S` constraint with name `name` exists in the model `model`, return
 the corresponding index, otherwise return `nothing`. Errors if two constraints
-have the same name and the model implementation does not check for duplicates
-when the names are set.
+have the same name.
 
     get(model::ModelLike, ::Type{ConstraintIndex}, name::String)
 
 If *any* constraint with name `name` exists in the model `model`, return the
 corresponding index, otherwise return `nothing`. This version is available for
 convenience but may incur a performance penalty because it is not type stable.
-Errors if two constraints have the same name and the model implementation does
-not check for duplicates when the names are set.
+Errors if two constraints have the same name.
 
 ### Examples
 
@@ -509,15 +506,9 @@ struct ListOfVariableAttributesSet <: AbstractModelAttribute end
 """
     VariableName()
 
-A variable attribute for the string identifying the variable. It is invalid for
-two variables to have the same name.
-
-## Note
-
-An implementation may but is not required to check for duplicate names when the
-`VariableName` attribute is set. If this check is not performed when the name
-is set, then looking up a variable by name must throw an error when more than
-one variable has the same name.
+A variable attribute for a string identifying the variable. It is *valid* for
+two variables to have the same name; however, variables with duplicate names
+cannot be looked up using [`MOI.get`](@ref).
 """
 struct VariableName <: AbstractVariableAttribute end
 
@@ -580,15 +571,10 @@ struct ListOfConstraintAttributesSet{F,S} <: AbstractModelAttribute end
 """
     ConstraintName()
 
-A constraint attribute for the string identifying the constraint. It is invalid
-for two constraints of any kind to have the same name.
-
-## Note
-
-An implementation may but is not required to check for duplicate names when the
-`ConstraintName` attribute is set. If this check is not performed when the name
-is set, then looking up a constraint by name must throw an error when more than
-one constraint (of any type) has the same name.
+A constraint attribute for a string identifying the constraint. It is *valid*
+for constraints variables to have the same name; however, constraints with
+duplicate names cannot be looked up using [`MOI.get`](@ref) regardless of if
+they have the same `F`-in`S` type.
 """
 struct ConstraintName <: AbstractConstraintAttribute end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -1,12 +1,4 @@
-MOIU.@model(LPModel,
-            (),
-            (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval),
-            (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives),
-            (),
-            (MOI.SingleVariable,),
-            (MOI.ScalarAffineFunction,),
-            (MOI.VectorOfVariables,),
-            (MOI.VectorAffineFunction,))
+# TODO: It's hard to find where Model is defined!
 
 @testset "Name test" begin
     MOIT.nametest(Model{Float64}())


### PR DESCRIPTION
Throw an error only when looking up a string that corresponds to multiple
variables.

Closes #548
Closes JuliaOpt/JuMP.jl#1292