### PR TITLE
redesign TerminationStatus

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -414,8 +414,9 @@ and certificates.
 
 ### Common status situations
 
-The sections below describe how to interpret typical status cases for three
-common classes of solvers. Solver wrappers may provide additional information on
+The sections below describe how to interpret typical or interesting status cases
+for three common classes of solvers. The example cases are illustrative, not
+comprehensive. Solver wrappers may provide additional information on
 how the solver's statuses map to MOI statuses.
 
 `?` in the tables indicate that multiple different values are possible.

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -414,7 +414,7 @@ and certificates.
 
 ### Common status situations
 
-The sections below describe how to interpret different status cases for three
+The sections below describe how to interpret typical status cases for three
 common classes of solvers. Solver wrappers may provide additional information on
 how the solver's statuses map to MOI statuses.
 
@@ -424,12 +424,13 @@ how the solver's statuses map to MOI statuses.
 
 Linear programming and conic optimization solvers fall into this category.
 
-| What happended?                   | `TerminationStatus()` | `ResultCount()` | `PrimalStatus()`                         | `DualStatus()`                           |
-| --------------------------------- | --------------------- | --------------- | ---------------------------------------- | ---------------------------------------- |
-| Proved optimality                 | `Optimal`             | 1               | `FeasiblePoint`                          | `FeasiblePoint`                          |
-| Proved infeasible                 | `Infeasible`          | 1               | `NoSolution`                             | `InfeasibilityCertificate`               |
-| Optimal within relaxed tolerances | `AlmostOptimal`       | 1               | `FeasiblePoint` or `AlmostFeasiblePoint` | `FeasiblePoint` or `AlmostFeasiblePoint` |
-| Stall                             | `SlowProgress`        | 1               | ?                                        | ?                                        |
+| What happended?                         | `TerminationStatus()` | `ResultCount()` | `PrimalStatus()`                         | `DualStatus()`                           |
+| --------------------------------------- | --------------------- | --------------- | ---------------------------------------- | ---------------------------------------- |
+| Proved optimality                       | `Optimal`             | 1               | `FeasiblePoint`                          | `FeasiblePoint`                          |
+| Proved infeasible                       | `Infeasible`          | 1               | `NoSolution`                             | `InfeasibilityCertificate`               |
+| Optimal within relaxed tolerances       | `AlmostOptimal`       | 1               | `FeasiblePoint` or `AlmostFeasiblePoint` | `FeasiblePoint` or `AlmostFeasiblePoint` |
+| Detected an unbounded ray of the primal | `DualInfeasible`      | 1               | `InfeasibilityCertificate`               | `NoSolution`                             |
+| Stall                                   | `SlowProgress`        | 1               | ?                                        | ?                                        |
 
 #### Global branch-and-bound solvers
 
@@ -442,7 +443,7 @@ Mixed-integer programming solvers fall into this category.
 | Proved infeasibility                             | `Infeasible`            | 0               | `NoSolution`      | `NoSolution`   |
 | Timed out (no solution)                          | `TimeLimit`             | 0               | `NoSolution`      | `NoSolution`   |
 | Timed out (with a solution)                      | `TimeLimit`             | 1               | `FeasiblePoint`   | `NoSolution`   |
