### PR TITLE
Only warn if starting values not supported

### DIFF
--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -1472,8 +1472,6 @@ function partial_start_test(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
-    @test MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
-
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
 


### PR DESCRIPTION
I am still unsure whether we should add this in copy or do it by adding a custom `set` methods.
The advantage of doing it in `copy` is that we can easily add a keyword argument to disable the warning (normally all wrappers pass the keyword arguments with `kws...` so it won't imply any change for them).
The disadvantage is that it will not work in JuMP direct mode as it does not use copy. So in direct mode, adding starting values to an optimizer not supporting it gives an error. Maybe we could say in direct mode, the user should explicitly check if it is supported with `supports`.
Note that as starting values are not supported by the `MOIU` `@model` yet (it should IMO), the wrappers should use an `UniversalFallback` in the tests to pass the tests with starting values added in https://github.com/JuliaOpt/MathOptInterface.jl/pull/626.
See e.g.
https://github.com/blegat/SDPA.jl/blob/1d562d175febf90cd661a136bf103f04878620a1/test/MOI_wrapper.jl#L17-L18