### PR TITLE
NLPBlockDual is set by optimize

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -33,6 +33,8 @@ struct NLPBlockDual <: AbstractModelAttribute
 end
 NLPBlockDual() = NLPBlockDual(1)
 
+is_set_by_optimize(::NLPBlockDual) = true
+
 """
     NLPBlockDualStart()
 


### PR DESCRIPTION
This was silently broken because it's covered only by `JuMP/test/nlp_solver.jl`.