### PR TITLE
supports_default_copy_to

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 MathOptInterface (MOI) release notes
 ====================================
 
+0.7.0 (unreleased)
+--------------------------
+
+- Check `supports_default_copy_to` in tests (#594).
+
 v0.6.4 (November 27, 2018)
 --------------------------
 

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -86,9 +86,13 @@ function MOI.supports(b::AbstractBridgeOptimizer,
                                   MOI.AbstractOptimizerAttribute})
     return MOI.supports(b.model, attr)
 end
-function MOI.copy_to(b::AbstractBridgeOptimizer, src::MOI.ModelLike;
-                   copy_names = true)
-    return MOIU.default_copy_to(b, src, copy_names)
+
+function MOI.copy_to(mock::AbstractBridgeOptimizer, src::MOI.ModelLike; kws...)
+    MOIU.automatic_copy_to(mock, src; kws...)
+end
+function MOIU.supports_default_copy_to(b::AbstractBridgeOptimizer,
+                                       copy_names::Bool)
+    return MOIU.supports_default_copy_to(b.model, copy_names)
 end
 
 # References

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -11,6 +11,7 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     #       x>=0 y>=0 z>=0
     # Opt obj = -11, soln x = 1, y = 0, z = 2
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -92,6 +93,7 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     # Opt solution = -82
     # x = -4, y = -3, z = 16, s == 0
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -184,6 +186,7 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
     # s.t. -1 + x ∈ R₊
     #       1 + x ∈ R₋
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
@@ -232,6 +235,7 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
     # s.t. -1 + x ∈ R₊
     #           x ∈ R₋
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
@@ -285,6 +289,7 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     #  st  x            == 1
     #      x >= ||(y,z)||
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -359,6 +364,7 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     #        1 - t ∈ {0}
     #      (t,x,y) ∈ SOC₃
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
@@ -434,6 +440,7 @@ function soc3test(model::MOI.ModelLike, config::TestConfig)
     #      -1 + x ∈ R₋
     #       (x,y) ∈ SOC₂
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64},MOI.Nonnegatives)
@@ -484,6 +491,7 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     # Like SOCINT1 but with copies of variables and integrality relaxed
     # Tests out-of-order indices in cones
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
@@ -551,6 +559,7 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
     #     [0.0] - [    -z] SOCRotated
 
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if abvars
@@ -642,6 +651,7 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     b = [-2, -1, 1/2]
     c = [0.0,0.0,0.0]
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable,MOI.EqualTo{Float64})
@@ -708,6 +718,7 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     # [t1/√2, t2/√2, x] in SOC4
     # [x1/√2, u/√2,  v] in SOC3
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
@@ -807,6 +818,7 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
     # Therefore xyz ≤ 1
     # This can be attained using x = y = z = 1 so it is optimal.
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -869,6 +881,7 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     #      x == 1
     #      y == 2
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -936,6 +949,7 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
@@ -1002,6 +1016,7 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -1069,6 +1084,7 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     # X = ⎜       ⎟           y = 2
     #     ⎝ 1   1 ⎠
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -1202,6 +1218,7 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     α = √(3-2obj-4x2)/2
     β = k*α
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
@@ -1285,6 +1302,7 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     rtol = config.rtol
     # Caused getdual to fail on SCS and Mosek
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -1385,6 +1403,7 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
     #           |_________|
     #            -Q22 ≥ -1
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -11,7 +11,7 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     #       x>=0 y>=0 z>=0
     # Opt obj = -11, soln x = 1, y = 0, z = 2
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -93,7 +93,7 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     # Opt solution = -82
     # x = -4, y = -3, z = 16, s == 0
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -186,7 +186,7 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
     # s.t. -1 + x ∈ R₊
     #       1 + x ∈ R₋
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
@@ -235,7 +235,7 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
     # s.t. -1 + x ∈ R₊
     #           x ∈ R₋
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
@@ -289,7 +289,7 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     #  st  x            == 1
     #      x >= ||(y,z)||
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -364,7 +364,7 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     #        1 - t ∈ {0}
     #      (t,x,y) ∈ SOC₃
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
@@ -440,7 +440,7 @@ function soc3test(model::MOI.ModelLike, config::TestConfig)
     #      -1 + x ∈ R₋
     #       (x,y) ∈ SOC₂
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64},MOI.Nonnegatives)
@@ -491,7 +491,7 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     # Like SOCINT1 but with copies of variables and integrality relaxed
     # Tests out-of-order indices in cones
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
@@ -559,7 +559,7 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
     #     [0.0] - [    -z] SOCRotated
 
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if abvars
@@ -651,7 +651,7 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     b = [-2, -1, 1/2]
     c = [0.0,0.0,0.0]
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable,MOI.EqualTo{Float64})
@@ -718,7 +718,7 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     # [t1/√2, t2/√2, x] in SOC4
     # [x1/√2, u/√2,  v] in SOC3
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
@@ -818,7 +818,7 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
     # Therefore xyz ≤ 1
     # This can be attained using x = y = z = 1 so it is optimal.
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -881,7 +881,7 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     #      x == 1
     #      y == 2
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -949,7 +949,7 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.ExponentialCone)
@@ -1016,7 +1016,7 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -1084,7 +1084,7 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     # X = ⎜       ⎟           y = 2
     #     ⎝ 1   1 ⎠
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars
@@ -1218,7 +1218,7 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     α = √(3-2obj-4x2)/2
     β = k*α
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
@@ -1302,7 +1302,7 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     rtol = config.rtol
     # Caused getdual to fail on SCS and Mosek
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -1403,7 +1403,7 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
     #           |_________|
     #            -Q22 ≥ -1
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     if vecofvars

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -9,7 +9,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
     #       x, y >= 0   (x, y ∈ Nonnegatives)
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
@@ -356,7 +356,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x + y <= 1
     # x, y >= 0
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -418,7 +418,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x >= 0
     #      x >= 3
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -498,7 +498,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
@@ -581,7 +581,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #
     #   solution: x = 1.3333333, y = 1.3333333, objv = 2.66666666
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -704,7 +704,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -771,7 +771,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
@@ -855,7 +855,7 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     # s.t. 2x+y <= -1
     # x,y >= 0
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -907,7 +907,7 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     # s.t. -x+2y <= 0
     # x,y >= 0
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -950,7 +950,7 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     # s.t. x-y == 0
     # x,y >= 0
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
@@ -1003,7 +1003,7 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
     #   solution: (59.0909, 36.3636)
     #   objv: 71818.1818
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -1062,7 +1062,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     #       s.t.  5 <= x + y <= 10
     #                  x,  y >= 0
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
@@ -1154,7 +1154,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     # st   x + y >= 1
     #      x + y >= 2
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -1203,7 +1203,7 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     #      y <= 2
     # x,y >= 0
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -1256,7 +1256,7 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
     # s.t. 2x + 3y >= 1
     #      x - y == 0
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
 
