### PR TITLE
Add supports_default_copy_to

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -850,14 +850,14 @@ Avoid storing extra copies of the problem when possible. This means that solver 
   ```
   with
   ```julia
-  MOI.Utilities.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = true
+  MOI.Utilities.supports_default_copy_to(model::AbstractModel, copy_names::Bool) = true
   ```
   or
   ```julia
-  MOI.Utilities.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = !copy_names
+  MOI.Utilities.supports_default_copy_to(model::AbstractModel, copy_names::Bool) = !copy_names
   ```
   depending on whether the solver support names; see
-  [`Utilities.supports_incremental_copy`](@ref) for more details.
+  [`Utilities.supports_default_copy_to`](@ref) for more details.
 * If the solver does not support loading the problem incrementally, do not
   implement [`add_variable`](@ref) and [`add_constraint`](@ref) as implementing
   them would require caching the problem. Let users or JuMP decide whether to
@@ -867,7 +867,7 @@ Avoid storing extra copies of the problem when possible. This means that solver 
   do
   ```julia
   function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; kws...)
-      return MOIU.automatic_copy_to(dest, src, kws...)
+      return MOI.Utilities.automatic_copy_to(dest, src, kws...)
   end
   ```
   with
@@ -879,15 +879,17 @@ Avoid storing extra copies of the problem when possible. This means that solver 
   MOI.Utilities.supports_allocate_load(model::AbstractModel, copy_names::Bool) = !copy_names
   ```
   depending on whether the solver support names; see
-  [`Utilities.supports_allocate_load`](@ref) for more details. Note that even if both
-  writing  a custom implementation of [`copy_to`](@ref) and implementing the
-  [Allocate-Load API](@ref) requires the user to copy the model from a cache,
-  the [Allocate-Load API](@ref) allows MOI layers to be added between the cache
-  and the solver which allows to apply transformation without the need for
-  additional caching. For instance, with [Light bridges](https://github.com/JuliaOpt/MathOptInterface.jl/issues/523),
+  [`Utilities.supports_allocate_load`](@ref) for more details.
+
+  Note that even if both writing a custom implementation of [`copy_to`](@ref)
+  and implementing the [Allocate-Load API](@ref) requires the user to copy the
+  model from a cache, the [Allocate-Load API](@ref) allows MOI layers to be
+  added between the cache and the solver which allows transformations to be
+  applied without the need for additional caching. For instance, with the
+  proposed [Light bridges](https://github.com/JuliaOpt/MathOptInterface.jl/issues/523),
   no cache will be needed to store the bridged model when bridges are used by
-  JuMP so implementing the [Allocate-Load API](@ref) will allow JuMP to use
-  only one cache instead of two.
+  JuMP so implementing the [Allocate-Load API](@ref) will allow JuMP to use only
+  one cache instead of two.
 
 ### JuMP mapping
 

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -838,7 +838,7 @@ will additionally support `ScalarAffineFunction`-in-`Interval`.
 ### Implementing copy
 
 Avoid storing extra copies of the problem when possible. This means that solver wrappers should not use
-`CachingOptimizer` as part of the wrapper. Instead, there do one of the following to load the problem:
+`CachingOptimizer` as part of the wrapper. Instead, do one of the following to load the problem:
 
 * If the solver supports loading the problem incrementally, implement
   [`add_variable`](@ref), [`add_constraint`](@ref) for supported constraints and
@@ -859,10 +859,10 @@ MOI.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = !copy_na
   depending on whether the solver support names; see
   [`supports_incremental_copy`](@ref) for more details.
 * If the solver does not support loading the problem incrementally, do not
-  implement [`add_variable`](@ref) and [`add_constraint`](@ref) they would
-  require caching the problem. Let users or JuMP decide to use
-  a [`CachingOptimizer`](@ref) instead. Write either a custom implementation of
-  [`copy_to`](@ref) or implement the [Allocate-Load API](@ref). If you choose
+  implement [`add_variable`](@ref) and [`add_constraint`](@ref) as implementing
+  them would require caching the problem. Let users or JuMP decide whether to
+  use a [`CachingOptimizer`](@ref) instead. Write either a custom implementation
+  of [`copy_to`](@ref) or implement the [Allocate-Load API](@ref). If you choose
   to implement the [Allocate-Load API](@ref), do
   ```julia
 function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; copy_names=true)

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -844,41 +844,42 @@ Avoid storing extra copies of the problem when possible. This means that solver 
   [`add_variable`](@ref), [`add_constraint`](@ref) for supported constraints and
   [`set`](@ref) for supported attributes and add:
   ```julia
-function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; copy_names=true)
-    return MOIU.automatic_copy_to(dest, src, copy_names)
-end
+  function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; kws...)
+      return MOI.Utilities.automatic_copy_to(dest, src, kws...)
+  end
   ```
   with
   ```julia
