### PR TITLE
rename enum values for style consistency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,13 @@
 MathOptInterface (MOI) release notes
 ====================================
 
-v0.7.1 (unreleased)
---------------------------
+v0.8.0 (unreleased)
+-------------------
 
-- Add an `MOI.TerminationStatusCode` called `MOI.AlmostDualInfeasible`.
+- Rename all enum values to follow the JuMP naming guidelines for constants,
+  e.g., `Optimal` becomes `OPTIMAL`, and `DualInfeasible` becomes
+  `DUAL_INFEASIBLE`.
+- Add an `MOI.TerminationStatusCode` called `ALMOST_DUAL_INFEASIBLE`.
 
 v0.7.0 (December 13, 2018)
 --------------------------

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -981,7 +981,10 @@ users to avoid extra copies in this case.
 
 ### Statuses
 
-Solver wrappers should document how the low-level solver statuses map to the MOI statuses. In particular, the characterization of a result with status `FEASIBLE_POINT` and termination status `Success` is entirely solver defined. It may or may not be a globally optimal solution. Solver wrappers are not responsible for verifying the feasibility of results. Statuses like `NEARLY_FEASIBLE_POINT`, `INFEASIBLE_POINT`, and `NearlyReductionCertificate` are designed to be used when the solver explicitly indicates as much.
+Solver wrappers should document how the low-level statuses map to the MOI
+statuses. Statuses like `NEARLY_FEASIBLE_POINT` and `INFEASIBLE_POINT`, are
+designed to be used when the solver explicitly indicates that relaxed tolerances
+are satisfied or the returned point is infeasible, respectively.
 
 ### Naming
 

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -218,7 +218,7 @@ For example,
 x = add_variables(model, 2)
 set(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(),
             ScalarAffineFunction(ScalarAffineTerm.([5.0,-2.3],[x[1],x[2]]),1.0))
-set(model, ObjectiveSense(), MinSense)
+set(model, ObjectiveSense(), MIN_SENSE)
 ```
 sets the objective to the function just discussed in the minimization sense.
 
@@ -254,7 +254,7 @@ The code example below encodes the linear optimization problem:
 x = add_variables(model, 2)
 set(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(),
             ScalarAffineFunction(ScalarAffineTerm.([3.0, 2.0], x), 0.0))
-set(model, ObjectiveSense(), MaxSense)
+set(model, ObjectiveSense(), MAX_SENSE)
 add_constraint(model, ScalarAffineFunction(ScalarAffineTerm.(1.0, x), 0.0),
                       LessThan(5.0))
 add_constraint(model, SingleVariable(x[1]), GreaterThan(0.0))
@@ -278,7 +278,7 @@ The code example below encodes the convex optimization problem:
 x,y,z = add_variables(model, 3)
 set(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(),
             ScalarAffineFunction(ScalarAffineTerm.(1.0, [y,z]), 0.0))
-set(model, ObjectiveSense(), MaxSense)
+set(model, ObjectiveSense(), MAX_SENSE)
 vector_terms = [VectorAffineTerm(1, ScalarAffineTerm(3.0, x))]
 add_constraint(model, VectorAffineFunction(vector_terms,[-2.0]), Zeros(1))
 add_constraint(model, VectorOfVariables([x,y,z]), SecondOrderCone(3))
@@ -374,7 +374,7 @@ unexpected like invalid problem data or failure to converge. A typical usage of
 the `TerminationStatus` attribute is as follows:
 ```julia
 status = MOI.get(optimizer, TerminationStatus())
-if status == MOI.Optimal
+if status == MOI.OPTIMAL
     # Ok, we solved the problem!
 else
     # Handle other cases.
@@ -392,9 +392,9 @@ distinguishes between these two cases.
 
 The [`PrimalStatus`](@ref) and [`DualStatus`](@ref) attributes return a
 [`ResultStatusCode`](@ref) that indicates if that component of the result
-is present (i.e., not `NoSolution`) and explains how to interpret the result.
+is present (i.e., not `NO_SOLUTION`) and explains how to interpret the result.
 