@@ -1307,7 +1307,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     #      x, y, z >= 0
     #      z <= 1
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -1391,7 +1391,7 @@ function linear15test(model::MOI.ModelLike, config::TestConfig)
     # minimize 0
     # s.t. 0 == 0
     #      x == 1
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -9,6 +9,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
     #       x, y >= 0   (x, y ∈ Nonnegatives)
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
@@ -355,6 +356,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x + y <= 1
     # x, y >= 0
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -416,6 +418,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x >= 0
     #      x >= 3
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -495,6 +498,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
@@ -577,6 +581,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #
     #   solution: x = 1.3333333, y = 1.3333333, objv = 2.66666666
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -699,6 +704,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -765,6 +771,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
@@ -848,6 +855,7 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     # s.t. 2x+y <= -1
     # x,y >= 0
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -899,6 +907,7 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     # s.t. -x+2y <= 0
     # x,y >= 0
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -941,6 +950,7 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     # s.t. x-y == 0
     # x,y >= 0
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
@@ -993,6 +1003,7 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
     #   solution: (59.0909, 36.3636)
     #   objv: 71818.1818
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -1051,6 +1062,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     #       s.t.  5 <= x + y <= 10
     #                  x,  y >= 0
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
@@ -1142,6 +1154,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     # st   x + y >= 1
     #      x + y >= 2
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
@@ -1190,6 +1203,7 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     #      y <= 2
     # x,y >= 0
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -1242,6 +1256,7 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
     # s.t. 2x + 3y >= 1
     #      x - y == 0
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
 