-MOI.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = true
+  MOI.Utilities.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = true
   ```
   or
   ```julia
-MOI.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = !copy_names
+  MOI.Utilities.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = !copy_names
   ```
   depending on whether the solver support names; see
-  [`supports_incremental_copy`](@ref) for more details.
+  [`Utilities.supports_incremental_copy`](@ref) for more details.
 * If the solver does not support loading the problem incrementally, do not
   implement [`add_variable`](@ref) and [`add_constraint`](@ref) as implementing
   them would require caching the problem. Let users or JuMP decide whether to
-  use a [`CachingOptimizer`](@ref) instead. Write either a custom implementation
-  of [`copy_to`](@ref) or implement the [Allocate-Load API](@ref). If you choose
-  to implement the [Allocate-Load API](@ref), do
+  use a `CachingOptimizer` instead. Write either a custom implementation of
+  [`copy_to`](@ref) or implement the [Allocate-Load API](@ref). If you choose to
+  implement the Allocate-Load API,
+  do
   ```julia
-function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; copy_names=true)
-    return MOIU.automatic_copy_to(dest, src, copy_names)
-end
+  function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; kws...)
+      return MOIU.automatic_copy_to(dest, src, kws...)
+  end
   ```
   with
   ```julia
-MOI.supports_allocate_load(model::AbstractModel, copy_names::Bool) = true
+  MOI.Utilities.supports_allocate_load(model::AbstractModel, copy_names::Bool) = true
   ```
   or
   ```julia
-MOI.supports_allocate_load(model::AbstractModel, copy_names::Bool) = !copy_names
+  MOI.Utilities.supports_allocate_load(model::AbstractModel, copy_names::Bool) = !copy_names
   ```
   depending on whether the solver support names; see
-  [`supports_allocate_load`](@ref) for more details. Note that even if both
+  [`Utilities.supports_allocate_load`](@ref) for more details. Note that even if both
   writing  a custom implementation of [`copy_to`](@ref) and implementing the
   [Allocate-Load API](@ref) requires the user to copy the model from a cache,
   the [Allocate-Load API](@ref) allows MOI layers to be added between the cache

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -368,7 +368,7 @@ The following utilities can be used to implement [`copy_to`](@ref). See
 ```@docs
 Utilities.automatic_copy_to
 Utilities.default_copy_to
-Utilities.supports_incremental_copy
+Utilities.supports_default_copy_to
 ```
 
 ### Allocate-Load API

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -360,22 +360,33 @@ Bridges.RSOCtoPSDBridge
 ```
 For each bridge defined in this package, a corresponding bridge optimizer is available with the same name without the "Bridge" suffix, e.g., `SplitInterval` is an `SingleBridgeOptimizer` for the `SplitIntervalBridge`.
 
-## Allocate-Load API
+## Copy utilities
+
+The following utilities can be used to implement [`copy_to`](@ref). See
+[Implementing copy](@ref) for more details.
+
+```@docs
+Utilities.automatic_copy_to
+Utilities.default_copy_to
+Utilities.supports_incremental_copy
+```
+
+### Allocate-Load API
 
 The Allocate-Load API allows solvers that do not support loading the problem
 incrementally to implement [`copy_to`](@ref) in a way that still allows
 transformations to be applied in the copy between the cache and the