-| `CPXMIP_OPTIMAL_INFEAS`                          | `AlmostOptimal`               | 1               | `InfeasiblePoint` | `NoSolution`   |
+| `CPXMIP_OPTIMAL_INFEAS`                          | `AlmostOptimal`         | 1               | `InfeasiblePoint` | `NoSolution`   |
 
 [`CPXMIP_OPTIMAL_INFEAS`](https://www.ibm.com/support/knowledgecenter/en/SSSA5P_12.6.1/ilog.odms.cplex.help/refcallablelibrary/macros/CPXMIP_OPTIMAL_INFEAS.html)
 is a CPLEX status that indicates that a preprocessed problem was solved to

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -425,7 +425,7 @@ how the solver's statuses map to MOI statuses.
 
 Linear programming and conic optimization solvers fall into this category.
 
-| What happended?                         | `TerminationStatus()` | `ResultCount()` | `PrimalStatus()`                         | `DualStatus()`                           |
+| What happened?                          | `TerminationStatus()` | `ResultCount()` | `PrimalStatus()`                         | `DualStatus()`                           |
 | --------------------------------------- | --------------------- | --------------- | ---------------------------------------- | ---------------------------------------- |
 | Proved optimality                       | `Optimal`             | 1               | `FeasiblePoint`                          | `FeasiblePoint`                          |
 | Proved infeasible                       | `Infeasible`          | 1               | `NoSolution`                             | `InfeasibilityCertificate`               |
@@ -437,7 +437,7 @@ Linear programming and conic optimization solvers fall into this category.
 
 Mixed-integer programming solvers fall into this category.
 
-| What happended?                                  | `TerminationStatus()`   | `ResultCount()` | `PrimalStatus()`  | `DualStatus()` |
+| What happened?                                   | `TerminationStatus()`   | `ResultCount()` | `PrimalStatus()`  | `DualStatus()` |
 | ------------------------------------------------ | ----------------------- | --------------- | ----------------- | -------------- |
 | Proved optimality                                | `Optimal`               | 1               | `FeasiblePoint`   | `NoSolution`   |
 | Presolve detected infeasibility or unboundedness | `InfeasibleOrUnbounded` | 0               | `NoSolution`      | `NoSolution`   |
@@ -453,14 +453,18 @@ original problem.
 
 #### Local search solvers
 
-Nonlinear programming solvers fall into this category.
+Nonlinear programming solvers fall into this category. It also includes
+non-global tree search solvers like
+[Juniper](https://github.com/lanl-ansi/Juniper.jl).
 
-| What happended?                  | `TerminationStatus()`           | `ResultCount()` | `PrimalStatus()`  | `DualStatus()`  |
-| -------------------------------- | ------------------------------- | --------------- | ----------------- | --------------- |
-| Converged to a stationary point  | `LocallyConverged`              | 1               | `FeasiblePoint`   | `FeasiblePoint` |
-| Converged to an infeasible point | `LocallyInfeasible`             | 1               | `InfeasiblePoint` | ?               |
-| Iteration limit                  | `IterationLimit`                | 1               | ?                 | ?               |
-| Diverging iterates               | `NormLimit` or `ObjectiveLimit` | 1               | ?                 | ?               |
+| What happened?                                         | `TerminationStatus()`           | `ResultCount()` | `PrimalStatus()`  | `DualStatus()`  |
+| ------------------------------------------------------ | ------------------------------- | --------------- | ----------------- | --------------- |
+| Converged to a stationary point                        | `LocallySolved`                 | 1               | `FeasiblePoint`   | `FeasiblePoint` |
+| Completed a non-global tree search (with a solution)   | `LocallySolved`                 | 1               | `FeasiblePoint`   | `FeasiblePoint` |
+| Converged to an infeasible point                       | `LocallyInfeasible`             | 1               | `InfeasiblePoint` | ?               |
+| Completed a non-global tree search (no solution found) | `LocallyInfeasible`             | 0               | `NoSolution`      | `NoSolution`    |
+| Iteration limit                                        | `IterationLimit`                | 1               | ?                 | ?               |
+| Diverging iterates                                     | `NormLimit` or `ObjectiveLimit` | 1               | ?                 | ?               |
 
 
 ## A complete example: solving a knapsack problem

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -442,7 +442,7 @@ Mixed-integer programming solvers fall into this category.
 | Proved infeasibility                             | `Infeasible`            | 0               | `NoSolution`      | `NoSolution`   |
 | Timed out (no solution)                          | `TimeLimit`             | 0               | `NoSolution`      | `NoSolution`   |
 | Timed out (with a solution)                      | `TimeLimit`             | 1               | `FeasiblePoint`   | `NoSolution`   |
-| `CPXMIP_OPTIMAL_INFEAS`                          | `Optimal`               | 1               | `InfeasiblePoint` | `NoSolution`   |
+| `CPXMIP_OPTIMAL_INFEAS`                          | `AlmostOptimal`               | 1               | `InfeasiblePoint` | `NoSolution`   |
 
 [`CPXMIP_OPTIMAL_INFEAS`](https://www.ibm.com/support/knowledgecenter/en/SSSA5P_12.6.1/ilog.odms.cplex.help/refcallablelibrary/macros/CPXMIP_OPTIMAL_INFEAS.html)
 is a CPLEX status that indicates that a preprocessed problem was solved to

--- a/src/Test/UnitTests/unit_tests.jl
+++ b/src/Test/UnitTests/unit_tests.jl
@@ -15,7 +15,7 @@ const unittests = Dict{String, Function}()
 
 Solve, and then test, various aspects of a model.
 
-First, check that `TerminationStatus == MOI.Success`.
+First, check that `TerminationStatus == MOI.Optimal`.
 
 If `objective_value` is not nothing, check that the attribute `ObjectiveValue()`
 is approximately `objective_value`.
@@ -59,7 +59,7 @@ function test_model_solution(model, config;
     config.solve || return
     atol, rtol = config.atol, config.rtol
     MOI.optimize!(model)
-    @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
     if objective_value != nothing
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ objective_value atol=atol rtol=rtol
     end

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -47,7 +47,7 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -141,7 +141,7 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -204,10 +204,10 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
         MOI.optimize!(model)
 
         if config.infeas_certificates
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible
             @test MOI.get(model, MOI.ResultCount()) > 0
         else
-            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Infeasible, MOI.InfeasibleOrUnbounded]
         end
         if MOI.get(model, MOI.ResultCount()) > 0
             @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
@@ -252,10 +252,10 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
         MOI.optimize!(model)
 
         if config.infeas_certificates
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible
             @test MOI.get(model, MOI.ResultCount()) > 0
         else
-            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Infeasible, MOI.InfeasibleOrUnbounded]
         end
         if MOI.get(model, MOI.ResultCount()) > 0
             @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
@@ -320,7 +320,7 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -392,7 +392,7 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -456,7 +456,7 @@ function soc3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible
 
         @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
                                                      MOI.InfeasiblePoint)
@@ -505,7 +505,7 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -584,7 +584,7 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -670,9 +670,9 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleNoResult, MOI.InfeasibleOrUnbounded]
+        @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Infeasible, MOI.InfeasibleOrUnbounded]
 