@@ -1292,6 +1307,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     #      x, y, z >= 0
     #      z <= 1
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -1375,6 +1391,7 @@ function linear15test(model::MOI.ModelLike, config::TestConfig)
     # minimize 0
     # s.t. 0 == 0
     #      x == 1
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -9,6 +9,7 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
     #     x +  y      >= 1 (c2)
     #     x,y \in R
 
+    @test MOIU.supports_default_copy_to(model, false)
     MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
 
@@ -62,6 +63,7 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     #     x +  y      >= 1 (c2)
     #     x,y \in R
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
 
@@ -134,6 +136,7 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     #       s.t.  x, y >= 0
     #             x + y = 1
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
@@ -213,6 +216,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     # Optimal solution
     # x = 1/2, y = 7/4
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})
@@ -275,6 +279,7 @@ function qcp2test(model::MOI.ModelLike, config::TestConfig)
     # Max x
     # s.t. x^2 <= 2 (c)
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})
 
@@ -324,6 +329,7 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     # Min -x
     # s.t. x^2 <= 2
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})
 
@@ -385,6 +391,7 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     #      x^2 + y^2 <= t^2 (c2)
     #      t >= 0 (bound)
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -9,7 +9,7 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
     #     x +  y      >= 1 (c2)
     #     x,y \in R
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
 
@@ -63,7 +63,7 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     #     x +  y      >= 1 (c2)
     #     x,y \in R
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
 
@@ -136,7 +136,7 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     #       s.t.  x, y >= 0
     #             x + y = 1
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
     MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
     MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
@@ -216,7 +216,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     # Optimal solution
     # x = 1/2, y = 7/4
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
     @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})
@@ -279,7 +279,7 @@ function qcp2test(model::MOI.ModelLike, config::TestConfig)
     # Max x
     # s.t. x^2 <= 2 (c)
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})
 
@@ -329,7 +329,7 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     # Min -x
     # s.t. x^2 <= 2
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})
 
@@ -391,7 +391,7 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     #      x^2 + y^2 <= t^2 (c2)
     #      t >= 0 (bound)
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -10,7 +10,7 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     #      x >= ||(y,z)||
     #      (y,z) binary
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -10,6 +10,7 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     #      x >= ||(y,z)||
     #      (y,z) binary
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -13,7 +13,7 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     #         y is integer: 0 <= y <= 10
     #         z is binary
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -87,7 +87,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "SOSI" begin
-        @test MOIU.supports_default_copy_to(model, false)
+        @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
         @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test MOI.supports(model, MOI.ObjectiveSense())
         @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
@@ -154,7 +154,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         end
     end
     @testset "SOSII" begin
-        @test MOIU.supports_default_copy_to(model, false)
+        @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
         @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test MOI.supports(model, MOI.ObjectiveSense())
         @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
@@ -255,7 +255,7 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)
@@ -312,7 +312,7 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -13,6 +13,7 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     #         y is integer: 0 <= y <= 10
     #         z is binary
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
@@ -86,6 +87,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     @testset "SOSI" begin
+        @test MOIU.supports_default_copy_to(model, false)
         @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test MOI.supports(model, MOI.ObjectiveSense())
         @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
@@ -152,6 +154,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         end
     end
     @testset "SOSII" begin
+        @test MOIU.supports_default_copy_to(model, false)
         @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
         @test MOI.supports(model, MOI.ObjectiveSense())
         @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.SOS1{Float64})