-model if the transformations are implemented as MOI layers implemented the
+model if the transformations are implemented as MOI layers implementing the
 Allocate-Load API, see [Implementing copy](@ref) for more details.
 
 Loading a model using the Allocate-Load interface consists of two passes
 through the model data:
-1) the allocate pass where the model typically record the necessary information
-about the constraints and attributes such as their number and size.
-This information may be used by the solver to allocate datastructures of
-appriate size.
-2) the load pass where the model typically load the constraint and attribute
-data to the model.
+1) the allocate pass where the model typically records the necessary information
+   about the constraints and attributes such as their number and size.
+   This information may be used by the solver to allocate datastructures of
+   appriate size.
+2) the load pass where the model typically loads the constraints and attributes
+   data to the model.
 
 The description above only gives a suggestion of what to achieve in each pass.
 In fact the exact same constraints and attributes are passes in each pass so
@@ -384,31 +395,30 @@ convenient in each pass.
 
 The main difference between each pass, appart from the fact that one is
 executed before the other during a copy is that the allocate pass needs to
-create and return new variable and constraint indices while the load pass
-needs to be given the appropriate constraint index.
+create and return new variable and constraint indices while during the load pass
+the appropriate constraint indices are provided.
 
-The Allocate-Load API is **not** meant to be used outside a copy operation.
+The Allocate-Load API is **not** meant to be used outside a copy operation,
+that is, the interface is not meant to be used to create new constraints with
+[`Utilities.allocate_constraint`](@ref) followed by
+[`Utilities.load_constraint`](@ref) after a solve.
 This means that the order in which the different functions of the API are
-called is fixed by [`MathOptInterface.Utilities.allocate_load`](@ref) and
-models implementing the API can rely on the fact that functions will be
-called in this order. That is, it can be assumed that the different functions
-will the called in the following order:
-1) [`allocate_variables`](@ref)
-2) [`allocate`](@ref) and [`allocate_constraint`](@ref)
-3) [`load_variables`](@ref) and [`allocate_constraint`](@ref)
-4) [`load`](@ref) and [`load_constraint`](@ref)
-
-The interface is not meant to be used to create new constraints with
-[`allocate_constraint`](@ref) followed by [`load_constraint`](@ref) after a
-solve, it is only meant for being used in this order to implement
-[`copy_to`](@ref).
+called is fixed by [`Utilities.allocate_load`](@ref) and models implementing the
+API can rely on the fact that functions will be called in this order. That is,
+it can be assumed that the different functions will the called in the following
+order:
+1) [`Utilities.allocate_variables`](@ref)
+2) [`Utilities.allocate`](@ref) and [`Utilities.allocate_constraint`](@ref)
+3) [`Utilities.load_variables`](@ref)
+4) [`Utilities.load`](@ref) and [`Utilities.load_constraint`](@ref)
 
 ```@docs
-allocate_variables
-allocate
-allocate_constraint
-load_variables
-load
-load_constraint
-allocate_load
+Utilities.allocate_load
+Utilities.supports_allocate_load
+Utilities.allocate_variables
+Utilities.allocate
+Utilities.allocate_constraint
+Utilities.load_variables
+Utilities.load
+Utilities.load_constraint
 ```

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -362,12 +362,13 @@ For each bridge defined in this package, a corresponding bridge optimizer is ava
 
 ## Allocate-Load API
 
-The Allocate-Load API allows to implement [`copy_to`](@ref) in a way that still
-allows transformations to be applied in the copy between the cache and the
+The Allocate-Load API allows solvers that do not support loading the problem
+incrementally to implement [`copy_to`](@ref) in a way that still allows
+transformations to be applied in the copy between the cache and the
 model if the transformations are implemented as MOI layers implemented the
-Allocate-Load API.
+Allocate-Load API, see [Implementing copy](@ref) for more details.
 
-Allocate-Load Interface: 2-pass copy of a MathOptInterface model
+The Allocate-Load Interface: 2-pass copy of a MathOptInterface model
 Some solver wrappers (e.g. SCS, ECOS, SDOI) do not supporting copying an optimization model using `MOI.add_constraints`, `MOI.add_variables` and `MOI.set`
 as they first need to figure out some information about a model before being able to pass the problem data to the solver.
 

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -384,19 +384,19 @@ through the model data:
 1) the allocate pass where the model typically records the necessary information
    about the constraints and attributes such as their number and size.
    This information may be used by the solver to allocate datastructures of
