### PR TITLE
Disable Julia v0.6 and v0.7 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.6
-  - julia_version: 0.7
+# - julia_version: 0.6 # Disabled to speed up CI, Julia v0.6 and v0.7 are still
+# - julia_version: 0.7 # tested on Linux with Travis
   - julia_version: 1.0
 
 platform:


### PR DESCRIPTION
Similar to https://github.com/JuliaOpt/JuMP.jl/pull/1572