-        if MOI.get(model, MOI.TerminationStatus()) in [MOI.Success, MOI.InfeasibleOrUnbounded] && config.duals
+        if config.duals
             @test MOI.get(model, MOI.DualStatus()) in [MOI.InfeasibilityCertificate, MOI.NearlyInfeasibilityCertificate]
 
             y1 = MOI.get(model, MOI.ConstraintDual(), vc1)
@@ -746,7 +746,7 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -838,7 +838,7 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
@@ -900,7 +900,7 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -963,7 +963,7 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -1025,7 +1025,7 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -1101,7 +1101,7 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -1243,7 +1243,7 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -1322,7 +1322,7 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         if config.duals
@@ -1419,7 +1419,7 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -64,7 +64,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -99,7 +99,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -154,7 +154,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -186,7 +186,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -211,7 +211,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -236,7 +236,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -263,7 +263,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -292,7 +292,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -385,7 +385,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -443,7 +443,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -478,7 +478,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -519,7 +519,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
@@ -533,7 +533,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(100.0))
     if config.solve
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
@@ -547,7 +547,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan(-100.0))
     if config.solve
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
@@ -610,7 +610,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -642,7 +642,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -663,7 +663,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -684,7 +684,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -723,7 +723,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
@@ -737,7 +737,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(100.0))
     if config.solve
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
@@ -751,7 +751,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan(-100.0))
     if config.solve
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
@@ -789,7 +789,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
@@ -810,7 +810,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
 
     if config.solve
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
@@ -831,7 +831,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
 
     if config.solve
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
@@ -868,10 +868,12 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         if config.infeas_certificates
             # solver returned an infeasibility ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+
             @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
             cd = MOI.get(model, MOI.ConstraintDual(), c)
             @test cd < -atol
@@ -885,8 +887,6 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
-                MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
     end
 end
@@ -919,16 +919,15 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.DualInfeasible ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         if config.infeas_certificates
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
-                MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
     end
 end
@@ -961,19 +960,17 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.DualInfeasible ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         if config.infeas_certificates
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
             ray = MOI.get(model, MOI.VariablePrimal(), [x,y])
             @test ray[1] ≈ ray[2] atol=atol rtol=rtol
-
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.UnboundedNoResult ||
-                MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
     end
 end
@@ -1033,7 +1030,7 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 79e4/11 atol=atol rtol=rtol
@@ -1075,7 +1072,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
@@ -1093,7 +1090,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 5 atol=atol rtol=rtol
@@ -1114,7 +1111,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
@@ -1126,7 +1123,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 12 atol=atol rtol=rtol
@@ -1161,7 +1158,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
     end
@@ -1175,7 +1172,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol=atol rtol=rtol
     end
@@ -1211,10 +1208,11 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         if config.infeas_certificates
             # solver returned an infeasibility ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
             @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
             cd1 = MOI.get(model, MOI.ConstraintDual(), c1)
             cd2 = MOI.get(model, MOI.ConstraintDual(), c2)
@@ -1228,8 +1226,6 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleNoResult ||
-                MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
         end
     end
 end
@@ -1259,7 +1255,7 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
         MOI.optimize!(model)
         @test MOI.get(model, MOI.ResultCount()) > 0
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -1314,7 +1310,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -1347,7 +1343,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -1402,7 +1398,7 @@ function linear15test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -41,7 +41,7 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -94,7 +94,7 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -116,7 +116,7 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -163,7 +163,7 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -183,7 +183,7 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -242,7 +242,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -261,7 +261,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     #
     # MOI.optimize!(model)
     #
-    # @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+    # @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
     #
     # @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
     #
