### PR TITLE
Fix copy doc

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -884,24 +884,26 @@ MOI.set(model, MyPackage.PrintLevel(), 0)
 
 ### Implementing copy
 
-Avoid storing extra copies of the problem when possible. This means that solver wrappers should not use
-`CachingOptimizer` as part of the wrapper. Instead, do one of the following to load the problem:
+Avoid storing extra copies of the problem when possible. This means that solver
+wrappers should not use `CachingOptimizer` as part of the wrapper. Instead, do
+one of the following to load the problem (assuming the solver wrapper type is
+called `Optimizer`):
 
 * If the solver supports loading the problem incrementally, implement
   [`add_variable`](@ref), [`add_constraint`](@ref) for supported constraints and
   [`set`](@ref) for supported attributes and add:
   ```julia
-  function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; kws...)
+  function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; kws...)
       return MOI.Utilities.automatic_copy_to(dest, src, kws...)
   end
   ```
   with
   ```julia
-  MOI.Utilities.supports_default_copy_to(model::AbstractModel, copy_names::Bool) = true
+  MOI.Utilities.supports_default_copy_to(model::Optimizer, copy_names::Bool) = true
   ```
   or
   ```julia
-  MOI.Utilities.supports_default_copy_to(model::AbstractModel, copy_names::Bool) = !copy_names
+  MOI.Utilities.supports_default_copy_to(model::Optimizer, copy_names::Bool) = !copy_names
   ```
   depending on whether the solver support names; see
   [`Utilities.supports_default_copy_to`](@ref) for more details.
@@ -913,17 +915,17 @@ Avoid storing extra copies of the problem when possible. This means that solver 
   implement the Allocate-Load API,
   do
   ```julia
-  function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; kws...)
+  function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; kws...)
       return MOI.Utilities.automatic_copy_to(dest, src, kws...)
   end
   ```
   with
   ```julia
-  MOI.Utilities.supports_allocate_load(model::AbstractModel, copy_names::Bool) = true
+  MOI.Utilities.supports_allocate_load(model::Optimizer, copy_names::Bool) = true
   ```
   or
   ```julia
-  MOI.Utilities.supports_allocate_load(model::AbstractModel, copy_names::Bool) = !copy_names
+  MOI.Utilities.supports_allocate_load(model::Optimizer, copy_names::Bool) = !copy_names
   ```
   depending on whether the solver support names; see
   [`Utilities.supports_allocate_load`](@ref) for more details.

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -894,7 +894,7 @@ called `Optimizer`):
   [`set`](@ref) for supported attributes and add:
   ```julia
   function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; kws...)
-      return MOI.Utilities.automatic_copy_to(dest, src, kws...)
+      return MOI.Utilities.automatic_copy_to(dest, src; kws...)
   end
   ```
   with
@@ -916,7 +916,7 @@ called `Optimizer`):
   do
   ```julia
   function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike; kws...)
-      return MOI.Utilities.automatic_copy_to(dest, src, kws...)
+      return MOI.Utilities.automatic_copy_to(dest, src; kws...)
   end
   ```
   with

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -48,7 +48,7 @@ be implemented as
 ```julia
 MOI.Utilities.supports_default_copy_to(model::MyModel, copy_names::Bool) = true
 function MOI.copy_to(dest::MyModel, src::MOI.ModelLike; kws...)
-    return MOI.Utilities.automatic_copy_to(dest, src, kws...)
+    return MOI.Utilities.automatic_copy_to(dest, src; kws...)
 end
 ```
 The [`Utilities.automatic_copy_to`](@ref) function automatically redirects to


### PR DESCRIPTION
With the implementation suggested, we get
```julia
MethodError: no method matching automatic_copy_to(::SCS.Optimizer, ::SCSModelData{Float64}, ::Pair{Symbol,Bool})
  Closest candidates are:
    automatic_copy_to(::MathOptInterface.ModelLike, ::MathOptInterface.ModelLike; copy_names) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/copy.jl:14
```