### PR TITLE
Use a Travis project to build doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,14 @@ after_success:
   #- julia -e 'cd(Pkg.dir("MathOptInterface")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
   - julia -e 'cd(Pkg.dir("MathOptInterface")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("MathOptInterface")); include(joinpath("docs", "make.jl"))'
+
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();
+                                    Pkg.develop(PackageSpec(path=pwd()))'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.19"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ deploydocs(
     repo   = "github.com/JuliaOpt/MathOptInterface.jl.git",
     target = "build",
     osname = "linux",
-    julia  = "0.6",
+    julia  = "1.0",
     deps   = nothing,
     make   = nothing,
 )


### PR DESCRIPTION
It allows to prevent breakage with Documenter v0.20 as it is fixed to v0.19 in `docs/Project.toml`: https://discourse.julialang.org/t/psa-documenter-jl-breaking-changes-version-capping/16431

Closes #539