### PR TITLE
Add `OptimizeNotCalled` termination status with tests and docs

### DIFF
--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -3,6 +3,12 @@
 struct UnknownScalarSet <: MOI.AbstractScalarSet end
 struct UnknownVectorSet <: MOI.AbstractVectorSet end
 
+function default_status_test(model::MOI.ModelLike)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NoSolution
+    @test MOI.get(model, MOI.DualStatus()) == MOI.NoSolution
+end
+
 function nametest(model::MOI.ModelLike)
     @testset "Name test with $(typeof(model))" begin
         @test MOI.supports(model, MOI.Name())

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -65,13 +65,13 @@ function MockOptimizer(inner_model::MOI.ModelLike; needs_allocate_load=false,
                          false,
                          false,
                          false,
-                         MOI.Success,
+                         MOI.OptimizeNotCalled,
                          0,
                          eval_objective_value,
                          NaN,
                          NaN,
-                         MOI.UnknownResultStatus,
-                         MOI.UnknownResultStatus,
+                         MOI.NoSolution,
+                         MOI.NoSolution,
                          Dict{MOI.VariableIndex,Float64}(),
                          eval_variable_constraint_dual,
                          Dict{MOI.ConstraintIndex,Any}())
@@ -197,12 +197,12 @@ function MOI.empty!(mock::MockOptimizer)
     mock.solved = false
     mock.hasprimal = false
     mock.hasdual = false
-    mock.terminationstatus = MOI.Success
+    mock.terminationstatus = MOI.OptimizeNotCalled
     mock.resultcount = 0
     mock.objectivevalue = NaN
     mock.objectivebound = NaN
-    mock.primalstatus = MOI.UnknownResultStatus
-    mock.dualstatus = MOI.UnknownResultStatus
+    mock.primalstatus = MOI.NoSolution
+    mock.dualstatus = MOI.NoSolution
     mock.varprimal = Dict{MOI.VariableIndex,Float64}()
     mock.condual = Dict{MOI.ConstraintIndex,Any}()
     return
@@ -214,11 +214,11 @@ function MOI.is_empty(mock::MockOptimizer)
     # TODO: Default values are currently copied in three places, not good.
     return MOI.is_empty(mock.inner_model) && mock.attribute == 0 &&
         !mock.solved && !mock.hasprimal && !mock.hasdual &&
-        mock.terminationstatus == MOI.Success &&
+        mock.terminationstatus == MOI.OptimizeNotCalled &&
         mock.resultcount == 0 && isnan(mock.objectivevalue) &&
         isnan(mock.objectivebound) &&
-        mock.primalstatus == MOI.UnknownResultStatus &&
-        mock.dualstatus == MOI.UnknownResultStatus
+        mock.primalstatus == MOI.NoSolution &&
+        mock.dualstatus == MOI.NoSolution
 end
 
 MOI.is_valid(mock::MockOptimizer, idx::MOI.Index) = MOI.is_valid(mock.inner_model, xor_index(idx))

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -693,7 +693,13 @@ struct TerminationStatus <: AbstractModelAttribute end
     TerminationStatusCode
 
 An Enum of possible values for the `TerminationStatus` attribute. This attribute
-is meant to explain the reason why the optimizer stopped executing.
+is meant to explain the reason why the optimizer stopped executing in the most
+recent call to [`optimize!`](@ref).
+
+If no call has been made to [`optimize!`](@ref), then the `TerminationStatus`
+is:
+
+* `OptimizeNotCalled`: the algorithm has not started.
 
 ## OK
 
@@ -747,9 +753,9 @@ This group of statuses means that something unexpected or problematic happened.
 * `Interrupted`: the algorithm stopped because of an interrupt signal.
 * `OtherError`: the algorithm stopped because of an error not covered by one of
   the statuses defined above.
-
 """
 @enum(TerminationStatusCode,
+    OptimizeNotCalled,
     # OK
     Success, AlmostSuccess, InfeasibleNoResult, UnboundedNoResult,
         InfeasibleOrUnbounded,

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -1,5 +1,6 @@
 @testset "Default statuses" begin
     model = MOIU.MockOptimizer(ModelForMock{Float64}())
+    MOIT.default_status_test(model)
     MOI.empty!(model)
     MOIT.default_status_test(model)
 end

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -1,3 +1,9 @@
+@testset "Default statuses" begin
+    model = MOIU.MockOptimizer(ModelForMock{Float64}())
+    MOI.empty!(model)
+    MOIT.default_status_test(model)
+end
+
 @testset "Mock optimizer name test" begin
     MOIT.nametest(MOIU.MockOptimizer(ModelForMock{Float64}()))
 end


### PR DESCRIPTION
Also fixes default statuses in CachingOptimizer.

Closes #571 
Closes #572 