-   appriate size.
-2) the load pass where the model typically loads the constraints and attributes
+   appropriate size.
+2) the load pass where the model typically loads the constraint and attribute
    data to the model.
 
 The description above only gives a suggestion of what to achieve in each pass.
-In fact the exact same constraints and attributes are passes in each pass so
-an implementation of the Allocate-Load API is free to do whatever is more
+In fact the exact same constraint and attribute data is provided to each pass,
+so an implementation of the Allocate-Load API is free to do whatever is more
 convenient in each pass.
 
-The main difference between each pass, appart from the fact that one is
-executed before the other during a copy is that the allocate pass needs to
-create and return new variable and constraint indices while during the load pass
-the appropriate constraint indices are provided.
+The main difference between each pass, apart from the fact that one is executed
+before the other during a copy, is that the allocate pass needs to create and
+return new variable and constraint indices, while during the load pass the
+appropriate constraint indices are provided.
 
 The Allocate-Load API is **not** meant to be used outside a copy operation,
 that is, the interface is not meant to be used to create new constraints with

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -108,6 +108,52 @@ is_valid(dest, index_map[x]) # true
 """
 function copy_to end
 
+"""
+    supports_default_copy_to(model::ModelLike; copy_names::Bool=true)
+
+Return a `Bool` indicating whether the model `model` supports
+`default_copy_to(model, src, copy_names=copy_names)` where all the attibutes
+set and constraints added in `src` are supported by `model`.
+
+## Examples
+
+If [`set`](@ref), [`add_variable`](@ref) and [`add_constraint`](@ref) are
+implemented for a model of type `MyModel`, [`copy_to`](@ref) can be implemented
+as
+That is, whether given a model `src`
+Copy the model from `src` into `dest`. The target `dest` is emptied, and all
+previous indices to variables or constraints in `dest` are invalidated. Returns
+a dictionary-like object that translates variable and constraint indices from
+the `src` model to the corresponding indices in the `dest` model.
+
+If `copy_names` is `false`, the `Name`, `VariableName` and `ConstraintName`
+attributes are not copied even if they are set in `src`. If a constraint that
+is copied from `src` is not supported by `dest` then an
+[`UnsupportedConstraint`](@ref) error is thrown. Similarly, if a model, variable
+or constraint attribute that is copied from `src` is not supported by `dest`
+then an [`UnsupportedAttribute`](@ref) error is thrown. Unsupported *optimizer*
+attributes are treated differently:
+
+* If `warn_attributes` is `true`, a warning is displayed, otherwise,
+* the attribute is silently ignored.
+
+### Example
+
+```julia
+# Given empty `ModelLike` objects `src` and `dest`.
+
+x = add_variable(src)
+
+is_valid(src, x)   # true
+is_valid(dest, x)  # false (`dest` has no variables)
+
+index_map = copy_to(dest, src)
+is_valid(dest, x) # false (unless index_map[x] == x)
+is_valid(dest, index_map[x]) # true
+```
+"""
+function supports_default_copy_without_names end
+
 include("error.jl")
 include("indextypes.jl")
 include("functions.jl")

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -108,52 +108,6 @@ is_valid(dest, index_map[x]) # true
 """
 function copy_to end
 