@@ -299,7 +299,7 @@ function qcp2test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -348,7 +348,7 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -422,7 +422,7 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -39,7 +39,7 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -55,7 +55,7 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -123,7 +123,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         if config.solve
             MOI.optimize!(model)
 
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -140,7 +140,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         if config.solve
             MOI.optimize!(model)
 
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -208,7 +208,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         if config.solve
             MOI.optimize!(model)
 
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -226,7 +226,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
         if config.solve
             MOI.optimize!(model)
 
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -277,7 +277,7 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -286,7 +286,7 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
         # test for CPLEX.jl #76
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
 
@@ -333,7 +333,7 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Optimal
 
         @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
 

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -136,7 +136,7 @@ function hs071test_template(model::MOI.ModelLike, config::TestConfig, evaluator:
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.LocallySolved
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -241,7 +241,7 @@ function feasibility_sense_test_template(model::MOI.ModelLike,
     if config.solve
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Success
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.LocallySolved
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -313,7 +313,7 @@ rec_mock_optimize(mock::MockOptimizer, opt::Function) = opt
 
 Sets the termination status of `mock` to `termstatus` and the primal (resp. dual) status to `primstatus` (resp. `dualstatus`).
 The primal values of the variables in the order returned by `ListOfVariableIndices` are set to `varprim`.
-If `termstatus` is missing, it is assumed to be `MOI.Success`.
+If `termstatus` is missing, it is assumed to be `MOI.Optimal`.
 If `primstatus` is missing, it is assumed to be `MOI.FeasiblePoint`.
 If `dualstatus` is missing, it is assumed to be `MOI.FeasiblePoint` if there is a primal solution and `primstatus` is not `MOI.InfeasiblePoint`, otherwise it is `MOI.InfeasibilityCertificate`.
 The dual values are set to the values specified by `conduals`. Each pair is of the form `(F,S)=>[...]` where `[...]` is the the vector of dual values for the constraints `F`-in-`S` in the order returned by `ListOfConstraintIndices{F,S}`.
@@ -325,7 +325,7 @@ function mock_optimize!(mock::MockOptimizer, termstatus::MOI.TerminationStatusCo
     mock_dual!(mock, dual...)
 end
 # Default termination status
-mock_optimize!(mock::MockOptimizer, primdual...) = mock_optimize!(mock, MOI.Success, primdual...)
+mock_optimize!(mock::MockOptimizer, primdual...) = mock_optimize!(mock, MOI.Optimal, primdual...)
 function mock_optimize!(mock::MockOptimizer, termstatus::MOI.TerminationStatusCode)
     MOI.set(mock, MOI.TerminationStatus(), termstatus)
     MOI.set(mock, MOI.ResultCount(), 0)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -713,9 +713,12 @@ These are generally OK statuses, i.e., the algorithm ran to completion normally.
   problem. If, additionally, a feasible (primal) solution is known to
   exist, this status typically implies that the problem is unbounded, with some
   technical exceptions.
-* `LocallyConverged`: The algorithm converged to a stationary point, local
-  optimal solution, or could not find directions for improvement.
-* `LocallyInfeasible`: The algorithm converged to an infeasible point.
+* `LocallySolved`: The algorithm converged to a stationary point, local
+  optimal solution, could not find directions for improvement, or otherwise
+  completed its search without global guarantees.
+* `LocallyInfeasible`: The algorithm converged to an infeasible point or
+  otherwise completed its search without finding a feasible solution, without
+  guarantees that no feasible solution exists.
 * `InfeasibleOrUnbounded`: The algorithm stopped because it decided that the
   problem is infeasible or unbounded; this occasionally happens during MIP
   presolve.
@@ -726,7 +729,7 @@ These are generally OK statuses, i.e., the algorithm ran to completion normally.
   tolerances.
 * `AlmostInfeasible`: The algorithm concluded that no feasible solution exists
   within relaxed tolerances.
-* `AlmostLocallyConverged`: The algorithm converged to a stationary point, local
+* `AlmostLocallySolved`: The algorithm converged to a stationary point, local
   optimal solution, or could not find directions for improvement within relaxed
   tolerances.
 
@@ -768,10 +771,10 @@ This group of statuses means that something unexpected or problematic happened.
 @enum(TerminationStatusCode,
     OptimizeNotCalled,
     # OK
-    Optimal, Infeasible, DualInfeasible, LocallyConverged, LocallyInfeasible,
+    Optimal, Infeasible, DualInfeasible, LocallySolved, LocallyInfeasible,
         InfeasibleOrUnbounded,
     # Solved to relaxed tolerances
-    AlmostOptimal, AlmostInfeasible, AlmostLocallyConverged,
+    AlmostOptimal, AlmostInfeasible, AlmostLocallySolved,
     # Limits
     IterationLimit, TimeLimit,  NodeLimit, SolutionLimit, MemoryLimit,
         ObjectiveLimit, NormLimit, OtherLimit,

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -701,66 +701,77 @@ recent call to [`optimize!`](@ref).
 If no call has been made to [`optimize!`](@ref), then the `TerminationStatus`
 is:
 
-* `OptimizeNotCalled`: the algorithm has not started.
+* `OptimizeNotCalled`: The algorithm has not started.
 
 ## OK
 
 These are generally OK statuses, i.e., the algorithm ran to completion normally.
 
-* `Success`: the algorithm ran successfully and has a result; this includes
-  cases where the algorithm converges to an infeasible point (NLP) or converges
-  to a solution of a homogeneous self-dual problem and has a certificate of
-  primal/dual infeasibility.
-* `InfeasibleNoResult`: the algorithm stopped because it decided that the
-  problem is infeasible but does not have a primal or dual result to return.
-* `UnboundedNoResult`: the algorithm stopped because it decided that the problem
-  is unbounded but does not have a primal or dual result to return.
-* `InfeasibleOrUnbounded`: the algorithm stopped because it decided that the
-  problem is infeasible or unbounded (no primal or dual result is available);
-  this occasionally happens during MIP presolve.
+* `Optimal`: The algorithm found a globally optimal solution.
+* `Infeasible`: The algorithm concluded that no feasible solution exists.
+* `DualInfeasible`: The algorithm concluded that no dual bound exists for the
+  problem. If, additionally, a feasible (primal) solution is known to
+  exist, this status typically implies that the problem is unbounded, with some
+  technical exceptions.
+* `LocallyConverged`: The algorithm converged to a stationary point, local
+  optimal solution, or could not find directions for improvement.
+* `LocallyInfeasible`: The algorithm converged to an infeasible point.
+* `InfeasibleOrUnbounded`: The algorithm stopped because it decided that the
+  problem is infeasible or unbounded; this occasionally happens during MIP
+  presolve.
+
+## Solved to relaxed tolerances
+
+* `AlmostOptimal`: The algorithm found a globally optimal solution to relaxed
+  tolerances.
+* `AlmostInfeasible`: The algorithm concluded that no feasible solution exists
+  within relaxed tolerances.
+* `AlmostLocallyConverged`: The algorithm converged to a stationary point, local
+  optimal solution, or could not find directions for improvement within relaxed
+  tolerances.
 
 ## Limits
 
 The optimizer stopped because of some user-defined limit.
 
-* `IterationLimit`: an iterative algorithm stopped after conducting the maximum
+* `IterationLimit`: An iterative algorithm stopped after conducting the maximum
   number of iterations.
-* `TimeLimit`: the algorithm stopped after a user-specified computation time.
-* `NodeLimit`: a branch-and-bound algorithm stopped because it explored a
+* `TimeLimit`: The algorithm stopped after a user-specified computation time.
+* `NodeLimit`: A branch-and-bound algorithm stopped because it explored a
   maximum number of nodes in the branch-and-bound tree.
-* `SolutionLimit`: the algorithm stopped because it found the required number of
+* `SolutionLimit`: The algorithm stopped because it found the required number of
   solutions. This is often used in MIPs to get the solver to return the first
   feasible solution it encounters.
-* `MemoryLimit`: the algorithm stopped because it ran out of memory.
-* `ObjectiveLimit`: the algorthm stopped because it found a solution better than
+* `MemoryLimit`: The algorithm stopped because it ran out of memory.
+* `ObjectiveLimit`: The algorthm stopped because it found a solution better than
   a minimum limit set by the user.
-* `NormLimit`: the algorithm stopped because the norm of an iterate became too
+* `NormLimit`: The algorithm stopped because the norm of an iterate became too
   large.
-* `OtherLimit`: the algorithm stopped due to a limit not covered by one of the
+* `OtherLimit`: The algorithm stopped due to a limit not covered by one of the
   above.
 
 ## Problematic
 
 This group of statuses means that something unexpected or problematic happened.
 
-* `SlowProgress`: the algorithm stopped because it was unable to continue making
+* `SlowProgress`: The algorithm stopped because it was unable to continue making
   progress towards the solution.
-* `AlmostSuccess` should be used if there is additional information that relaxed
-  convergence tolerances are satisfied
-* `NumericalError`: the algorithm stopped because it encountered unrecoverable
+* `NumericalError`: The algorithm stopped because it encountered unrecoverable
   numerical error.
-* `InvalidModel`: the algorithm stopped because the model is invalid.
-* `InvalidOption`: the algorithm stopped because it was provided an invalid
+* `InvalidModel`: The algorithm stopped because the model is invalid.
+* `InvalidOption`: The algorithm stopped because it was provided an invalid
   option.
-* `Interrupted`: the algorithm stopped because of an interrupt signal.
-* `OtherError`: the algorithm stopped because of an error not covered by one of
+* `Interrupted`: The algorithm stopped because of an interrupt signal.
+* `OtherError`: The algorithm stopped because of an error not covered by one of
   the statuses defined above.
 """
 @enum(TerminationStatusCode,
     OptimizeNotCalled,
     # OK
-    Success, AlmostSuccess, InfeasibleNoResult, UnboundedNoResult,
+    Optimal, Infeasible, DualInfeasible, LocallyConverged, LocallyInfeasible,
         InfeasibleOrUnbounded,
+    # Solved to relaxed tolerances
+    AlmostOptimal, AlmostInfeasible, AlmostLocallyConverged,
     # Limits
     IterationLimit, TimeLimit,  NodeLimit, SolutionLimit, MemoryLimit,
         ObjectiveLimit, NormLimit, OtherLimit,

--- a/test/Test/contconic.jl
+++ b/test/Test/contconic.jl
@@ -18,15 +18,15 @@
                               (MOI.VectorAffineFunction{Float64}, MOI.Nonpositives) => [[0]],
                               (MOI.VectorAffineFunction{Float64}, MOI.Zeros)        => [[7, 2, -4], [7]])
         MOIT.lin2ftest(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
         MOIT.lin3test(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibleNoResult)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible)
         MOIT.lin3test(mock, MOIT.TestConfig(infeas_certificates=false))
         mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibleOrUnbounded)
         MOIT.lin3test(mock, MOIT.TestConfig(infeas_certificates=false))
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
         MOIT.lin4test(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibleNoResult)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible)
         MOIT.lin4test(mock, MOIT.TestConfig(infeas_certificates=false))
         mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibleOrUnbounded)
         MOIT.lin4test(mock, MOIT.TestConfig(infeas_certificates=false))
@@ -49,7 +49,7 @@
                               (MOI.VectorAffineFunction{Float64}, MOI.Zeros)           => [[√2]],
                               (MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)    => [[-1.0]])
         MOIT.soc2ptest(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
         MOIT.soc3test(mock, config)
         mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 2/√5, 1/√5, 2/√5, 1/√5],
                               (MOI.VectorAffineFunction{Float64}, MOI.Zeros)           => [[-√5, -2.0, -1.0]])
@@ -66,7 +66,7 @@
         mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/√2, 1/√2],
                               (MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone) => [[√2, 1/√2, -1.0, -1.0]])
         MOIT.rotatedsoc1ftest(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, tuple(),
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible, tuple(),
                               (MOI.SingleVariable,                MOI.LessThan{Float64})      => [-1],
                               (MOI.SingleVariable,                MOI.EqualTo{Float64})       => [-1],
                               (MOI.SingleVariable,                MOI.GreaterThan{Float64})   => [1],

--- a/test/Test/contlinear.jl
+++ b/test/Test/contlinear.jl
@@ -63,23 +63,25 @@
     set_mock_optimize_linear7Test!(mock)
     MOIT.linear7test(mock, config_no_lhs_modif)
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, tuple(),
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible,
+                                                           tuple(),
              (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1]))
     MOIT.linear8atest(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibleNoResult))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible))
     MOIT.linear8atest(mock, MOIT.TestConfig(infeas_certificates=false))
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibilityCertificate))
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DualInfeasible,
+                                                           MOI.InfeasibilityCertificate))
     MOIT.linear8btest(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.UnboundedNoResult))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DualInfeasible))
     MOIT.linear8btest(mock, MOIT.TestConfig(infeas_certificates=false))
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, (MOI.InfeasibilityCertificate, [1, 1])))
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DualInfeasible, (MOI.InfeasibilityCertificate, [1, 1])))
     MOIT.linear8ctest(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.UnboundedNoResult))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DualInfeasible))
     MOIT.linear8ctest(mock, MOIT.TestConfig(infeas_certificates=false))
     MOIU.set_mock_optimize!(mock,
          (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [650/11, 400/11]))
@@ -97,11 +99,12 @@
          (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [0.5, 0.5]))
     MOIT.linear11test(mock, config)
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, tuple(),
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible,
+                                                           tuple(),
               (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})    => [-1, -1]))
     MOIT.linear12test(mock, config)
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibleNoResult))
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible))
     MOIT.linear12test(mock, MOIT.TestConfig(infeas_certificates=false))
     MOIU.set_mock_optimize!(mock,
          (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/5, 1/5],

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -28,7 +28,7 @@ end
     @testset "solve_blank_obj" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1]),
                 MOI.FeasiblePoint
             )
@@ -37,7 +37,7 @@ end
         # The objective is blank so any primal value ≥ 1 is correct
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [2]),
                 MOI.FeasiblePoint
             )
@@ -47,7 +47,7 @@ end
     @testset "solve_constant_obj" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1]),
                 MOI.FeasiblePoint
             )
@@ -57,7 +57,7 @@ end
     @testset "solve_singlevariable_obj" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1]),
                 MOI.FeasiblePoint
             )
@@ -67,7 +67,7 @@ end
     @testset "solve_with_lowerbound" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1]),
                 MOI.FeasiblePoint,
                     (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [2.0],
@@ -82,7 +82,7 @@ end
     @testset "solve_with_upperbound" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1]),
                 MOI.FeasiblePoint,
                     (MOI.SingleVariable, MOI.LessThan{Float64})    => [-2.0],
@@ -97,7 +97,7 @@ end
     @testset "solve_affine_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [0.5]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-0.5]
@@ -108,7 +108,7 @@ end
     @testset "solve_affine_greaterthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [0.5]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [0.5]
@@ -119,7 +119,7 @@ end
     @testset "solve_affine_equalto" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [0.5]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}) => [0.5]
@@ -130,7 +130,7 @@ end
     @testset "solve_affine_interval" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [2.0]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [-1.5]
@@ -142,11 +142,11 @@ end
     @testset "solve_qcp_edge_cases" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [0.5, 0.5])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [0.5, (√13 - 1)/4])
             )
         )
@@ -156,19 +156,19 @@ end
     @testset "solve_qp_edge_cases" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1.0, 2.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1.0, 2.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1.0, 2.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1.0, 2.0])
             )
         )
@@ -177,7 +177,7 @@ end
     @testset "solve_duplicate_terms_obj" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success,
+                MOI.Optimal,
                 (MOI.FeasiblePoint, [1]),
                 MOI.FeasiblePoint
             )
@@ -187,19 +187,19 @@ end
     @testset "solve_affine_deletion_edge_cases" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [0.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [0.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [0.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [0.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [2.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [2.0])
             )
         )
         MOIT.solve_affine_deletion_edge_cases(mock, config)
@@ -207,16 +207,16 @@ end
     @testset "solve_integer_edge_cases" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [2.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [2.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [0.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [0.0])
             )
         )
         MOIT.solve_integer_edge_cases(mock, config)
@@ -225,19 +225,19 @@ end
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> begin
                 MOI.set(mock, MOI.ObjectiveBound(), 3.0)
-                MOIU.mock_optimize!(mock, MOI.Success, (MOI.FeasiblePoint, [2.0]))
+                MOIU.mock_optimize!(mock, MOI.Optimal, (MOI.FeasiblePoint, [2.0]))
             end,
             (mock::MOIU.MockOptimizer) -> begin
                 MOI.set(mock, MOI.ObjectiveBound(), 3.0)
-                MOIU.mock_optimize!(mock, MOI.Success, (MOI.FeasiblePoint, [1.0]))
+                MOIU.mock_optimize!(mock, MOI.Optimal, (MOI.FeasiblePoint, [1.0]))
             end,
             (mock::MOIU.MockOptimizer) -> begin
                 MOI.set(mock, MOI.ObjectiveBound(), 2.0)
-                MOIU.mock_optimize!(mock, MOI.Success, (MOI.FeasiblePoint, [1.5]))
+                MOIU.mock_optimize!(mock, MOI.Optimal, (MOI.FeasiblePoint, [1.5]))
             end,
             (mock::MOIU.MockOptimizer) -> begin
                 MOI.set(mock, MOI.ObjectiveBound(), 4.0)
-                MOIU.mock_optimize!(mock, MOI.Success, (MOI.FeasiblePoint, [1.5]))
+                MOIU.mock_optimize!(mock, MOI.Optimal, (MOI.FeasiblePoint, [1.5]))
             end
         )
         MOIT.solve_objbound_edge_cases(mock, config)
@@ -251,11 +251,11 @@ end
     @testset "solve_set_singlevariable_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0]),
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
                 MOI.FeasiblePoint
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [2.0]),
+                MOI.Optimal, (MOI.FeasiblePoint, [2.0]),
                 MOI.FeasiblePoint
             )
         )
@@ -264,11 +264,11 @@ end
     @testset "solve_transform_singlevariable_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0]),
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
                 MOI.FeasiblePoint
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [2.0]),
+                MOI.Optimal, (MOI.FeasiblePoint, [2.0]),
                 MOI.FeasiblePoint
             )
         )
@@ -277,12 +277,12 @@ end
     @testset "solve_set_scalaraffine_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0]),
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0]
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [2.0]),
+                MOI.Optimal, (MOI.FeasiblePoint, [2.0]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0]
             )
@@ -292,12 +292,12 @@ end
     @testset "solve_coef_scalaraffine_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0]),
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0]
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [0.5]),
+                MOI.Optimal, (MOI.FeasiblePoint, [0.5]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-0.5]
             )
@@ -307,12 +307,12 @@ end
     @testset "solve_func_scalaraffine_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0]),
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0]
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [0.5]),
+                MOI.Optimal, (MOI.FeasiblePoint, [0.5]),
                 MOI.FeasiblePoint,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-0.5]
             )
@@ -322,10 +322,10 @@ end
     @testset "solve_const_vectoraffine_nonpos" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [0.0, 0.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [0.0, 0.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0, 0.75])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0, 0.75])
             )
         )
         MOIT.solve_const_vectoraffine_nonpos(mock, config)
@@ -333,10 +333,10 @@ end
     @testset "solve_multirow_vectoraffine_nonpos" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [0.5])
+                MOI.Optimal, (MOI.FeasiblePoint, [0.5])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [0.25])
+                MOI.Optimal, (MOI.FeasiblePoint, [0.25])
             )
         )
         MOIT.solve_multirow_vectoraffine_nonpos(mock, config)
@@ -344,10 +344,10 @@ end
     @testset "solve_const_scalar_objective" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
             )
         )
         MOIT.solve_const_scalar_objective(mock, config)
@@ -355,10 +355,10 @@ end
     @testset "solve_coef_scalar_objective" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Success, (MOI.FeasiblePoint, [1.0])
+                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
             )
         )
         MOIT.solve_coef_scalar_objective(mock, config)

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -41,10 +41,10 @@ end
     v1 = MOI.add_variable(optimizer)
 
     # Load fake solution
-    MOI.set(optimizer, MOI.TerminationStatus(), MOI.InfeasibleNoResult)
+    MOI.set(optimizer, MOI.TerminationStatus(), MOI.Infeasible)
 
     MOI.optimize!(optimizer)
-    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.InfeasibleNoResult
+    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Infeasible
     @test MOI.get(optimizer, MOI.ResultCount()) == 0
 end
 
@@ -60,7 +60,7 @@ end
 
     # Load fake solution
     # TODO: Provide a more compact API for this.
-    MOI.set(optimizer, MOI.TerminationStatus(), MOI.Success)
+    MOI.set(optimizer, MOI.TerminationStatus(), MOI.Optimal)
     MOI.set(optimizer, MOI.ObjectiveValue(), 1.0)
     MOI.set(optimizer, MOI.ResultCount(), 1)
     MOI.set(optimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
@@ -71,7 +71,7 @@ end
     MOI.set(optimizer, MOI.ConstraintDual(), soc, [1.0,2.0])
 
     MOI.optimize!(optimizer)
-    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Success
+    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Optimal
     @test MOI.get(optimizer, MOI.ResultCount()) == 1
     @test MOI.get(optimizer, MOI.ObjectiveValue()) == 1.0
     @test MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FeasiblePoint

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -277,11 +277,11 @@ end
         @testset "Quadratic constraints with 2 variables" begin
             MOIU.set_mock_optimize!(mock,
                 (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                    MOI.Success,
+                    MOI.Optimal,
                     (MOI.FeasiblePoint, [0.5, 0.5])
                 ),
                 (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                    MOI.Success,
+                    MOI.Optimal,
                     (MOI.FeasiblePoint, [0.5, (√13 - 1)/4])
                 )
             )


### PR DESCRIPTION
This is a breaking change to `TerminationStatus` following the discussion in https://github.com/JuliaOpt/JuMP.jl/issues/1656.

The main change is that `TerminationStatus` now distinguishes between optimal, locally optimal, infeasible, locally infeasible, and dual infeasible, addressing a usability issue in JuMP where users had to query both termination status and result statuses in order to interpret what happened in very basic cases. We had originally planned to abstract this away at the JuMP level, but this was hard to do because it requires additional knowledge about the solver than what's available through MOI.

I've made only the documentation changes. If we agree on this I'll get tests passing. If you can think of additional interesting corner cases, I'll add them to the tables in the docs (screenshots below). The tables seem useful for justifying why we need to put so much effort into reporting statuses correctly.

![image](https://user-images.githubusercontent.com/1733683/49687512-f75d5d00-fad1-11e8-9f93-9c04320c3874.png)

![image](https://user-images.githubusercontent.com/1733683/49687538-53c07c80-fad2-11e8-865b-e2e3e9123904.png)

![image](https://user-images.githubusercontent.com/1733683/49687525-18be4900-fad2-11e8-92ad-ff23d8fc45d8.png)


@ccoffrin @chkwon @tkoolen @ulfworsoe @frapac 