@@ -252,6 +255,7 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)
@@ -308,6 +312,7 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
+    @test MOIU.supports_default_copy_to(model, false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -18,7 +18,7 @@ end
 
 function nametest(model::MOI.ModelLike)
     @testset "Name test with $(typeof(model))" begin
-        @test MOIU.supports_default_copy_to(model, true)
+        @test MOIU.supports_default_copy_to(model, #=copy_names=# true)
         @test MOI.supports(model, MOI.Name())
         @test !(MOI.Name() in MOI.get(model, MOI.ListOfModelAttributesSet()))
         @test MOI.get(model, MOI.Name()) == ""
@@ -105,7 +105,7 @@ end
 
 # Taken from https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/41
 function validtest(model::MOI.ModelLike)
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     v = MOI.add_variables(model, 2)
     @test MOI.is_valid(model, v[1])
     @test MOI.is_valid(model, v[2])
@@ -124,7 +124,7 @@ function validtest(model::MOI.ModelLike)
 end
 
 function emptytest(model::MOI.ModelLike)
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     # Taken from LIN1
     v = MOI.add_variables(model, 3)
     @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
@@ -199,7 +199,7 @@ function failcopytestca(dest::MOI.ModelLike)
 end
 
 function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
-    @test MOIU.supports_default_copy_to(src, false)
+    @test MOIU.supports_default_copy_to(src, #=copy_names=# false)
     x, y, z = MOI.add_variables(src, 3)
     vpattr = MOI.VariablePrimalStart()
     MOI.set(src, vpattr, x, 1.0)
@@ -237,7 +237,7 @@ function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
 end
 
 function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
-    @test MOIU.supports_default_copy_to(src, true)
+    @test MOIU.supports_default_copy_to(src, #=copy_names=# true)
     MOI.set(src, MOI.Name(), "ModelName")
     v = MOI.add_variables(src, 3)
     w = MOI.add_variable(src)
@@ -319,7 +319,7 @@ Test whether the model returns ListOfVariableIndices and ListOfConstraintIndices
 sorted by creation time.
 """
 function orderedindicestest(model::MOI.ModelLike)
-    @test MOIU.supports_default_copy_to(model, false)
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     MOI.empty!(model)
     v1 = MOI.add_variable(model)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v1]

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -18,6 +18,7 @@ end
 
 function nametest(model::MOI.ModelLike)
     @testset "Name test with $(typeof(model))" begin
+        @test MOIU.supports_default_copy_to(model, true)
         @test MOI.supports(model, MOI.Name())
         @test !(MOI.Name() in MOI.get(model, MOI.ListOfModelAttributesSet()))
         @test MOI.get(model, MOI.Name()) == ""
@@ -104,6 +105,7 @@ end
 
 # Taken from https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/41
 function validtest(model::MOI.ModelLike)
+    @test MOIU.supports_default_copy_to(model, false)
     v = MOI.add_variables(model, 2)
     @test MOI.is_valid(model, v[1])
     @test MOI.is_valid(model, v[2])
@@ -122,6 +124,7 @@ function validtest(model::MOI.ModelLike)
 end
 
 function emptytest(model::MOI.ModelLike)
+    @test MOIU.supports_default_copy_to(model, false)
     # Taken from LIN1
     v = MOI.add_variables(model, 3)
     @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.Nonnegatives)
@@ -196,6 +199,7 @@ function failcopytestca(dest::MOI.ModelLike)
 end
 
 function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
+    @test MOIU.supports_default_copy_to(src, false)
     x, y, z = MOI.add_variables(src, 3)
     vpattr = MOI.VariablePrimalStart()
     MOI.set(src, vpattr, x, 1.0)
@@ -233,6 +237,7 @@ function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
 end
 
 function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
+    @test MOIU.supports_default_copy_to(src, true)
     MOI.set(src, MOI.Name(), "ModelName")
     v = MOI.add_variables(src, 3)
     w = MOI.add_variable(src)
@@ -314,6 +319,7 @@ Test whether the model returns ListOfVariableIndices and ListOfConstraintIndices
 sorted by creation time.
 """
 function orderedindicestest(model::MOI.ModelLike)
+    @test MOIU.supports_default_copy_to(model, false)
     MOI.empty!(model)
     v1 = MOI.add_variable(model)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v1]


### PR DESCRIPTION
The addition of supports_copy_to was not entirely finished in https://github.com/JuliaOpt/MathOptInterface.jl/pull/561 because we wanted it to be non-breaking.
This PR finishes the job.
Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/562
Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/592