-"""
-    supports_default_copy_to(model::ModelLike; copy_names::Bool=true)
-
-Return a `Bool` indicating whether the model `model` supports
-`default_copy_to(model, src, copy_names=copy_names)` where all the attibutes
-set and constraints added in `src` are supported by `model`.
-
-## Examples
-
-If [`set`](@ref), [`add_variable`](@ref) and [`add_constraint`](@ref) are
-implemented for a model of type `MyModel`, [`copy_to`](@ref) can be implemented
-as
-That is, whether given a model `src`
-Copy the model from `src` into `dest`. The target `dest` is emptied, and all
-previous indices to variables or constraints in `dest` are invalidated. Returns
-a dictionary-like object that translates variable and constraint indices from
-the `src` model to the corresponding indices in the `dest` model.
-
-If `copy_names` is `false`, the `Name`, `VariableName` and `ConstraintName`
-attributes are not copied even if they are set in `src`. If a constraint that
-is copied from `src` is not supported by `dest` then an
-[`UnsupportedConstraint`](@ref) error is thrown. Similarly, if a model, variable
-or constraint attribute that is copied from `src` is not supported by `dest`
-then an [`UnsupportedAttribute`](@ref) error is thrown. Unsupported *optimizer*
-attributes are treated differently:
-
-* If `warn_attributes` is `true`, a warning is displayed, otherwise,
-* the attribute is silently ignored.
-
-### Example
-
-```julia
-# Given empty `ModelLike` objects `src` and `dest`.
-
-x = add_variable(src)
-
-is_valid(src, x)   # true
-is_valid(dest, x)  # false (`dest` has no variables)
-
-index_map = copy_to(dest, src)
-is_valid(dest, x) # false (unless index_map[x] == x)
-is_valid(dest, index_map[x]) # true
-```
-"""
-function supports_default_copy_without_names end
-
 include("error.jl")
 include("indextypes.jl")
 include("functions.jl")

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -134,9 +134,10 @@ function attachoptimizer!(model::CachingOptimizer)
     end
 end
 
-function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; copy_names=true)
-    return default_copy_to(m, src, copy_names)
+function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; kws...)
+    return automatic_copy_to(m, src; kws...)
 end
+supports_incremental_copy(model::CachingOptimizer, copy_names::Bool) = true
 
 function MOI.empty!(m::CachingOptimizer)
     MOI.empty!(m.model_cache)

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -137,7 +137,9 @@ end
 function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; kws...)
     return automatic_copy_to(m, src; kws...)
 end
-supports_default_copy_to(model::CachingOptimizer, copy_names::Bool) = true
+function supports_default_copy_to(model::CachingOptimizer, copy_names::Bool)
+    return supports_default_copy_to(model.model_cache, copy_names)
+end
 
 function MOI.empty!(m::CachingOptimizer)
     MOI.empty!(m.model_cache)

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -137,7 +137,7 @@ end
 function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; kws...)
     return automatic_copy_to(m, src; kws...)
 end
-supports_incremental_copy(model::CachingOptimizer, copy_names::Bool) = true
+supports_default_copy_to(model::CachingOptimizer, copy_names::Bool) = true
 
 function MOI.empty!(m::CachingOptimizer)
     MOI.empty!(m.model_cache)

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -1,3 +1,51 @@
+# This file contains default implementations for the `MOI.copy_to` function
+# that can be used by a model.
+
+"""
+    supports_incremental_copy(model::ModelLike, copy_names::Bool)
+
+Return a `Bool` indicating whether the model `model` supports
+[`incremental_copy_to(model, src, copy_names=copy_names)`](@ref) if all
+the attibutes set to `src` and constraints added to `src` are supported by
+`model`.
+
+This function can be used to determine whether a model can loaded into `model`
+incrementally or whether it should be cached and copied at once instead.
+This is used by JuMP to determine whether to add a cache or not.
+If this function returns false whatever the value of `copy_names` is then
+JuMP stores a cache in a [`CachingOptimizer`](@ref) handling the names. Then if
+bridges are used, a cache of the bridged model is stored in another
+[`CachingOptimizer`](@ref).
+If `supports_incremental_copy(optimizer, false)` is `true` then no cache is
+used by default for the bridged model. If
+`supports_incremental_copy(optimizer, true)` is `true` then no caching is used
+by default to store the model and handling names as names are handled by
+`optimizer`.
+
+## Examples
+
+If [`set`](@ref), [`add_variable`](@ref) and [`add_constraint`](@ref) are
+implemented for a model of type `MyModel` and names are supported, then
+[`copy_to`](@ref) can be implemented as
+```julia
+MOI.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = true
+function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; copy_names=true)
+    return default_copy_to(dest, src, copy_names)
+end
+```
+The [`default_copy_to`](@ref) automatically redirects to
+[`incremental_copy_to`](@ref).
+
+If names are not supported, simply change the first line by
+```julia
+MOI.supports_incremental_copy(model::AbstractModel, copy_names::Bool) = !copy_names
+```
+The [`default_copy_to`](@ref) automatically throws an helpful error in case
+`copy_to` is called with `copy_names` equal to `true`.
+"""
+function supports_incremental_copy end
+
+
 struct IndexMap
     varmap::Dict{MOI.VariableIndex, MOI.VariableIndex}
     conmap::Dict{MOI.ConstraintIndex, MOI.ConstraintIndex}

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -32,10 +32,10 @@ This function can be used to determine whether a model can be loaded into
 `model` incrementally or whether it should be cached and copied at once instead.
 This is used by JuMP to determine whether to add a cache or not in two
 situations:
-1) A first cache can be used to store the model as entered by the user as well
+1. A first cache can be used to store the model as entered by the user as well
    as the names of variables and constraints. This cache is created if this
    function returns `false` when `copy_names` is `true`.
-2) If bridges are used, then a second cache can be used to store of the bridged
+2. If bridges are used, then a second cache can be used to store the bridged
    model with unnamed variables and constraints. This cache is created if this
    function returns `false` when `copy_names` is `false`.
 

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -61,7 +61,7 @@ MOI.supports_default_copy_to(model::MyModel, copy_names::Bool) = !copy_names
 The [`Utilities.default_copy_to`](@ref) function automatically throws an helpful
 error in case `copy_to` is called with `copy_names` equal to `true`.
 """
-supports_default_copy_to(model::MOI.ModelLike) = false
+supports_default_copy_to(model::MOI.ModelLike, copy_names::Bool) = false
 
 struct IndexMap
     varmap::Dict{MOI.VariableIndex, MOI.VariableIndex}

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -269,16 +269,17 @@ end
 # TODO: transform
 
 MOI.supports_constraint(mock::MockOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet}) = MOI.supports_constraint(mock.inner_model, F, S)
-function MOI.copy_to(mock::MockOptimizer, src::MOI.ModelLike; copy_names=true)
-    if needs_allocate_load(mock)
-        allocate_load(mock, src, copy_names)
-    else
-        default_copy_to(mock, src, copy_names)
-    end
+function MOI.copy_to(mock::MockOptimizer, src::MOI.ModelLike; kws...)
+    automatic_copy_to(mock, src; kws...)
+end
+function supports_incremental_copy(mock::MockOptimizer, copy_names::Bool)
+    return !mock.needs_allocate_load && supports_incremental_copy(mock.inner_model, copy_names)
 end
 
 # Allocate-Load Interface
-needs_allocate_load(mock::MockOptimizer) = mock.needs_allocate_load || needs_allocate_load(mock.inner_model)
+function supports_allocate_load(mock::MockOptimizer, copy_names::Bool)
+    return supports_allocate_load(mock.inner_model, copy_names)
+end
 
 allocate_variables(mock::MockOptimizer, nvars) = allocate_variables(mock.inner_model, nvars)
 allocate(mock::MockOptimizer, attr::MOI.AnyAttribute, value) = allocate(mock.inner_model, attr, value)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -272,8 +272,8 @@ MOI.supports_constraint(mock::MockOptimizer, F::Type{<:MOI.AbstractFunction}, S:
 function MOI.copy_to(mock::MockOptimizer, src::MOI.ModelLike; kws...)
     automatic_copy_to(mock, src; kws...)
 end
-function supports_incremental_copy(mock::MockOptimizer, copy_names::Bool)
-    return !mock.needs_allocate_load && supports_incremental_copy(mock.inner_model, copy_names)
+function supports_default_copy_to(mock::MockOptimizer, copy_names::Bool)
+    return !mock.needs_allocate_load && supports_default_copy_to(mock.inner_model, copy_names)
 end
 
 # Allocate-Load Interface

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -329,14 +329,15 @@ function MOI.is_empty(model::AbstractModel)
     iszero(model.nextvariableid) && iszero(model.nextconstraintid)
 end
 
-function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; copy_names=true)
-    return default_copy_to(dest, src, copy_names)
+function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; kws...)
+    return automatic_copy_to(dest, src; kws...)
 end
+supports_incremental_copy(model::AbstractModel, copy_names::Bool) = true
 
 # Allocate-Load Interface
 # Even if the model does not need it and use default_copy_to, it could be used
 # by a layer that needs it
-needs_allocate_load(model::AbstractModel) = false
+supports_allocate_load(model::AbstractModel, copy_names::Bool) = true
 
 function allocate_variables(model::AbstractModel, nvars)
     return MOI.add_variables(model, nvars)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -332,7 +332,7 @@ end
 function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; kws...)
     return automatic_copy_to(dest, src; kws...)
 end
-supports_incremental_copy(model::AbstractModel, copy_names::Bool) = true
+supports_default_copy_to(model::AbstractModel, copy_names::Bool) = true
 
 # Allocate-Load Interface
 # Even if the model does not need it and use default_copy_to, it could be used

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -46,7 +46,12 @@ function MOI.empty!(uf::UniversalFallback)
     empty!(uf.varattr)
     empty!(uf.conattr)
 end
-MOI.copy_to(uf::UniversalFallback, src::MOI.ModelLike; copy_names=true) = MOIU.default_copy_to(uf, src, copy_names)
+function MOI.copy_to(uf::UniversalFallback, src::MOI.ModelLike; kws...)
+    MOIU.automatic_copy_to(uf, src; kws...)
+end
+function supports_incremental_copy(uf::UniversalFallback, copy_names::Bool)
+    return supports_incremental_copy(uf.model, copy_names)
+end
 
 # References
 MOI.is_valid(uf::UniversalFallback, idx::VI) = MOI.is_valid(uf.model, idx)

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -49,8 +49,8 @@ end
 function MOI.copy_to(uf::UniversalFallback, src::MOI.ModelLike; kws...)
     MOIU.automatic_copy_to(uf, src; kws...)
 end
-function supports_incremental_copy(uf::UniversalFallback, copy_names::Bool)
-    return supports_incremental_copy(uf.model, copy_names)
+function supports_default_copy_to(uf::UniversalFallback, copy_names::Bool)
+    return supports_default_copy_to(uf.model, copy_names)
 end
 
 # References

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -1,5 +1,18 @@
 @testset "Copy test" begin
+    @testset "Automatic copy" begin
+        src = DummyModel()
+        dest = DummyModel()
+        @test_throws ErrorException MOIU.automatic_copy_to(dest, src)
+        try
+            @test_throws ErrorException MOIU.automatic_copy_to(dest, src)
+        catch err
+            @test sprint(showerror, err) == "Model DummyModel does not" *
+            " support copy with names."
+        end
+    end
     @testset "Default copy" begin
+        @test !MOIU.supports_default_copy_to(DummyModel(), false)
+        @test !MOIU.supports_default_copy_to(DummyModel(), true)
         model = Model{Float64}()
         MOIT.failcopytestc(model)
         MOIT.failcopytestia(model)
@@ -8,6 +21,8 @@
         MOIT.copytest(model, Model{Float64}())
     end
     @testset "Allocate-Load copy" begin
+        @test !MOIU.supports_allocate_load(DummyModel(), false)
+        @test !MOIU.supports_allocate_load(DummyModel(), true)
         mock = MOIU.MockOptimizer(Model{Float64}(), needs_allocate_load=true)
         MOIT.failcopytestc(mock)
         MOIT.failcopytestia(mock)


### PR DESCRIPTION
As discussed, we plan to make bridging happen after caching hence the need for an additional caching after the bridges to cache the bridge model.
If the optimizer returns `true` for `supports_incremental_copy` then this second cache will not be added.
If it returns `true` even if `copy_names` is true we could even get rid of the first cache.
With MOI v0.7, the second cache could also be removed if `supports_allocate_load` is true and `supports_incremental_copy` is false.
This PR should be non-breaking even if it adds this new function so it can be part of MOI v0.6.3