-If `PrimalStatus` is not `NoSolution`, then the primal may be retrieved with the
+If `PrimalStatus` is not `NO_SOLUTION`, then the primal may be retrieved with the
 [`VariablePrimal`](@ref) attribute:
 ```julia
 MOI.get(optimizer, VariablePrimal(), x)
@@ -424,26 +424,26 @@ how the solver's statuses map to MOI statuses.
 
 Linear programming and conic optimization solvers fall into this category.
 
-| What happened?                          | `TerminationStatus()` | `ResultCount()` | `PrimalStatus()`                         | `DualStatus()`                           |
-| --------------------------------------- | --------------------- | --------------- | ---------------------------------------- | ---------------------------------------- |
-| Proved optimality                       | `Optimal`             | 1               | `FeasiblePoint`                          | `FeasiblePoint`                          |
-| Proved infeasible                       | `Infeasible`          | 1               | `NoSolution`                             | `InfeasibilityCertificate`               |
-| Optimal within relaxed tolerances       | `AlmostOptimal`       | 1               | `FeasiblePoint` or `AlmostFeasiblePoint` | `FeasiblePoint` or `AlmostFeasiblePoint` |
-| Detected an unbounded ray of the primal | `DualInfeasible`      | 1               | `InfeasibilityCertificate`               | `NoSolution`                             |
-| Stall                                   | `SlowProgress`        | 1               | ?                                        | ?                                        |
+| What happened?                          | `TerminationStatus()` | `ResultCount()` | `PrimalStatus()`                            | `DualStatus()`                              |
+| --------------------------------------- | --------------------- | --------------- | ------------------------------------------- | ------------------------------------------- |
+| Proved optimality                       | `Optimal`             | 1               | `FEASIBLE_POINT`                            | `FEASIBLE_POINT`                            |
+| Proved infeasible                       | `Infeasible`          | 1               | `NO_SOLUTION`                               | `INFEASIBILITY_CERTIFICATE`                 |
+| Optimal within relaxed tolerances       | `ALMOST_OPTIMAL`      | 1               | `FEASIBLE_POINT` or `ALMOST_FEASIBLE_POINT` | `FEASIBLE_POINT` or `ALMOST_FEASIBLE_POINT` |
+| Detected an unbounded ray of the primal | `DUAL_INFEASIBLE`     | 1               | `INFEASIBILITY_CERTIFICATE`                 | `NO_SOLUTION`                               |
+| Stall                                   | `SLOW_PROGRESS`       | 1               | ?                                           | ?                                           |
 
 #### Global branch-and-bound solvers
 
 Mixed-integer programming solvers fall into this category.
 
-| What happened?                                   | `TerminationStatus()`   | `ResultCount()` | `PrimalStatus()`  | `DualStatus()` |
-| ------------------------------------------------ | ----------------------- | --------------- | ----------------- | -------------- |
-| Proved optimality                                | `Optimal`               | 1               | `FeasiblePoint`   | `NoSolution`   |
-| Presolve detected infeasibility or unboundedness | `InfeasibleOrUnbounded` | 0               | `NoSolution`      | `NoSolution`   |
-| Proved infeasibility                             | `Infeasible`            | 0               | `NoSolution`      | `NoSolution`   |
-| Timed out (no solution)                          | `TimeLimit`             | 0               | `NoSolution`      | `NoSolution`   |
-| Timed out (with a solution)                      | `TimeLimit`             | 1               | `FeasiblePoint`   | `NoSolution`   |
-| `CPXMIP_OPTIMAL_INFEAS`                          | `AlmostOptimal`         | 1               | `InfeasiblePoint` | `NoSolution`   |
+| What happened?                                   | `TerminationStatus()`     | `ResultCount()` | `PrimalStatus()`   | `DualStatus()` |
+| ------------------------------------------------ | ------------------------- | --------------- | ------------------ | -------------- |
+| Proved optimality                                | `Optimal`                 | 1               | `FEASIBLE_POINT`   | `NO_SOLUTION`  |
+| Presolve detected infeasibility or unboundedness | `INFEASIBLE_OR_UNBOUNDED` | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
+| Proved infeasibility                             | `Infeasible`              | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
+| Timed out (no solution)                          | `TIME_LIMIT`              | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
+| Timed out (with a solution)                      | `TIME_LIMIT`              | 1               | `FEASIBLE_POINT`   | `NO_SOLUTION`  |
+| `CPXMIP_OPTIMAL_INFEAS`                          | `ALMOST_OPTIMAL`          | 1               | `INFEASIBLE_POINT` | `NO_SOLUTION`  |
 
 [`CPXMIP_OPTIMAL_INFEAS`](https://www.ibm.com/support/knowledgecenter/en/SSSA5P_12.6.1/ilog.odms.cplex.help/refcallablelibrary/macros/CPXMIP_OPTIMAL_INFEAS.html)
 is a CPLEX status that indicates that a preprocessed problem was solved to
@@ -456,14 +456,14 @@ Nonlinear programming solvers fall into this category. It also includes
 non-global tree search solvers like
 [Juniper](https://github.com/lanl-ansi/Juniper.jl).
 
-| What happened?                                         | `TerminationStatus()`           | `ResultCount()` | `PrimalStatus()`  | `DualStatus()`  |
-| ------------------------------------------------------ | ------------------------------- | --------------- | ----------------- | --------------- |
-| Converged to a stationary point                        | `LocallySolved`                 | 1               | `FeasiblePoint`   | `FeasiblePoint` |
-| Completed a non-global tree search (with a solution)   | `LocallySolved`                 | 1               | `FeasiblePoint`   | `FeasiblePoint` |
-| Converged to an infeasible point                       | `LocallyInfeasible`             | 1               | `InfeasiblePoint` | ?               |
-| Completed a non-global tree search (no solution found) | `LocallyInfeasible`             | 0               | `NoSolution`      | `NoSolution`    |
-| Iteration limit                                        | `IterationLimit`                | 1               | ?                 | ?               |
-| Diverging iterates                                     | `NormLimit` or `ObjectiveLimit` | 1               | ?                 | ?               |
+| What happened?                                         | `TerminationStatus()`             | `ResultCount()` | `PrimalStatus()`   | `DualStatus()`   |
+| ------------------------------------------------------ | --------------------------------- | --------------- | ------------------ | ---------------- |
+| Converged to a stationary point                        | `LOCALLY_SOLVED`                  | 1               | `FEASIBLE_POINT`   | `FEASIBLE_POINT` |
+| Completed a non-global tree search (with a solution)   | `LOCALLY_SOLVED`                  | 1               | `FEASIBLE_POINT`   | `FEASIBLE_POINT` |
+| Converged to an infeasible point                       | `LOCALLY_INFEASIBLE`              | 1               | `INFEASIBLE_POINT` | ?                |
+| Completed a non-global tree search (no solution found) | `LOCALLY_INFEASIBLE`              | 0               | `NO_SOLUTION`      | `NO_SOLUTION`    |
+| Iteration limit                                        | `ITERATION_LIMIT`                 | 1               | ?                  | ?                |
+| Diverging iterates                                     | `NORM_LIMIT` or `OBJECTIVE_LIMIT` | 1               | ?                  | ?                |
 
 
 ## A complete example: solving a knapsack problem
@@ -493,7 +493,7 @@ x = MOI.add_variables(optimizer, num_variables)
 objective_function = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(c, x), 0.0)
 MOI.set(optimizer, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         objective_function)
-MOI.set(optimizer, MOI.ObjectiveSense(), MOI.MaxSense)
+MOI.set(optimizer, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
 # Add the knapsack constraint.
 knapsack_function = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(w, x), 0.0)
@@ -509,13 +509,13 @@ MOI.optimize!(optimizer)
 
 termination_status = MOI.get(optimizer, MOI.TerminationStatus())
 obj_value = MOI.get(optimizer, MOI.ObjectiveValue())
-if termination_status != MOI.Optimal
+if termination_status != MOI.OPTIMAL
     error("Solver terminated with status $termination_status")
 end
 
 @assert MOI.get(optimizer, MOI.ResultCount()) > 0
 
-@assert MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FeasiblePoint
+@assert MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
 primal_variable_result = MOI.get(optimizer, MOI.VariablePrimal(), x)
 
@@ -981,7 +981,7 @@ users to avoid extra copies in this case.
 
 ### Statuses
 
-Solver wrappers should document how the low-level solver statuses map to the MOI statuses. In particular, the characterization of a result with status `FeasiblePoint` and termination status `Success` is entirely solver defined. It may or may not be a globally optimal solution. Solver wrappers are not responsible for verifying the feasibility of results. Statuses like `NearlyFeasiblePoint`, `InfeasiblePoint`, `NearlyInfeasiblePoint`, and `NearlyReductionCertificate` are designed to be used when the solver explicitly indicates as much.
+Solver wrappers should document how the low-level solver statuses map to the MOI statuses. In particular, the characterization of a result with status `FEASIBLE_POINT` and termination status `Success` is entirely solver defined. It may or may not be a globally optimal solution. Solver wrappers are not responsible for verifying the feasibility of results. Statuses like `NEARLY_FEASIBLE_POINT`, `INFEASIBLE_POINT`, and `NearlyReductionCertificate` are designed to be used when the solver explicitly indicates as much.
 
 ### Naming
 

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -427,7 +427,7 @@ Linear programming and conic optimization solvers fall into this category.
 | What happened?                          | `TerminationStatus()` | `ResultCount()` | `PrimalStatus()`                            | `DualStatus()`                              |
 | --------------------------------------- | --------------------- | --------------- | ------------------------------------------- | ------------------------------------------- |
 | Proved optimality                       | `Optimal`             | 1               | `FEASIBLE_POINT`                            | `FEASIBLE_POINT`                            |
-| Proved infeasible                       | `Infeasible`          | 1               | `NO_SOLUTION`                               | `INFEASIBILITY_CERTIFICATE`                 |
+| Proved infeasible                       | `INFEASIBLE`          | 1               | `NO_SOLUTION`                               | `INFEASIBILITY_CERTIFICATE`                 |
 | Optimal within relaxed tolerances       | `ALMOST_OPTIMAL`      | 1               | `FEASIBLE_POINT` or `ALMOST_FEASIBLE_POINT` | `FEASIBLE_POINT` or `ALMOST_FEASIBLE_POINT` |
 | Detected an unbounded ray of the primal | `DUAL_INFEASIBLE`     | 1               | `INFEASIBILITY_CERTIFICATE`                 | `NO_SOLUTION`                               |
 | Stall                                   | `SLOW_PROGRESS`       | 1               | ?                                           | ?                                           |
@@ -440,7 +440,7 @@ Mixed-integer programming solvers fall into this category.
 | ------------------------------------------------ | ------------------------- | --------------- | ------------------ | -------------- |
 | Proved optimality                                | `Optimal`                 | 1               | `FEASIBLE_POINT`   | `NO_SOLUTION`  |
 | Presolve detected infeasibility or unboundedness | `INFEASIBLE_OR_UNBOUNDED` | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
-| Proved infeasibility                             | `Infeasible`              | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
+| Proved infeasibility                             | `INFEASIBLE`              | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
 | Timed out (no solution)                          | `TIME_LIMIT`              | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
 | Timed out (with a solution)                      | `TIME_LIMIT`              | 1               | `FEASIBLE_POINT`   | `NO_SOLUTION`  |
 | `CPXMIP_OPTIMAL_INFEAS`                          | `ALMOST_OPTIMAL`          | 1               | `INFEASIBLE_POINT` | `NO_SOLUTION`  |

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -385,7 +385,7 @@ After checking the `TerminationStatus`, one should typically check
 [`ResultCount`](@ref). This attribute returns the number of results that the
 solver has available to return. *A result is defined as a primal-dual pair,
 but either the primal or the dual may be missing from the result.* While the
-`Optimal` termination status normally implies that at least one result is
+`OPTIMAL` termination status normally implies that at least one result is
 available, other statuses do not. For example, in the case of infeasiblity,
 a solver may return no result or a proof of infeasibility. The `ResultCount`
 distinguishes between these two cases.
@@ -426,7 +426,7 @@ Linear programming and conic optimization solvers fall into this category.
 
 | What happened?                          | `TerminationStatus()` | `ResultCount()` | `PrimalStatus()`                            | `DualStatus()`                              |
 | --------------------------------------- | --------------------- | --------------- | ------------------------------------------- | ------------------------------------------- |
-| Proved optimality                       | `Optimal`             | 1               | `FEASIBLE_POINT`                            | `FEASIBLE_POINT`                            |
+| Proved optimality                       | `OPTIMAL`             | 1               | `FEASIBLE_POINT`                            | `FEASIBLE_POINT`                            |
 | Proved infeasible                       | `INFEASIBLE`          | 1               | `NO_SOLUTION`                               | `INFEASIBILITY_CERTIFICATE`                 |
 | Optimal within relaxed tolerances       | `ALMOST_OPTIMAL`      | 1               | `FEASIBLE_POINT` or `ALMOST_FEASIBLE_POINT` | `FEASIBLE_POINT` or `ALMOST_FEASIBLE_POINT` |
 | Detected an unbounded ray of the primal | `DUAL_INFEASIBLE`     | 1               | `INFEASIBILITY_CERTIFICATE`                 | `NO_SOLUTION`                               |
@@ -438,7 +438,7 @@ Mixed-integer programming solvers fall into this category.
 
 | What happened?                                   | `TerminationStatus()`     | `ResultCount()` | `PrimalStatus()`   | `DualStatus()` |
 | ------------------------------------------------ | ------------------------- | --------------- | ------------------ | -------------- |
-| Proved optimality                                | `Optimal`                 | 1               | `FEASIBLE_POINT`   | `NO_SOLUTION`  |
+| Proved optimality                                | `OPTIMAL`                 | 1               | `FEASIBLE_POINT`   | `NO_SOLUTION`  |
 | Presolve detected infeasibility or unboundedness | `INFEASIBLE_OR_UNBOUNDED` | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
 | Proved infeasibility                             | `INFEASIBLE`              | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |
 | Timed out (no solution)                          | `TIME_LIMIT`              | 0               | `NO_SOLUTION`      | `NO_SOLUTION`  |

--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -136,7 +136,7 @@ function solve_qcp_edge_cases(model::MOI.ModelLike, config::TestConfig)
         # max x + 2y | y + x^2 + x^2 <= 1, x >= 0.5, y >= 0.5
         MOI.empty!(model)
         x = MOI.add_variables(model, 2)
-        MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         MOI.set(model,
             MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
             MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0], x), 0.0)
@@ -160,7 +160,7 @@ function solve_qcp_edge_cases(model::MOI.ModelLike, config::TestConfig)
         # max x + 2y | x^2 + 0.25y*x + 0.25x*y + 0.5x*y + y^2 <= 1, x >= 0.5, y >= 0.5
         MOI.empty!(model)
         x = MOI.add_variables(model, 2)
-        MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         MOI.set(model,
             MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
             MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0], x), 0.0)
@@ -203,7 +203,7 @@ function solve_affine_deletion_edge_cases(model::MOI.ModelLike, config::TestConf
     vaf  = MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [0.0])
     vaf2 = MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-2.0])
     # max x
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), saf)
     # test adding a VectorAffineFunction -in- LessThan
     c1 = MOI.add_constraint(model, vaf, MOI.Nonpositives(1))

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -58,7 +58,7 @@ function solve_transform_singlevariable_lessthan(model::MOI.ModelLike, config::T
     c2 = MOI.transform(model, c, MOI.GreaterThan(2.0))
     @test !MOI.is_valid(model, c)
     @test MOI.is_valid(model, c2)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     test_model_solution(model, config;
         objective_value   = 2.0,
         variable_primal   = [(x, 2.0)],

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -17,42 +17,42 @@
 """
     max_sense(model::MOI.ModelLike, config::TestConfig)
 
-Test setting objective sense to MaxSense.
+Test setting objective sense to MAX_SENSE.
 """
 function max_sense(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.is_empty(model)
     @test MOI.supports(model, MOI.ObjectiveSense())
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
 end
 unittests["max_sense"] = max_sense
 
 """
     min_sense(model::MOI.ModelLike, config::TestConfig)
 
-Test setting objective sense to MinSense.
+Test setting objective sense to MIN_SENSE.
 """
 function min_sense(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.is_empty(model)
     @test MOI.supports(model, MOI.ObjectiveSense())
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
 end
 unittests["min_sense"] = min_sense
 
 """
     feasibility_sense(model::MOI.ModelLike, config::TestConfig)
 
-Test setting objective sense to FeasibilitySense.
+Test setting objective sense to FEASIBILITY_SENSE.
 """
 function feasibility_sense(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.is_empty(model)
     @test MOI.supports(model, MOI.ObjectiveSense())
-    MOI.set(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FeasibilitySense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE
 end
 unittests["feasibility_sense"] = feasibility_sense
 
@@ -135,7 +135,7 @@ function solve_blank_obj(model::MOI.ModelLike, config::TestConfig)
     )
     if config.solve
         # The objective is blank so any primal value ≥ 1 is correct
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.VariablePrimal(), x) + atol + rtol ≥ 1.0
         @test MOI.get(model, MOI.ConstraintPrimal(), c) + atol + rtol ≥ 1.0
     end
@@ -180,7 +180,7 @@ If `config.solve=true` confirm that it solves correctly.
 function solve_qp_edge_cases(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     x = MOI.add_variables(model, 2)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.add_constraint(model, MOI.SingleVariable(x[1]), MOI.GreaterThan(1.0))
     MOI.add_constraint(model, MOI.SingleVariable(x[2]), MOI.GreaterThan(2.0))
 
@@ -261,7 +261,7 @@ function solve_duplicate_terms_obj(model::MOI.ModelLike, config::TestConfig)
     @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction(
             [MOI.ScalarAffineTerm(2.0, x), MOI.ScalarAffineTerm(1.0, x)],

--- a/src/Test/UnitTests/unit_tests.jl
+++ b/src/Test/UnitTests/unit_tests.jl
@@ -15,21 +15,21 @@ const unittests = Dict{String, Function}()
 
 Solve, and then test, various aspects of a model.
 
-First, check that `TerminationStatus == MOI.Optimal`.
+First, check that `TerminationStatus == MOI.OPTIMAL`.
 
 If `objective_value` is not nothing, check that the attribute `ObjectiveValue()`
 is approximately `objective_value`.
 
 If `variable_primal` is not nothing, check that the attribute  `PrimalStatus` is
-`MOI.FeasiblePoint`. Then for each `(index, value)` in `variable_primal`, check
+`MOI.FEASIBLE_POINT`. Then for each `(index, value)` in `variable_primal`, check
 that the primal value of the variable `index` is approximately `value`.
 
 If `constraint_primal` is not nothing, check that the attribute  `PrimalStatus` is
-`MOI.FeasiblePoint`. Then for each `(index, value)` in `constraint_primal`, check
+`MOI.FEASIBLE_POINT`. Then for each `(index, value)` in `constraint_primal`, check
 that the primal value of the constraint `index` is approximately `value`.
 
 Finally, if `config.duals = true`, and if `constraint_dual` is not nothing,
-check that the attribute  `DualStatus` is `MOI.FeasiblePoint`. Then for each
+check that the attribute  `DualStatus` is `MOI.FEASIBLE_POINT`. Then for each
 `(index, value)` in `constraint_dual`, check that the dual of the constraint
 `index` is approximately `value`.
 
@@ -64,20 +64,20 @@ function test_model_solution(model, config;
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ objective_value atol=atol rtol=rtol
     end
     if variable_primal != nothing
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         for (index, solution_value) in variable_primal
             @test MOI.get(model, MOI.VariablePrimal(), index) ≈ solution_value atol=atol rtol=rtol
         end
     end
     if constraint_primal != nothing
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         for (index, solution_value) in constraint_primal
             @test MOI.get(model, MOI.ConstraintPrimal(), index) ≈ solution_value atol=atol rtol=rtol
         end
     end
     if config.duals
         if constraint_dual != nothing
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             for (index, solution_value) in constraint_dual
                 @test MOI.get(model, MOI.ConstraintDual(), index) ≈ solution_value atol=atol rtol=rtol
             end

--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -7,11 +7,11 @@ struct TestConfig
     duals::Bool # test dual solutions
     infeas_certificates::Bool # check for infeasibility certificates when appropriate
     # The expected "optimal" status returned by the solver. Either
-    # MOI.Optimal or MOI.LocallySolved.
+    # MOI.OPTIMAL or MOI.LOCALLY_SOLVED.
     optimal_status::MOI.TerminationStatusCode
     function TestConfig(;atol::Float64 = 1e-8, rtol::Float64 = 1e-8, solve::Bool = true, query::Bool = true,
                         modify_lhs::Bool = true, duals::Bool = true, infeas_certificates::Bool = true,
-                        optimal_status = MOI.Optimal)
+                        optimal_status = MOI.OPTIMAL)
         new(
             atol,
             rtol,

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -43,18 +43,18 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     @test (MOI.VectorAffineFunction{Float64},MOI.Zeros) in loc
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-3.0, -2.0, -4.0], v), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
@@ -115,7 +115,7 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     @test MOI.get(model, MOI.NumberOfVariables()) == 4
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([3.0, 2.0, -4.0], [x,y,z]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     c = MOI.add_constraint(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,1,2,3,3], MOI.ScalarAffineTerm.([1.0,-1.0,1.0,1.0,1.0], [x,s,y,x,z])), [4.0,3.0,-12.0]), MOI.Zeros(3))
 
@@ -143,15 +143,15 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}()) == 1
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
@@ -208,21 +208,21 @@ function lin3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Nonpositives}()) == 1
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         if config.infeas_certificates
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
             @test MOI.get(model, MOI.ResultCount()) > 0
         else
-            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Infeasible, MOI.InfeasibleOrUnbounded]
+            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.INFEASIBLE, MOI.INFEASIBLE_OR_UNBOUNDED]
         end
         if MOI.get(model, MOI.ResultCount()) > 0
-            @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
-                                                         MOI.InfeasiblePoint)
+            @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NO_SOLUTION,
+                                                         MOI.INFEASIBLE_POINT)
             if config.duals && config.infeas_certificates
-                @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+                @test MOI.get(model, MOI.DualStatus()) == MOI.INFEASIBILITY_CERTIFICATE
             end
         end
         # TODO test dual feasibility and objective sign
@@ -259,21 +259,21 @@ function lin4test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}()) == 1
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         if config.infeas_certificates
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
             @test MOI.get(model, MOI.ResultCount()) > 0
         else
-            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Infeasible, MOI.InfeasibleOrUnbounded]
+            @test MOI.get(model, MOI.TerminationStatus()) in [MOI.INFEASIBLE, MOI.INFEASIBLE_OR_UNBOUNDED]
         end
         if MOI.get(model, MOI.ResultCount()) > 0
-            @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
-                                                         MOI.InfeasiblePoint)
+            @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NO_SOLUTION,
+                                                         MOI.INFEASIBLE_POINT)
             if config.duals && config.infeas_certificates
-                @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+                @test MOI.get(model, MOI.DualStatus()) == MOI.INFEASIBILITY_CERTIFICATE
             end
         end
         # TODO test dual feasibility and objective sign
@@ -313,7 +313,7 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     x,y,z = MOI.add_variables(model, 3)
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [y,z]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     ceq = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Zeros(1))
     vov = MOI.VectorOfVariables([x,y,z])
@@ -331,15 +331,15 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     @test (vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone) in loc
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol=atol rtol=rtol
@@ -391,7 +391,7 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     x,y,t = MOI.add_variables(model, 3)
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if nonneg
         cnon = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [-1/√2]), MOI.Nonnegatives(1))
@@ -406,15 +406,15 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1/√2 atol=atol rtol=rtol
@@ -473,16 +473,16 @@ function soc3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.SecondOrderCone}()) == 1
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
 
-        @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NoSolution,
-                                                     MOI.InfeasiblePoint)
+        @test MOI.get(model, MOI.PrimalStatus()) in (MOI.NO_SOLUTION,
+                                                     MOI.INFEASIBLE_POINT)
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.get(model, MOI.DualStatus()) == MOI.INFEASIBILITY_CERTIFICATE
         end
 
         # TODO test dual feasibility and objective sign
@@ -523,17 +523,17 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,-2.0,-1.0, 0.0, 0.0], x), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -√5 atol=atol rtol=rtol
@@ -605,17 +605,17 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
     @test MOI.get(model, MOI.NumberOfConstraints{abvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol=atol rtol=rtol
@@ -634,7 +634,7 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
         @test MOI.get(model, MOI.ConstraintPrimal(), rsoc) ≈ [0.5, 1.0, 1/√2, 1/√2] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus(1)) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus(1)) == MOI.FEASIBLE_POINT
 
             if abvars
                 @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ -√2 atol=atol rtol=rtol
@@ -694,16 +694,16 @@ function rotatedsoc2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.RotatedSecondOrderCone}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(c, x), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) in [MOI.Infeasible, MOI.InfeasibleOrUnbounded]
+        @test MOI.get(model, MOI.TerminationStatus()) in [MOI.INFEASIBLE, MOI.INFEASIBLE_OR_UNBOUNDED]
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) in [MOI.InfeasibilityCertificate, MOI.NearlyInfeasibilityCertificate]
+            @test MOI.get(model, MOI.DualStatus()) in [MOI.INFEASIBILITY_CERTIFICATE, MOI.NEARLY_INFEASIBILITY_CERTIFICATE]
 
             y1 = MOI.get(model, MOI.ConstraintDual(), vc1)
             @test y1 < -atol # Should be strictly negative
@@ -772,18 +772,18 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.RotatedSecondOrderCone}()) == 2
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √ub atol=atol rtol=rtol
@@ -868,14 +868,14 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, t)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
@@ -932,18 +932,18 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
     cy = MOI.add_constraint(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[2])], 0.), MOI.EqualTo(2.))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, v), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 + 2exp(1/2) atol=atol rtol=rtol
@@ -998,18 +998,18 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
     c5 = MOI.add_constraint(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[7])], 0.0), MOI.EqualTo(0.0))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[6])], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ exp(-0.3) atol=atol rtol=rtol
@@ -1063,18 +1063,18 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
     ec = MOI.add_constraint(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 3], MOI.ScalarAffineTerm.(1.0, [x, y])), [0.0, 1.0, 0.0]), MOI.ExponentialCone())
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ log(5) atol=atol rtol=rtol
@@ -1143,17 +1143,17 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, [X[1], X[end]]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
@@ -1283,22 +1283,22 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
     objXidx = square ? [1:2; 4:6; 8:9] : [1:3; 5:6]
     objXcoefs = square ? [2., 1., 1., 2., 1., 1., 2.] : 2*ones(5)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([objXcoefs; 1.0], [X[objXidx]; x[1]]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, psdcone}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 2
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables, MOI.SecondOrderCone}()) == 1
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ obj atol=atol rtol=rtol
@@ -1370,17 +1370,17 @@ function psdt2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x[7])], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [2η/3, 0, η/3, 0, 0, 0, η*δ*(1 - 1/√3)/2] atol=atol rtol=rtol
@@ -1479,15 +1479,15 @@ function _det1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool, de
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, t)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         expectedobjval = logdet ? 0. : 1.
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ expectedobjval atol=atol rtol=rtol

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -40,9 +40,9 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,0.0,-1.0,0.0,0.0,0.0], [v; v; v]), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
 
     if config.query
         vrs = MOI.get(model, MOI.ListOfVariableIndices())
@@ -63,13 +63,13 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     end
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
 
@@ -78,7 +78,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
@@ -91,27 +91,27 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,0.0], v), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.query
         @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     end
 
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
 
     if config.solve
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
@@ -161,7 +161,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus(1)) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus(1)) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
@@ -170,7 +170,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -2 atol=atol rtol=rtol
 
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 1 atol=atol rtol=rtol
@@ -193,7 +193,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
@@ -218,7 +218,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
@@ -243,7 +243,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
@@ -257,7 +257,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,2.0,0.0], v), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.query
         @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -270,7 +270,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
@@ -299,7 +299,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
@@ -316,7 +316,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), vc3) ≈ 0 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus(1)) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus(1)) == MOI.FEASIBLE_POINT
 
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1.5 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ 0.5 atol=atol rtol=rtol
@@ -382,18 +382,18 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0,0.0], [x, y]), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
 
@@ -404,7 +404,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
@@ -445,7 +445,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
 
     objf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
         MOI.optimize!(model)
@@ -454,7 +454,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
@@ -480,10 +480,10 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
 
     objf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
@@ -491,7 +491,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
 
@@ -521,18 +521,18 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     #             y <= 0.0   (c2)
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x,y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     c2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.LessThan(0.0))
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
@@ -546,7 +546,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
@@ -560,7 +560,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
@@ -618,16 +618,16 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [x, y]), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 8/3 atol=atol rtol=rtol
 
@@ -659,7 +659,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
@@ -680,7 +680,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
@@ -701,7 +701,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
@@ -731,18 +731,18 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     #             y <= 0.0   (c2)
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x,y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0), MOI.GreaterThan(0.0))
     c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, y)], 0.0), MOI.LessThan(0.0))
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
@@ -756,7 +756,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
@@ -770,7 +770,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
@@ -800,18 +800,18 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     #             y <= 0.0   (c2)
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x,y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     c1 = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [0.0]), MOI.Nonnegatives(1))
     c2 = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [0.0]), MOI.Nonpositives(1))
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
@@ -832,7 +832,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
@@ -853,7 +853,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
@@ -885,20 +885,20 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
     bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible ||
-            MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
         if config.infeas_certificates
             # solver returned an infeasibility ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.get(model, MOI.DualStatus()) == MOI.INFEASIBILITY_CERTIFICATE
             cd = MOI.get(model, MOI.ConstraintDual(), c)
             @test cd < -atol
             # TODO: farkas dual on bounds - see #127
@@ -939,19 +939,19 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
     MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0, -1.0], [x, y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.DualInfeasible ||
-            MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
         if config.infeas_certificates
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.INFEASIBILITY_CERTIFICATE
         else
             # solver returned nothing
             @test MOI.get(model, MOI.ResultCount()) == 0
@@ -983,19 +983,19 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0, -1.0], [x, y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.DualInfeasible ||
-            MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
         if config.infeas_certificates
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.INFEASIBILITY_CERTIFICATE
             ray = MOI.get(model, MOI.VariablePrimal(), [x,y])
             @test ray[1] ≈ ray[2] atol=atol rtol=rtol
         else
@@ -1056,15 +1056,15 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
                       MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1_000.0, 350.0], [x, y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 79e4/11 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 650/11 atol=atol rtol=rtol
@@ -1101,39 +1101,39 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
     c = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x,y]), 0.0), MOI.Interval(5.0, 10.0))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
         end
     end
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 5 atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
         end
     end
@@ -1148,19 +1148,19 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
     end
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 12 atol=atol rtol=rtol
     end
@@ -1190,15 +1190,15 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.GreaterThan(2.0))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
     end
 
@@ -1212,7 +1212,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol=atol rtol=rtol
     end
 end
@@ -1243,19 +1243,19 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
     bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.Infeasible ||
-            MOI.get(model, MOI.TerminationStatus()) == MOI.InfeasibleOrUnbounded
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
         if config.infeas_certificates
             # solver returned an infeasibility ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
-            @test MOI.get(model, MOI.DualStatus()) == MOI.InfeasibilityCertificate
+            @test MOI.get(model, MOI.DualStatus()) == MOI.INFEASIBILITY_CERTIFICATE
             cd1 = MOI.get(model, MOI.ConstraintDual(), c1)
             cd2 = MOI.get(model, MOI.ConstraintDual(), c2)
             bndxd = MOI.get(model, MOI.ConstraintDual(), bndx)
@@ -1291,18 +1291,18 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
     y = MOI.add_variable(model)
     c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0), MOI.GreaterThan(1.0))
     c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,-1.0], [x,y]), 0.0), MOI.EqualTo(0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FeasibilitySense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
         @test MOI.get(model, MOI.ResultCount()) > 0
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         xsol = MOI.get(model, MOI.VariablePrimal(), x)
         ysol = MOI.get(model, MOI.VariablePrimal(), y)
@@ -1317,7 +1317,7 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 0 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ 0 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ 0 atol=atol rtol=rtol
         end
@@ -1351,16 +1351,16 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
     cubz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.LessThan(1.0))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], [x, y, z]), 4.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 8 atol=atol rtol=rtol
 
@@ -1375,7 +1375,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), cubz) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
@@ -1393,7 +1393,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 6 atol=atol rtol=rtol
 
@@ -1403,7 +1403,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), clby) ≈ 1 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
@@ -1442,16 +1442,16 @@ function linear15test(model::MOI.ModelLike, config::TestConfig)
     MOI.set(model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0], x), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
 

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -28,8 +28,8 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
 
     obj = MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm{Float64}[], MOI.ScalarQuadraticTerm.([2.0, 1.0, 2.0, 1.0, 2.0], v[[1,1,2,2,3]], v[[1,2,2,3,3]]), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
 
     if config.query
         @test obj ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
@@ -40,13 +40,13 @@ function qp1test(model::MOI.ModelLike, config::TestConfig)
     end
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 13/7 atol=atol rtol=rtol
 
@@ -84,8 +84,8 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
 
     obj = MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm.(0.0, v), MOI.ScalarQuadraticTerm.([2.0, 0.5, 0.5, 2.0, 1.0, 1.0, 1.0], [v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]]), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
 
     if config.query
         @test obj ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
@@ -96,13 +96,13 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     end
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 13/7 atol=atol rtol=rtol
 
@@ -112,8 +112,8 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
     # change objective to Max -2(x^2 + xy + y^2 + yz + z^2)
     obj2 = MOI.ScalarQuadraticFunction(MOI.ScalarAffineTerm.(0.0, v), MOI.ScalarQuadraticTerm.([-4.0, -1.0, -1.0, -4.0, -2.0, -2.0, -2.0], [v[1], v[1], v[1], v[2], v[2], v[3], v[3]], [v[1], v[2], v[2], v[2], v[3], v[3], v[3]]), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj2)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
 
     if config.query
         @test obj2 ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}())
@@ -124,7 +124,7 @@ function qp2test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -2*13/7 atol=atol rtol=rtol
 
@@ -165,16 +165,16 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
             1.0
           )
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.875 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), [x,y]) ≈ [0.25, 0.75] atol=atol rtol=rtol
@@ -187,14 +187,14 @@ function qp3test(model::MOI.ModelLike, config::TestConfig)
     # (x,y) = (1,0), obj = 3
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,1.0], [x,y]), 1.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), [x,y]) ≈ [1.0, 0.0] atol=atol rtol=rtol
@@ -242,21 +242,21 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [x,y]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
 
     if config.query
         @test c2f ≈ MOI.get(model, MOI.ConstraintFunction(), c2)
     end
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.25 atol=atol rtol=rtol
 
@@ -275,7 +275,7 @@ function qcp1test(model::MOI.ModelLike, config::TestConfig)
     #
     # @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
     #
-    # @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+    # @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
     #
     # @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
 end
@@ -302,24 +302,24 @@ function qcp2test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
 
     if config.query
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
     end
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ sqrt(2) atol=atol rtol=rtol
@@ -354,24 +354,24 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(-1.0, x)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
 
     if config.query
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
     end
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -sqrt(2) atol=atol rtol=rtol
@@ -429,8 +429,8 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable, MOI.GreaterThan{Float64}}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, t)], 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MinSense
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
 
     if config.query
         @test c1f ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
@@ -439,13 +439,13 @@ function socp1test(model::MOI.ModelLike, config::TestConfig)
     end
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ sqrt(1/2) atol=atol rtol=rtol
 

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -22,7 +22,7 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     x,y,z = MOI.add_variables(model, 3)
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-2.0,-1.0], [y,z]), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     ceq = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-1.0]), MOI.Zeros(1))
     csoc = MOI.add_constraint(model, MOI.VectorOfVariables([x,y,z]), MOI.SecondOrderCone(3))
@@ -38,13 +38,13 @@ function intsoc1test(model::MOI.ModelLike, config::TestConfig)
     bin2 = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.ZeroOne())
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -2 atol=atol rtol=rtol
 

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -49,12 +49,12 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
 
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.1, 2.0, 5.0], v), 0.0)
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
@@ -62,7 +62,7 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
+        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 19.4 atol=atol rtol=rtol
 
@@ -121,11 +121,11 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
 
         objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 1.0, 1.0], v), 0.0)
         MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-        MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
-        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
 
         if config.solve
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
             MOI.optimize!(model)
 
@@ -133,7 +133,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
 
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
@@ -150,7 +150,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
 
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5 atol=atol rtol=rtol
 
@@ -209,11 +209,11 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
 
         objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [v[9], v[10]]), 0.0)
         MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-        MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
-        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MaxSense
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+        @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
 
         if config.solve
-            @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
             MOI.optimize!(model)
 
@@ -221,7 +221,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
 
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 15.0 atol=atol rtol=rtol
 
@@ -239,7 +239,7 @@ function int2test(model::MOI.ModelLike, config::TestConfig)
 
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
-            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+            @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 30.0 atol=atol rtol=rtol
 
@@ -282,16 +282,16 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
     c = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(vcat(1.0, fill(-0.5 / 40, 10)), vcat(z, b)), 0.0), MOI.Interval(0.0, 0.999))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(vcat(1.0, fill(-0.5 / 40, 3)), vcat(z, b[1:3])), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
 
@@ -300,7 +300,7 @@ function int3test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
     end
@@ -337,20 +337,20 @@ function knapsacktest(model::MOI.ModelLike, config::TestConfig)
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([5.0, 3.0, 2.0, 7.0, 4.0], v), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
         MOI.set(model, MOI.VariablePrimalStart(), v, [0.0, 0.0, 0.0, 0.0, 0.0])
     end
 
     if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
 
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
 
-        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FeasiblePoint, MOI.NearlyFeasiblePoint ]
+        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 16 atol=atol rtol=rtol
 

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -6,14 +6,14 @@ struct UnknownVectorSet <: MOI.AbstractVectorSet end
 function default_objective_test(model::MOI.ModelLike)
     @testset "Test default objective" begin
         MOI.empty!(model)
-        MOI.get(model, MOI.ObjectiveSense()) == MOI.FeasibilitySense
+        MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE
     end
 end
 
 function default_status_test(model::MOI.ModelLike)
-    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
-    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NoSolution
-    @test MOI.get(model, MOI.DualStatus()) == MOI.NoSolution
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
+    @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
 end
 
 function nametest(model::MOI.ModelLike)
@@ -132,7 +132,7 @@ function emptytest(model::MOI.ModelLike)
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
     c = MOI.add_constraint(model, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1,1,1,2,2], MOI.ScalarAffineTerm.(1.0, [v;v[2];v[3]])), [-3.0,-2.0]), MOI.Zeros(2))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-3.0, -2.0, -4.0], v), 0.0))
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     @test !MOI.is_empty(model)
 
@@ -251,7 +251,7 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
     cva = MOI.add_constraint(src, MOI.VectorAffineFunction(MOI.VectorAffineTerm.([1, 2], MOI.ScalarAffineTerm.(1.0, [v[3], v[2]])), [-3.0,-2.0]), MOI.Zeros(2))
     MOI.set(src, MOI.ConstraintName(), cva, "cva")
     MOI.set(src, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-3.0, -2.0, -4.0], v), 0.0))
-    MOI.set(src, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(src, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     @test MOI.supports(dest, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
     @test MOI.supports_constraint(dest, MOI.SingleVariable, MOI.EqualTo{Float64})
@@ -294,7 +294,7 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
 
     @test MOI.get(dest, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()) ≈ MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-3.0, -2.0, -4.0], [dict[v[1]], dict[v[2]], dict[v[3]]]), 0.0)
     @test MOI.get(dest, MOI.ObjectiveFunctionType()) == MOI.ScalarAffineFunction{Float64}
-    @test MOI.get(dest, MOI.ObjectiveSense()) == MOI.MinSense
+    @test MOI.get(dest, MOI.ObjectiveSense()) == MOI.MIN_SENSE
 end
 
 function supports_constrainttest(model::MOI.ModelLike, ::Type{GoodT}, ::Type{BadT}) where {GoodT, BadT}

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -130,7 +130,7 @@ function hs071test_template(model::MOI.ModelLike, config::TestConfig, evaluator:
     end
 
     MOI.set(model, MOI.NLPBlock(), block_data)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     # TODO: config.query tests
     if config.solve
@@ -140,7 +140,7 @@ function hs071test_template(model::MOI.ModelLike, config::TestConfig, evaluator:
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 17.014017145179164 atol=atol rtol=rtol
 
@@ -155,7 +155,7 @@ end
 hs071_test(model, config) = hs071test_template(model, config, HS071(true))
 hs071_no_hessian_test(model, config) = hs071test_template(model, config, HS071(false))
 
-# Test for FeasibilitySense.
+# Test for FEASIBILITY_SENSE.
 # Find x satisfying x^2 == 1.
 struct FeasibilitySenseEvaluator <: MOI.AbstractNLPEvaluator
     enable_hessian::Bool
@@ -235,7 +235,7 @@ function feasibility_sense_test_template(model::MOI.ModelLike,
     MOI.set(model, MOI.VariablePrimalStart(), x, 1.5)
 
     MOI.set(model, MOI.NLPBlock(), block_data)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.FeasibilitySense)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
 
     # TODO: config.query tests
     if config.solve
@@ -245,7 +245,7 @@ function feasibility_sense_test_template(model::MOI.ModelLike,
 
         @test MOI.get(model, MOI.ResultCount()) >= 1
 
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FeasiblePoint
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
 

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -617,7 +617,7 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
         function $MOI.empty!(model::$esc_modelname{T}) where T
             model.name = ""
             model.senseset = false
-            model.sense = $MOI.FeasibilitySense
+            model.sense = $MOI.FEASIBILITY_SENSE
             model.objectiveset = false
             model.objective = $SAF{T}(MOI.ScalarAffineTerm{T}[], zero(T))
             model.num_variables_created = 0
@@ -681,7 +681,7 @@ macro model(modelname, ss, sst, vs, vst, sf, sft, vf, vft)
 
         $modeldef
         function $esc_modelname{T}() where T
-            $esc_modelname{T}("", false, $MOI.FeasibilitySense, false, $SAF{T}($MOI.ScalarAffineTerm{T}[], zero(T)),
+            $esc_modelname{T}("", false, $MOI.FEASIBILITY_SENSE, false, $SAF{T}($MOI.ScalarAffineTerm{T}[], zero(T)),
                               0, nothing, Dict{$VI, String}(), nothing,
                               0, Dict{$CI, String}(), nothing, Int[],
                               $(_getCV.(funs)...))

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -229,11 +229,11 @@ function loadfromstring!(model, s)
         elseif label == :maxobjective
             f = parsedtoMOI(model, parsefunction(ex))
             MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
-            MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         elseif label == :minobjective
             f = parsedtoMOI(model, parsefunction(ex))
             MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
-            MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
         else
             # constraint
             @assert isexpr(ex, :call)

--- a/src/Utilities/results.jl
+++ b/src/Utilities/results.jl
@@ -187,14 +187,14 @@ function variable_dual(model::MOI.ModelLike,
                        ci::MOI.ConstraintIndex,
                        vi::MOI.VariableIndex)
     status = MOI.get(model, MOI.DualStatus())
-    ray = status == MOI.InfeasibilityCertificate ||
-          status == MOI.NearlyInfeasibilityCertificate
+    ray = status == MOI.INFEASIBILITY_CERTIFICATE ||
+          status == MOI.NEARLY_INFEASIBILITY_CERTIFICATE
     dual = 0.0
     if !ray
         sense = MOI.get(model, MOI.ObjectiveSense())
         # Dual definition for maximization problem corresponds to dual
         # definition for minimization problem with flipped objectived in MOI
-        sign = sense == MOI.MaxSense ? -1.0 : 1.0
+        sign = sense == MOI.MAX_SENSE ? -1.0 : 1.0
         F = MOI.get(model, MOI.ObjectiveFunctionType())
         obj_attr = MOI.ObjectiveFunction{F}()
         if F == MOI.SingleVariable

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -354,12 +354,12 @@ struct Name <: AbstractModelAttribute end
     ObjectiveSense()
 
 A model attribute for the `OptimizationSense` of the objective function, which
-can be `MinSense`, `MaxSense`, or `FeasiblitySense`. The default is
-`FeasibilitySense`.
+can be `MIN_SENSE`, `MAX_SENSE`, or `FeasiblitySense`. The default is
+`FEASIBILITY_SENSE`.
 """
 struct ObjectiveSense <: AbstractModelAttribute end
 
-@enum OptimizationSense MinSense MaxSense FeasibilitySense
+@enum OptimizationSense MIN_SENSE MAX_SENSE FEASIBILITY_SENSE
 
 """
     NumberOfVariables()
@@ -553,13 +553,15 @@ struct VariableBasisStatus <: AbstractVariableAttribute end
 An Enum of possible values for the `VariableBasisStatus` and `ConstraintBasisStatus` attributes.
 This explains the status of a given element with respect to an optimal solution basis.
 Possible values are:
-* `Basic`: element is in the basis
-* `Nonbasic`: element is not in the basis
-* `NonbasicAtLower`: element is not in the basis and is at its lower bound
-* `NonbasicAtUpper`: element is not in the basis and is at its upper bound
-* `SuperBasic`: element is not in the basis but is also not at one of its bounds
+* `BASIC`: element is in the basis
+* `NONBASIC`: element is not in the basis
+* `NONBASIC_AT_LOWER`: element is not in the basis and is at its lower bound
+* `NONBASIC_AT_UPPER`: element is not in the basis and is at its upper bound
+* `SUPER_BASIC`: element is not in the basis but is also not at one of its
+  bounds
 """
-@enum BasisStatusCode Basic Nonbasic NonbasicAtLower NonbasicAtUpper SuperBasic
+@enum(BasisStatusCode, BASIC, NONBASIC, NONBASIC_AT_LOWER, NONBASIC_AT_UPPER,
+      SUPER_BASIC)
 
 ## Constraint attributes
 
@@ -701,13 +703,13 @@ recent call to [`optimize!`](@ref).
 If no call has been made to [`optimize!`](@ref), then the `TerminationStatus`
 is:
 
-* `OptimizeNotCalled`: The algorithm has not started.
+* `OPTIMIZE_NOT_CALLED`: The algorithm has not started.
 
 ## OK
 
 These are generally OK statuses, i.e., the algorithm ran to completion normally.
 
-* `Optimal`: The algorithm found a globally optimal solution.
+* `OPTIMAL`: The algorithm found a globally optimal solution.
 * `Infeasible`: The algorithm concluded that no feasible solution exists.
 * `DualInfeasible`: The algorithm concluded that no dual bound exists for the
   problem. If, additionally, a feasible (primal) solution is known to
@@ -719,19 +721,19 @@ These are generally OK statuses, i.e., the algorithm ran to completion normally.
 * `LocallyInfeasible`: The algorithm converged to an infeasible point or
   otherwise completed its search without finding a feasible solution, without
   guarantees that no feasible solution exists.
-* `InfeasibleOrUnbounded`: The algorithm stopped because it decided that the
+* `INFEASIBLE_OR_UNBOUNDED`: The algorithm stopped because it decided that the
   problem is infeasible or unbounded; this occasionally happens during MIP
   presolve.
 
 ## Solved to relaxed tolerances
 
-* `AlmostOptimal`: The algorithm found a globally optimal solution to relaxed
+* `ALMOST_OPTIMAL`: The algorithm found a globally optimal solution to relaxed
   tolerances.
-* `AlmostInfeasible`: The algorithm concluded that no feasible solution exists
+* `ALMOST_INFEASIBLE`: The algorithm concluded that no feasible solution exists
   within relaxed tolerances.
-* `AlmostDualInfeasible`: The algorithm concluded that no dual bound exists for
+* `ALMOST_DUAL_INFEASIBLE`: The algorithm concluded that no dual bound exists for
   the problem within relaxed tolerances.
-* `AlmostLocallySolved`: The algorithm converged to a stationary point, local
+* `ALMOST_LOCALLY_SOLVED`: The algorithm converged to a stationary point, local
   optimal solution, or could not find directions for improvement within relaxed
   tolerances.
 
@@ -771,12 +773,13 @@ This group of statuses means that something unexpected or problematic happened.
   the statuses defined above.
 """
 @enum(TerminationStatusCode,
-    OptimizeNotCalled,
+    OPTIMIZE_NOT_CALLED,
     # OK
-    Optimal, Infeasible, DualInfeasible, LocallySolved, LocallyInfeasible,
-        InfeasibleOrUnbounded,
+    OPTIMAL, Infeasible, DualInfeasible, LocallySolved, LocallyInfeasible,
+        INFEASIBLE_OR_UNBOUNDED,
     # Solved to relaxed tolerances
-    AlmostOptimal, AlmostInfeasible, AlmostDualInfeasible, AlmostLocallySolved,
+    ALMOST_OPTIMAL, ALMOST_INFEASIBLE, ALMOST_DUAL_INFEASIBLE,
+    ALMOST_LOCALLY_SOLVED,
     # Limits
     IterationLimit, TimeLimit,  NodeLimit, SolutionLimit, MemoryLimit,
         ObjectiveLimit, NormLimit, OtherLimit,
@@ -793,26 +796,27 @@ This group of statuses means that something unexpected or problematic happened.
 An Enum of possible values for the `PrimalStatus` and `DualStatus` attributes.
 The values indicate how to interpret the result vector.
 
-* `NoSolution`: the result vector is empty.
-* `FeasiblePoint`: the result vector is a feasible point.
-* `NearlyFeasiblePoint`: the result vector is feasible if some constraint
+* `NO_SOLUTION`: the result vector is empty.
+* `FEASIBLE_POINT`: the result vector is a feasible point.
+* `NEARLY_FEASIBLE_POINT`: the result vector is feasible if some constraint
   tolerances are relaxed.
-* `InfeasiblePoint`: the result vector is an infeasible point.
-* `InfeasibilityCertificate`: the result vector is an infeasibility certificate.
-  If the `PrimalStatus` is `InfeasibilityCertificate`, then the primal result
+* `INFEASIBLE_POINT`: the result vector is an infeasible point.
+* `INFEASIBILITY_CERTIFICATE`: the result vector is an infeasibility certificate.
+  If the `PrimalStatus` is `INFEASIBILITY_CERTIFICATE`, then the primal result
   vector is a certificate of dual infeasibility. If the `DualStatus` is
-  `InfeasibilityCertificate`, then the dual result vector is a proof of primal
+  `INFEASIBILITY_CERTIFICATE`, then the dual result vector is a proof of primal
   infeasibility.
-* `NearlyInfeasibilityCertificate`: the result satisfies a relaxed criterion for
+* `NEARLY_INFEASIBILITY_CERTIFICATE`: the result satisfies a relaxed criterion for
   a certificate of infeasibility.
-* `UnknownResultStatus`: the result vector contains a solution with an unknown
+* `UNKNOWN_RESULT_STATUS`: the result vector contains a solution with an unknown
   interpretation.
-* `OtherResultStatus`: the result vector contains a solution with an
+* `OTHER_RESULT_STATUS`: the result vector contains a solution with an
   interpretation not covered by one of the statuses defined above.
 """
-@enum(ResultStatusCode, NoSolution, FeasiblePoint, NearlyFeasiblePoint,
-    InfeasiblePoint, InfeasibilityCertificate, NearlyInfeasibilityCertificate,
-    UnknownResultStatus, OtherResultStatus)
+@enum(ResultStatusCode, NO_SOLUTION, FEASIBLE_POINT, NEARLY_FEASIBLE_POINT,
+    INFEASIBLE_POINT, INFEASIBILITY_CERTIFICATE,
+    NEARLY_INFEASIBILITY_CERTIFICATE, UNKNOWN_RESULT_STATUS,
+    OTHER_RESULT_STATUS)
 
 """
     PrimalStatus(N)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -710,15 +710,15 @@ is:
 These are generally OK statuses, i.e., the algorithm ran to completion normally.
 
 * `OPTIMAL`: The algorithm found a globally optimal solution.
-* `Infeasible`: The algorithm concluded that no feasible solution exists.
-* `DualInfeasible`: The algorithm concluded that no dual bound exists for the
+* `INFEASIBLE`: The algorithm concluded that no feasible solution exists.
+* `DUAL_INFEASIBLE`: The algorithm concluded that no dual bound exists for the
   problem. If, additionally, a feasible (primal) solution is known to
   exist, this status typically implies that the problem is unbounded, with some
   technical exceptions.
-* `LocallySolved`: The algorithm converged to a stationary point, local
+* `LOCALLY_SOLVED`: The algorithm converged to a stationary point, local
   optimal solution, could not find directions for improvement, or otherwise
   completed its search without global guarantees.
-* `LocallyInfeasible`: The algorithm converged to an infeasible point or
+* `LOCALLY_INFEASIBLE`: The algorithm converged to an infeasible point or
   otherwise completed its search without finding a feasible solution, without
   guarantees that no feasible solution exists.
 * `INFEASIBLE_OR_UNBOUNDED`: The algorithm stopped because it decided that the
@@ -741,51 +741,51 @@ These are generally OK statuses, i.e., the algorithm ran to completion normally.
 
 The optimizer stopped because of some user-defined limit.
 
-* `IterationLimit`: An iterative algorithm stopped after conducting the maximum
+* `ITERATION_LIMIT`: An iterative algorithm stopped after conducting the maximum
   number of iterations.
-* `TimeLimit`: The algorithm stopped after a user-specified computation time.
-* `NodeLimit`: A branch-and-bound algorithm stopped because it explored a
+* `TIME_LIMIT`: The algorithm stopped after a user-specified computation time.
+* `NODE_LIMIT`: A branch-and-bound algorithm stopped because it explored a
   maximum number of nodes in the branch-and-bound tree.
-* `SolutionLimit`: The algorithm stopped because it found the required number of
+* `SOLUTION_LIMIT`: The algorithm stopped because it found the required number of
   solutions. This is often used in MIPs to get the solver to return the first
   feasible solution it encounters.
-* `MemoryLimit`: The algorithm stopped because it ran out of memory.
-* `ObjectiveLimit`: The algorthm stopped because it found a solution better than
+* `MEMORY_LIMIT`: The algorithm stopped because it ran out of memory.
+* `OBJECTIVE_LIMIT`: The algorthm stopped because it found a solution better than
   a minimum limit set by the user.
-* `NormLimit`: The algorithm stopped because the norm of an iterate became too
+* `NORM_LIMIT`: The algorithm stopped because the norm of an iterate became too
   large.
-* `OtherLimit`: The algorithm stopped due to a limit not covered by one of the
+* `OTHER_LIMIT`: The algorithm stopped due to a limit not covered by one of the
   above.
 
 ## Problematic
 
 This group of statuses means that something unexpected or problematic happened.
 
-* `SlowProgress`: The algorithm stopped because it was unable to continue making
+* `SLOW_PROGRESS`: The algorithm stopped because it was unable to continue making
   progress towards the solution.
-* `NumericalError`: The algorithm stopped because it encountered unrecoverable
+* `NUMERICAL_ERROR`: The algorithm stopped because it encountered unrecoverable
   numerical error.
-* `InvalidModel`: The algorithm stopped because the model is invalid.
-* `InvalidOption`: The algorithm stopped because it was provided an invalid
+* `INVALID_MODEL`: The algorithm stopped because the model is invalid.
+* `INVALID_OPTION`: The algorithm stopped because it was provided an invalid
   option.
-* `Interrupted`: The algorithm stopped because of an interrupt signal.
-* `OtherError`: The algorithm stopped because of an error not covered by one of
+* `INTERRUPTED`: The algorithm stopped because of an interrupt signal.
+* `OTHER_ERROR`: The algorithm stopped because of an error not covered by one of
   the statuses defined above.
 """
 @enum(TerminationStatusCode,
     OPTIMIZE_NOT_CALLED,
     # OK
-    OPTIMAL, Infeasible, DualInfeasible, LocallySolved, LocallyInfeasible,
-        INFEASIBLE_OR_UNBOUNDED,
+    OPTIMAL, INFEASIBLE, DUAL_INFEASIBLE, LOCALLY_SOLVED, LOCALLY_INFEASIBLE,
+    INFEASIBLE_OR_UNBOUNDED,
     # Solved to relaxed tolerances
     ALMOST_OPTIMAL, ALMOST_INFEASIBLE, ALMOST_DUAL_INFEASIBLE,
     ALMOST_LOCALLY_SOLVED,
     # Limits
-    IterationLimit, TimeLimit,  NodeLimit, SolutionLimit, MemoryLimit,
-        ObjectiveLimit, NormLimit, OtherLimit,
+    ITERATION_LIMIT, TIME_LIMIT,  NODE_LIMIT, SOLUTION_LIMIT, MEMORY_LIMIT,
+    OBJECTIVE_LIMIT, NORM_LIMIT, OTHER_LIMIT,
     # Problematic
-    SlowProgress, NumericalError, InvalidModel, InvalidOption, Interrupted,
-        OtherError
+    SLOW_PROGRESS, NUMERICAL_ERROR, INVALID_MODEL, INVALID_OPTION, INTERRUPTED,
+    OTHER_ERROR
 )
 
 ## Result status

--- a/src/error.jl
+++ b/src/error.jl
@@ -48,9 +48,9 @@ function Base.showerror(io::IO, err::NotAllowedError)
     else
         print(io, ": ", m)
     end
-    print(io, " You may want to use a `CachingOptimizer` in `Automatic` mode",
+    print(io, " You may want to use a `CachingOptimizer` in `AUTOMATIC` mode",
           " or you may need to call `resetoptimizer!` before doing this",
-          " operation if the `CachingOptimizer` is in `Manual` mode.")
+          " operation if the `CachingOptimizer` is in `MANUAL` mode.")
 end
 
 """

--- a/test/Test/contconic.jl
+++ b/test/Test/contconic.jl
@@ -18,17 +18,17 @@
                               (MOI.VectorAffineFunction{Float64}, MOI.Nonpositives) => [[0]],
                               (MOI.VectorAffineFunction{Float64}, MOI.Zeros)        => [[7, 2, -4], [7]])
         MOIT.lin2ftest(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE, MOI.INFEASIBLE_POINT, MOI.INFEASIBILITY_CERTIFICATE)
         MOIT.lin3test(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE)
         MOIT.lin3test(mock, MOIT.TestConfig(infeas_certificates=false))
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibleOrUnbounded)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE_OR_UNBOUNDED)
         MOIT.lin3test(mock, MOIT.TestConfig(infeas_certificates=false))
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE, MOI.INFEASIBLE_POINT, MOI.INFEASIBILITY_CERTIFICATE)
         MOIT.lin4test(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE)
         MOIT.lin4test(mock, MOIT.TestConfig(infeas_certificates=false))
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.InfeasibleOrUnbounded)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE_OR_UNBOUNDED)
         MOIT.lin4test(mock, MOIT.TestConfig(infeas_certificates=false))
     end
     @testset "SOC" begin
@@ -49,7 +49,7 @@
                               (MOI.VectorAffineFunction{Float64}, MOI.Zeros)           => [[√2]],
                               (MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)    => [[-1.0]])
         MOIT.soc2ptest(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible, MOI.InfeasiblePoint, MOI.InfeasibilityCertificate)
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE, MOI.INFEASIBLE_POINT, MOI.INFEASIBILITY_CERTIFICATE)
         MOIT.soc3test(mock, config)
         mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 2/√5, 1/√5, 2/√5, 1/√5],
                               (MOI.VectorAffineFunction{Float64}, MOI.Zeros)           => [[-√5, -2.0, -1.0]])
@@ -66,7 +66,7 @@
         mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/√2, 1/√2],
                               (MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone) => [[√2, 1/√2, -1.0, -1.0]])
         MOIT.rotatedsoc1ftest(mock, config)
-        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible, tuple(),
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE, tuple(),
                               (MOI.SingleVariable,                MOI.LessThan{Float64})      => [-1],
                               (MOI.SingleVariable,                MOI.EqualTo{Float64})       => [-1],
                               (MOI.SingleVariable,                MOI.GreaterThan{Float64})   => [1],

--- a/test/Test/contlinear.jl
+++ b/test/Test/contlinear.jl
@@ -63,25 +63,25 @@
     set_mock_optimize_linear7Test!(mock)
     MOIT.linear7test(mock, config_no_lhs_modif)
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible,
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE,
                                                            tuple(),
              (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1]))
     MOIT.linear8atest(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE))
     MOIT.linear8atest(mock, MOIT.TestConfig(infeas_certificates=false))
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DualInfeasible,
-                                                           MOI.InfeasibilityCertificate))
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DUAL_INFEASIBLE,
+                                                           MOI.INFEASIBILITY_CERTIFICATE))
     MOIT.linear8btest(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DualInfeasible))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DUAL_INFEASIBLE))
     MOIT.linear8btest(mock, MOIT.TestConfig(infeas_certificates=false))
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DualInfeasible, (MOI.InfeasibilityCertificate, [1, 1])))
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DUAL_INFEASIBLE, (MOI.INFEASIBILITY_CERTIFICATE, [1, 1])))
     MOIT.linear8ctest(mock, config)
     MOIU.set_mock_optimize!(mock,
-        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DualInfeasible))
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.DUAL_INFEASIBLE))
     MOIT.linear8ctest(mock, MOIT.TestConfig(infeas_certificates=false))
     MOIU.set_mock_optimize!(mock,
          (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [650/11, 400/11]))
@@ -99,12 +99,12 @@
          (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [0.5, 0.5]))
     MOIT.linear11test(mock, config)
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible,
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE,
                                                            tuple(),
               (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})    => [-1, -1]))
     MOIT.linear12test(mock, config)
     MOIU.set_mock_optimize!(mock,
-         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.Infeasible))
+         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, MOI.INFEASIBLE))
     MOIT.linear12test(mock, MOIT.TestConfig(infeas_certificates=false))
     MOIU.set_mock_optimize!(mock,
          (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/5, 1/5],

--- a/test/Test/contquadratic.jl
+++ b/test/Test/contquadratic.jl
@@ -14,13 +14,13 @@
     end
     @testset "QCP" begin
         MOIU.set_mock_optimize!(mock,
-            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 7/4], MOI.FeasiblePoint))
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 7/4], MOI.FEASIBLE_POINT))
         MOIT.qcp1test(mock, config)
         MOIU.set_mock_optimize!(mock,
-            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FeasiblePoint))
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
         MOIT.qcp2test(mock, config)
         MOIU.set_mock_optimize!(mock,
-            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FeasiblePoint))
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
         MOIT.qcp3test(mock, config)
     end
     @testset "SOCP" begin

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -28,18 +28,18 @@ end
     @testset "solve_blank_obj" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1]),
+                MOI.FEASIBLE_POINT
             )
         )
         MOIT.solve_blank_obj(mock, config)
         # The objective is blank so any primal value ≥ 1 is correct
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [2]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [2]),
+                MOI.FEASIBLE_POINT
             )
         )
         MOIT.solve_blank_obj(mock, config)
@@ -47,9 +47,9 @@ end
     @testset "solve_constant_obj" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1]),
+                MOI.FEASIBLE_POINT
             )
         )
         MOIT.solve_constant_obj(mock, config)
@@ -57,9 +57,9 @@ end
     @testset "solve_singlevariable_obj" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1]),
+                MOI.FEASIBLE_POINT
             )
         )
         MOIT.solve_singlevariable_obj(mock, config)
@@ -67,9 +67,9 @@ end
     @testset "solve_with_lowerbound" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1]),
+                MOI.FEASIBLE_POINT,
                     (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [2.0],
                     (MOI.SingleVariable, MOI.LessThan{Float64})    => [0.0]
             )
@@ -82,9 +82,9 @@ end
     @testset "solve_with_upperbound" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1]),
+                MOI.FEASIBLE_POINT,
                     (MOI.SingleVariable, MOI.LessThan{Float64})    => [-2.0],
                     (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [0.0]
             )
@@ -97,9 +97,9 @@ end
     @testset "solve_affine_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [0.5]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [0.5]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-0.5]
             )
         )
@@ -108,9 +108,9 @@ end
     @testset "solve_affine_greaterthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [0.5]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [0.5]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [0.5]
             )
         )
@@ -119,9 +119,9 @@ end
     @testset "solve_affine_equalto" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [0.5]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [0.5]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}) => [0.5]
             )
         )
@@ -130,9 +130,9 @@ end
     @testset "solve_affine_interval" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [2.0]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [2.0]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [-1.5]
             )
         )
@@ -142,12 +142,12 @@ end
     @testset "solve_qcp_edge_cases" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [0.5, 0.5])
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [0.5, 0.5])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [0.5, (√13 - 1)/4])
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [0.5, (√13 - 1)/4])
             )
         )
         MOIT.solve_qcp_edge_cases(mock, config)
@@ -156,20 +156,20 @@ end
     @testset "solve_qp_edge_cases" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1.0, 2.0])
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1.0, 2.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1.0, 2.0])
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1.0, 2.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1.0, 2.0])
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1.0, 2.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1.0, 2.0])
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1.0, 2.0])
             )
         )
         MOIT.solve_qp_edge_cases(mock, config)
@@ -177,9 +177,9 @@ end
     @testset "solve_duplicate_terms_obj" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal,
-                (MOI.FeasiblePoint, [1]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1]),
+                MOI.FEASIBLE_POINT
             )
         )
         MOIT.solve_duplicate_terms_obj(mock, config)
@@ -187,19 +187,19 @@ end
     @testset "solve_affine_deletion_edge_cases" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [0.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [0.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [0.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [0.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [2.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [2.0])
             )
         )
         MOIT.solve_affine_deletion_edge_cases(mock, config)
@@ -207,16 +207,16 @@ end
     @testset "solve_integer_edge_cases" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [2.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [2.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [0.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [0.0])
             )
         )
         MOIT.solve_integer_edge_cases(mock, config)
@@ -225,19 +225,19 @@ end
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> begin
                 MOI.set(mock, MOI.ObjectiveBound(), 3.0)
-                MOIU.mock_optimize!(mock, MOI.Optimal, (MOI.FeasiblePoint, [2.0]))
+                MOIU.mock_optimize!(mock, MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [2.0]))
             end,
             (mock::MOIU.MockOptimizer) -> begin
                 MOI.set(mock, MOI.ObjectiveBound(), 3.0)
-                MOIU.mock_optimize!(mock, MOI.Optimal, (MOI.FeasiblePoint, [1.0]))
+                MOIU.mock_optimize!(mock, MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0]))
             end,
             (mock::MOIU.MockOptimizer) -> begin
                 MOI.set(mock, MOI.ObjectiveBound(), 2.0)
-                MOIU.mock_optimize!(mock, MOI.Optimal, (MOI.FeasiblePoint, [1.5]))
+                MOIU.mock_optimize!(mock, MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.5]))
             end,
             (mock::MOIU.MockOptimizer) -> begin
                 MOI.set(mock, MOI.ObjectiveBound(), 4.0)
-                MOIU.mock_optimize!(mock, MOI.Optimal, (MOI.FeasiblePoint, [1.5]))
+                MOIU.mock_optimize!(mock, MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.5]))
             end
         )
         MOIT.solve_objbound_edge_cases(mock, config)
@@ -251,12 +251,12 @@ end
     @testset "solve_set_singlevariable_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0]),
+                MOI.FEASIBLE_POINT
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [2.0]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [2.0]),
+                MOI.FEASIBLE_POINT
             )
         )
         MOIT.solve_set_singlevariable_lessthan(mock, config)
@@ -264,12 +264,12 @@ end
     @testset "solve_transform_singlevariable_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0]),
+                MOI.FEASIBLE_POINT
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [2.0]),
-                MOI.FeasiblePoint
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [2.0]),
+                MOI.FEASIBLE_POINT
             )
         )
         MOIT.solve_transform_singlevariable_lessthan(mock, config)
@@ -277,13 +277,13 @@ end
     @testset "solve_set_scalaraffine_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0]
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [2.0]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [2.0]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0]
             )
         )
@@ -292,13 +292,13 @@ end
     @testset "solve_coef_scalaraffine_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0]
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [0.5]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [0.5]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-0.5]
             )
         )
@@ -307,13 +307,13 @@ end
     @testset "solve_func_scalaraffine_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0]
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [0.5]),
-                MOI.FeasiblePoint,
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [0.5]),
+                MOI.FEASIBLE_POINT,
                     (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-0.5]
             )
         )
@@ -322,10 +322,10 @@ end
     @testset "solve_const_vectoraffine_nonpos" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [0.0, 0.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [0.0, 0.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0, 0.75])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0, 0.75])
             )
         )
         MOIT.solve_const_vectoraffine_nonpos(mock, config)
@@ -333,10 +333,10 @@ end
     @testset "solve_multirow_vectoraffine_nonpos" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [0.5])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [0.5])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [0.25])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [0.25])
             )
         )
         MOIT.solve_multirow_vectoraffine_nonpos(mock, config)
@@ -344,10 +344,10 @@ end
     @testset "solve_const_scalar_objective" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0])
             )
         )
         MOIT.solve_const_scalar_objective(mock, config)
@@ -355,10 +355,10 @@ end
     @testset "solve_coef_scalar_objective" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0])
             ),
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                MOI.Optimal, (MOI.FeasiblePoint, [1.0])
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0])
             )
         )
         MOIT.solve_coef_scalar_objective(mock, config)

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -1,17 +1,17 @@
 @MOIU.model ModelForCachingOptimizer (MOI.ZeroOne, MOI.Integer) (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval) (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.RotatedSecondOrderCone, MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone, MOI.PositiveSemidefiniteConeTriangle, MOI.RootDetConeTriangle, MOI.LogDetConeTriangle) () (MOI.SingleVariable,) (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction) (MOI.VectorOfVariables,) (MOI.VectorAffineFunction,)
 
 @testset "Test default attributes" begin
-    # Without an optimizer attached (i.e., `MOI.state(model) == NoOptimizer`) we
+    # Without an optimizer attached (i.e., `MOI.state(model) == NO_OPTIMIZER`) we
     # need throw nice errors for attributes that are based on the optimizer. For
     # `AbstractModelAttribute`s that `is_set_by_optimize` returns `true` for, we
     # overload `TerminationStatus`, `PrimalStatus`, or `DualStatus` to return
     # sane default values. Otherwise we throw a nice error.
-    model = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), MOIU.Manual)
-    @test MOIU.state(model) == MOIU.NoOptimizer
+    model = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), MOIU.MANUAL)
+    @test MOIU.state(model) == MOIU.NO_OPTIMIZER
 
-    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OptimizeNotCalled
-    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NoSolution
-    @test MOI.get(model, MOI.DualStatus()) == MOI.NoSolution
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
+    @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
     x = MOI.add_variables(model, 2)
     if VERSION < v"0.7"
         @test_throws Exception MOI.get(model, MOI.VariablePrimal(), x[1])
@@ -40,14 +40,14 @@
     end
 end
 
-@testset "CachingOptimizer Manual mode" begin
-    m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), MOIU.Manual)
-    @test MOIU.state(m) == MOIU.NoOptimizer
+@testset "CachingOptimizer MANUAL mode" begin
+    m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), MOIU.MANUAL)
+    @test MOIU.state(m) == MOIU.NO_OPTIMIZER
 
     s = MOIU.MockOptimizer(ModelForMock{Float64}())
     @test MOI.is_empty(s)
     MOIU.resetoptimizer!(m, s)
-    @test MOIU.state(m) == MOIU.EmptyOptimizer
+    @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
 
     v = MOI.add_variable(m)
     x = MOI.add_variables(m, 2)
@@ -60,14 +60,14 @@ end
     @test_throws AssertionError MOI.optimize!(m)
 
     MOIU.attachoptimizer!(m)
-    @test MOIU.state(m) == MOIU.AttachedOptimizer
+    @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveFunction{typeof(saf)}())) ≈ saf
 
     @test MOI.supports(m, MOI.ObjectiveSense())
-    MOI.set(m, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MaxSense
-    @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense())) == MOI.MaxSense
-    @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense())) == MOI.MaxSense
+    MOI.set(m, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(m, MOI.ObjectiveSense()) == MOI.MAX_SENSE
+    @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense())) == MOI.MAX_SENSE
+    @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense())) == MOI.MAX_SENSE
 
     @test MOI.supports(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()))
     MOI.set(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()), 10)
@@ -96,7 +96,7 @@ end
     @test MOI.get(m, MOI.ConstraintFunction(), lb) == MOI.SingleVariable(v)
 
     MOIU.dropoptimizer!(m)
-    @test MOIU.state(m) == MOIU.NoOptimizer
+    @test MOIU.state(m) == MOIU.NO_OPTIMIZER
 
     MOI.set(m, MOI.ConstraintSet(), lb, MOI.LessThan(12.0))
     @test MOI.get(m, MOI.ConstraintSet(), lb) == MOI.LessThan(12.0)
@@ -110,9 +110,9 @@ end
 
 end
 
-@testset "CachingOptimizer Automatic mode" begin
-    m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), MOIU.Automatic)
-    @test MOIU.state(m) == MOIU.NoOptimizer
+@testset "CachingOptimizer AUTOMATIC mode" begin
+    m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), MOIU.AUTOMATIC)
+    @test MOIU.state(m) == MOIU.NO_OPTIMIZER
 
     v = MOI.add_variable(m)
     @test MOI.supports(m, MOI.VariableName(), typeof(v))
@@ -122,7 +122,7 @@ end
     s = MOIU.MockOptimizer(ModelForMock{Float64}())
     @test MOI.is_empty(s)
     MOIU.resetoptimizer!(m, s)
-    @test MOIU.state(m) == MOIU.EmptyOptimizer
+    @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
 
     saf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v)], 0.0)
     @test MOI.supports(m, MOI.ObjectiveFunction{typeof(saf)}())
@@ -130,7 +130,7 @@ end
     @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveFunction{typeof(saf)}())) ≈ saf
 
     MOI.optimize!(m)
-    @test MOIU.state(m) == MOIU.AttachedOptimizer
+    @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ResultCount())) == 0
 
     @test MOI.get(m, MOI.VariableName(), v) == "v"
@@ -139,9 +139,9 @@ end
     @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.VariableName()), v) == ""
 
     @test MOI.supports(m, MOI.ObjectiveSense())
-    MOI.set(m, MOI.ObjectiveSense(), MOI.MaxSense)
-    @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense())) == MOI.MaxSense
-    @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense())) == MOI.MaxSense
+    MOI.set(m, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(m, MOIU.AttributeFromModelCache(MOI.ObjectiveSense())) == MOI.MAX_SENSE
+    @test MOI.get(m, MOIU.AttributeFromOptimizer(MOI.ObjectiveSense())) == MOI.MAX_SENSE
 
     @test MOI.supports(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()))
     MOI.set(m, MOIU.AttributeFromOptimizer(MOIU.MockModelAttribute()), 10)
@@ -160,16 +160,16 @@ end
         MOI.modify(m, MOI.ObjectiveFunction{typeof(saf)}(),
                     MOI.ScalarConstantChange(1.0))
         s.modify_allowed = true
-        @test MOIU.state(m) == MOIU.EmptyOptimizer
+        @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
         MOIU.attachoptimizer!(m)
-        @test MOIU.state(m) == MOIU.AttachedOptimizer
+        @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
         ci = MOI.add_constraint(m, saf, MOI.EqualTo(0.0))
         s.modify_allowed = false
         MOI.modify(m, ci, MOI.ScalarCoefficientChange(v, 1.0))
         s.modify_allowed = true
-        @test MOIU.state(m) == MOIU.EmptyOptimizer
+        @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
         MOIU.attachoptimizer!(m)
-        @test MOIU.state(m) == MOIU.AttachedOptimizer
+        @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
     end
 
     # Simulate that constraints cannot be added
@@ -177,25 +177,25 @@ end
         s.add_con_allowed = false
         MOI.add_constraint(m, MOI.VectorOfVariables([v]), MOI.SecondOrderCone(1))
         s.add_con_allowed = true
-        @test MOIU.state(m) == MOIU.EmptyOptimizer
+        @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
         MOI.empty!(m)
-        @test MOIU.state(m) == MOIU.AttachedOptimizer
+        @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
     end
 
     @testset "Add variable not allowed" begin
         s.add_var_allowed = false # Simulate optimizer that cannot add variables incrementally
         MOI.add_variable(m)
-        @test MOIU.state(m) == MOIU.EmptyOptimizer
+        @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
         @test_throws MOI.AddVariableNotAllowed MOIU.attachoptimizer!(m)
-        @test MOIU.state(m) == MOIU.EmptyOptimizer
+        @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
 
         s.add_var_allowed = true
         MOIU.attachoptimizer!(m)
-        @test MOIU.state(m) == MOIU.AttachedOptimizer
+        @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
         s.add_var_allowed = false
         MOI.add_variables(m, 2)
         s.add_var_allowed = true
-        @test MOIU.state(m) == MOIU.EmptyOptimizer
+        @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
     end
 
     @testset "Delete not allowed" begin
@@ -203,18 +203,18 @@ end
         s.delete_allowed = false # Simulate optimizer that cannot delete variable
         MOI.delete(m, vi)
         s.delete_allowed = true
-        @test MOIU.state(m) == MOIU.EmptyOptimizer
+        @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
         MOIU.attachoptimizer!(m)
-        @test MOIU.state(m) == MOIU.AttachedOptimizer
+        @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
 
         vi = MOI.add_variable(m)
         ci = MOI.add_constraint(m, MOI.SingleVariable(vi), MOI.EqualTo(0.0))
         s.delete_allowed = false # Simulate optimizer that cannot delete constraint
         MOI.delete(m, ci)
         s.delete_allowed = true
-        @test MOIU.state(m) == MOIU.EmptyOptimizer
+        @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
         MOIU.attachoptimizer!(m)
-        @test MOIU.state(m) == MOIU.AttachedOptimizer
+        @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
     end
 
 end
@@ -226,8 +226,8 @@ end
         m = MOIU.CachingOptimizer(model, s)
         @test m isa MOIU.CachingOptimizer{typeof(s), typeof(model)}
         @test MOI.is_empty(m)
-        @test MOIU.state(m) == MOIU.AttachedOptimizer
-        @test MOIU.mode(m) == MOIU.Automatic
+        @test MOIU.state(m) == MOIU.ATTACHED_OPTIMIZER
+        @test MOIU.mode(m) == MOIU.AUTOMATIC
         @test MOI.get(m, MOI.SolverName()) == "Mock"
     end
     @testset "Non-empty optimizer" begin
@@ -248,13 +248,13 @@ end
     end
 end
 
-for state in (MOIU.NoOptimizer, MOIU.EmptyOptimizer, MOIU.AttachedOptimizer)
-    @testset "Optimization tests in state $state and mode $mode" for mode in (MOIU.Manual, MOIU.Automatic)
+for state in (MOIU.NO_OPTIMIZER, MOIU.EMPTY_OPTIMIZER, MOIU.ATTACHED_OPTIMIZER)
+    @testset "Optimization tests in state $state and mode $mode" for mode in (MOIU.MANUAL, MOIU.AUTOMATIC)
         m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), mode)
-        if state != MOIU.NoOptimizer
+        if state != MOIU.NO_OPTIMIZER
             s = MOIU.MockOptimizer(ModelForMock{Float64}())
             MOIU.resetoptimizer!(m, s)
-            if state == MOIU.AttachedOptimizer
+            if state == MOIU.ATTACHED_OPTIMIZER
                 MOIU.attachoptimizer!(m)
             end
         end

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -1,5 +1,5 @@
 @testset "Copy test" begin
-    @testset "Automatic copy" begin
+    @testset "AUTOMATIC copy" begin
         src = DummyModel()
         dest = DummyModel()
         @test_throws ErrorException MOIU.automatic_copy_to(dest, src)

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -41,10 +41,10 @@ end
     v1 = MOI.add_variable(optimizer)
 
     # Load fake solution
-    MOI.set(optimizer, MOI.TerminationStatus(), MOI.Infeasible)
+    MOI.set(optimizer, MOI.TerminationStatus(), MOI.INFEASIBLE)
 
     MOI.optimize!(optimizer)
-    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Infeasible
+    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.INFEASIBLE
     @test MOI.get(optimizer, MOI.ResultCount()) == 0
 end
 
@@ -60,22 +60,22 @@ end
 
     # Load fake solution
     # TODO: Provide a more compact API for this.
-    MOI.set(optimizer, MOI.TerminationStatus(), MOI.Optimal)
+    MOI.set(optimizer, MOI.TerminationStatus(), MOI.OPTIMAL)
     MOI.set(optimizer, MOI.ObjectiveValue(), 1.0)
     MOI.set(optimizer, MOI.ResultCount(), 1)
-    MOI.set(optimizer, MOI.PrimalStatus(), MOI.FeasiblePoint)
-    MOI.set(optimizer, MOI.DualStatus(), MOI.FeasiblePoint)
+    MOI.set(optimizer, MOI.PrimalStatus(), MOI.FEASIBLE_POINT)
+    MOI.set(optimizer, MOI.DualStatus(), MOI.FEASIBLE_POINT)
     MOI.set(optimizer, MOI.VariablePrimal(), v, [1.0, 2.0])
     MOI.set(optimizer, MOI.VariablePrimal(), v[1], 3.0)
     MOI.set(optimizer, MOI.ConstraintDual(), c1, 5.9)
     MOI.set(optimizer, MOI.ConstraintDual(), soc, [1.0,2.0])
 
     MOI.optimize!(optimizer)
-    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.Optimal
+    @test MOI.get(optimizer, MOI.TerminationStatus()) == MOI.OPTIMAL
     @test MOI.get(optimizer, MOI.ResultCount()) == 1
     @test MOI.get(optimizer, MOI.ObjectiveValue()) == 1.0
-    @test MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FeasiblePoint
-    @test MOI.get(optimizer, MOI.DualStatus()) == MOI.FeasiblePoint
+    @test MOI.get(optimizer, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+    @test MOI.get(optimizer, MOI.DualStatus()) == MOI.FEASIBLE_POINT
     @test MOI.get(optimizer, MOI.VariablePrimal(), v) == [3.0, 2.0]
     @test MOI.get(optimizer, MOI.VariablePrimal(), v[1]) == 3.0
     @test MOI.get(optimizer, MOI.ConstraintDual(), c1) == 5.9

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -85,7 +85,7 @@ end
         MOI.set(model, MOI.VariableName(), x, "x")
         MOI.set(model, MOI.VariableName(), y, "y")
         MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -2.0], [x, y]), 1.0))
-        MOI.set(model, MOI.ObjectiveSense(), MOI.MinSense)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
         model2 = GeneralModel{Float64}()
         MOIU.loadfromstring!(model2, s)
@@ -103,7 +103,7 @@ end
         MOI.set(model, MOI.VariableName(), x, "x")
         MOI.set(model, MOI.VariableName(), y, "y")
         MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -2.0], [x, y]), 1.0))
-        MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
         model2 = GeneralModel{Float64}()
         MOIU.loadfromstring!(model2, s)

--- a/test/bridge.jl
+++ b/test/bridge.jl
@@ -277,12 +277,12 @@ end
         @testset "Quadratic constraints with 2 variables" begin
             MOIU.set_mock_optimize!(mock,
                 (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                    MOI.Optimal,
-                    (MOI.FeasiblePoint, [0.5, 0.5])
+                    MOI.OPTIMAL,
+                    (MOI.FEASIBLE_POINT, [0.5, 0.5])
                 ),
                 (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
-                    MOI.Optimal,
-                    (MOI.FeasiblePoint, [0.5, (√13 - 1)/4])
+                    MOI.OPTIMAL,
+                    (MOI.FEASIBLE_POINT, [0.5, (√13 - 1)/4])
                 )
             )
             MOIT.solve_qcp_edge_cases(bridgedmock, config)
@@ -304,13 +304,13 @@ end
         end
         @testset "QCP tests" begin
             MOIU.set_mock_optimize!(mock,
-                (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 7/4], MOI.FeasiblePoint))
+                (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/2, 7/4], MOI.FEASIBLE_POINT))
             MOIT.qcp1test(bridgedmock, config)
             MOIU.set_mock_optimize!(mock,
-                (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FeasiblePoint))
+                (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
             MOIT.qcp2test(bridgedmock, config)
             MOIU.set_mock_optimize!(mock,
-                (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FeasiblePoint))
+                (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
             MOIT.qcp3test(bridgedmock, config)
             @testset "Bridge deletion" begin
                 ci = first(MOI.get(bridgedmock,

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -8,9 +8,9 @@
         catch err
             @test sprint(showerror, err) == "MathOptInterface.AddVariableNotAllowed:" *
             " Adding variables cannot be performed. You may want to use a" *
-            " `CachingOptimizer` in `Automatic` mode or you may need to call" *
+            " `CachingOptimizer` in `AUTOMATIC` mode or you may need to call" *
             " `resetoptimizer!` before doing this operation if the" *
-            " `CachingOptimizer` is in `Manual` mode."
+            " `CachingOptimizer` is in `MANUAL` mode."
         end
         @test_throws MOI.AddVariableNotAllowed MOI.add_variables(model, 2)
     end
@@ -60,9 +60,9 @@
             @test sprint(showerror, err) == "$MOI.AddConstraintNotAllowed{$MOI.SingleVariable,$MOI.EqualTo{Float64}}:" *
             " Adding `$MOI.SingleVariable`-in-`$MOI.EqualTo{Float64}`" *
             " constraints cannot be performed. You may want to use a" *
-            " `CachingOptimizer` in `Automatic` mode or you may need to call" *
+            " `CachingOptimizer` in `AUTOMATIC` mode or you may need to call" *
             " `resetoptimizer!` before doing this operation if the" *
-            " `CachingOptimizer` is in `Manual` mode."
+            " `CachingOptimizer` is in `MANUAL` mode."
         end
         @test_throws MOI.AddConstraintNotAllowed begin
             MOI.add_constraint(model, vi, MOI.EqualTo(0.0))
@@ -98,9 +98,9 @@
             @test sprint(showerror, err) == "MathOptInterface.DeleteNotAllowed{MathOptInterface.VariableIndex}:" *
             " Deleting the index MathOptInterface.VariableIndex(1) cannot be" *
             " performed. You may want to use a `CachingOptimizer` in" *
-            " `Automatic` mode or you may need to call `resetoptimizer!`" *
+            " `AUTOMATIC` mode or you may need to call `resetoptimizer!`" *
             " before doing this operation if the `CachingOptimizer` is in" *
-            " `Manual` mode."
+            " `MANUAL` mode."
         end
         @test_throws MOI.DeleteNotAllowed{typeof(ci)} MOI.delete(model, ci)
         try
@@ -109,9 +109,9 @@
             @test sprint(showerror, err) == "MathOptInterface.DeleteNotAllowed{MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable,MathOptInterface.EqualTo{Float64}}}:" *
             " Deleting the index MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable,MathOptInterface.EqualTo{Float64}}(1)" *
             " cannot be performed. You may want to use a `CachingOptimizer`" *
-            " in `Automatic` mode or you may need to call `resetoptimizer!`" *
+            " in `AUTOMATIC` mode or you may need to call `resetoptimizer!`" *
             " before doing this operation if the `CachingOptimizer` is in" *
-            " `Manual` mode."
+            " `MANUAL` mode."
         end
     end
 
@@ -128,7 +128,7 @@
 
     @testset "SetAttributeNotAllowed" begin
         @test_throws MOI.SetAttributeNotAllowed begin
-            MOI.set(model, MOI.ObjectiveSense(), MOI.MaxSense)
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         end
         @test_throws MOI.SetAttributeNotAllowed begin
             MOI.set(model, MOI.ConstraintPrimalStart(), ci, 0.0)
@@ -137,10 +137,10 @@
 
     @testset "$f errors" for f in (MOIU.load, MOIU.allocate)
         @test_throws MOI.ErrorException begin
-            f(model, MOI.ObjectiveSense(), MOI.MaxSense)
+            f(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         end
         try
-            f(model, MOI.ObjectiveSense(), MOI.MaxSense)
+            f(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         catch err
             @test err === MOIU.ALLOCATE_LOAD_NOT_IMPLEMENTED
         end
@@ -179,16 +179,16 @@ end
     " Attribute $MOI.Name() is not supported by the the model: Message"
     @test sprint(showerror, MOI.SetAttributeNotAllowed(MOI.Name())) == "$MOI.SetAttributeNotAllowed{$MOI.Name}:" *
     " Setting attribute $MOI.Name() cannot be performed. You may want to use" *
-    " a `CachingOptimizer` in `Automatic` mode or you may need to call" *
+    " a `CachingOptimizer` in `AUTOMATIC` mode or you may need to call" *
     " `resetoptimizer!` before doing this operation if the" *
-    " `CachingOptimizer` is in `Manual` mode."
+    " `CachingOptimizer` is in `MANUAL` mode."
     @test sprint(showerror, MOI.SetAttributeNotAllowed(MOI.Name(), "Message")) == "$MOI.SetAttributeNotAllowed{$MOI.Name}:" *
     " Setting attribute $MOI.Name() cannot be performed: Message You may want" *
-    " to use a `CachingOptimizer` in `Automatic` mode or you may need to call" *
+    " to use a `CachingOptimizer` in `AUTOMATIC` mode or you may need to call" *
     " `resetoptimizer!` before doing this operation if the `CachingOptimizer`" *
-    " is in `Manual` mode." == "$MOI.SetAttributeNotAllowed{$MOI.Name}:" *
+    " is in `MANUAL` mode." == "$MOI.SetAttributeNotAllowed{$MOI.Name}:" *
     " Setting attribute $MOI.Name() cannot be performed: Message You may want" *
-    " to use a `CachingOptimizer` in `Automatic` mode or you may need to call" *
+    " to use a `CachingOptimizer` in `AUTOMATIC` mode or you may need to call" *
     " `resetoptimizer!` before doing this operation if the `CachingOptimizer`" *
-    " is in `Manual` mode."
+    " is in `MANUAL` mode."
 end


### PR DESCRIPTION
https://github.com/JuliaOpt/JuMP.jl/pull/1682

I figure we should bite the bullet and make this change now before 0.19-beta. It unfortunately means another round of package tagging, but it should be a find-replace fix.