### PR TITLE
Make FeasibilitySense the default ObjectiveSense

### DIFF
--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -3,6 +3,13 @@
 struct UnknownScalarSet <: MOI.AbstractScalarSet end
 struct UnknownVectorSet <: MOI.AbstractVectorSet end
 
+function default_objective_test(model::MOI.ModelLike)
+    @testset "Test default objective" begin
+        MOI.empty!(model)
+        MOI.get(model, MOI.ObjectiveSense()) == MOI.FeasibilitySense
+    end
+end
+
 function nametest(model::MOI.ModelLike)
     @testset "Name test with $(typeof(model))" begin
         @test MOI.supports(model, MOI.Name())

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -353,7 +353,9 @@ struct Name <: AbstractModelAttribute end
 """
     ObjectiveSense()
 
-A model attribute for the `OptimizationSense` of the objective function, which can be `MinSense`, `MaxSense`, or `FeasiblitySense`.
+A model attribute for the `OptimizationSense` of the objective function, which
+can be `MinSense`, `MaxSense`, or `FeasiblitySense`. The default should be
+`FeasibilitySense`.
 """
 struct ObjectiveSense <: AbstractModelAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -354,7 +354,7 @@ struct Name <: AbstractModelAttribute end
     ObjectiveSense()
 
 A model attribute for the `OptimizationSense` of the objective function, which
-can be `MinSense`, `MaxSense`, or `FeasiblitySense`. The default should be
+can be `MinSense`, `MaxSense`, or `FeasiblitySense`. The default is
 `FeasibilitySense`.
 """
 struct ObjectiveSense <: AbstractModelAttribute end

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -1,3 +1,7 @@
+@testset "Mock optimizer default objective sense" begin
+    MOIT.default_objective_test(MOIU.MockOptimizer(ModelForMock{Float64}()))
+end
+
 @testset "Mock optimizer name test" begin
     MOIT.nametest(MOIU.MockOptimizer(ModelForMock{Float64}()))
 end


### PR DESCRIPTION
Presumably some solvers will need to be updated. But they won't fail current tests without opting into the `default_objective_test`.

Closes #335 