### PR TITLE
🐛 Fix CachingOptimizer with setting names

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -403,21 +403,6 @@ function MOI.set(m::CachingOptimizer, attr::Union{MOI.AbstractVariableAttribute,
     MOI.set(m.model_cache, attr, index, value)
 end
 
-# Names are not copied, i.e. we use the option `copy_names=false` in
-# `attachoptimizer`, so the caching optimizer can support names even if the
-# optimizer does not.
-function MOI.supports(m::CachingOptimizer,
-                      attr::Union{MOI.VariableName,
-                                  MOI.ConstraintName},
-                      IndexType::Type{<:MOI.Index})
-    return MOI.supports(m.model_cache, attr, IndexType)
-end
-
-function MOI.supports(m::CachingOptimizer,
-                      attr::MOI.Name)
-    return MOI.supports(m.model_cache, attr)
-end
-
 function MOI.supports(m::CachingOptimizer,
                       attr::Union{MOI.AbstractVariableAttribute,
                                   MOI.AbstractConstraintAttribute},
@@ -485,7 +470,33 @@ function MOI.get(model::CachingOptimizer,
   end
 end
 
-# Name
+#####
+##### Names
+#####
+
+# Names are not copied, i.e. we use the option `copy_names=false` in
+# `attachoptimizer`, so the caching optimizer can support names even if the
+# optimizer does not.
+function MOI.supports(model::CachingOptimizer,
+                      attr::Union{MOI.VariableName,
+                                  MOI.ConstraintName},
+                      IndexType::Type{<:MOI.Index})
+    return MOI.supports(model.model_cache, attr, IndexType)
+end
+function MOI.set(model::CachingOptimizer,
+                 attr::Union{MOI.VariableName, MOI.ConstraintName},
+                 index::MOI.Index, value)
+    MOI.set(model.model_cache, attr, index, value)
+end
+
+function MOI.supports(m::CachingOptimizer,
+                      attr::MOI.Name)
+    return MOI.supports(m.model_cache, attr)
+end
+function MOI.set(model::CachingOptimizer, attr::MOI.Name, value)
+    MOI.set(model.model_cache, attr, value)
+end
+
 function MOI.get(m::CachingOptimizer, IdxT::Type{<:MOI.Index}, name::String)
     return MOI.get(m.model_cache, IdxT, name)
 end

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -185,7 +185,7 @@ function MOI.set(mock::MockOptimizer, attr::MOI.Name, value)
 end
 function MOI.supports(mock::MockOptimizer, attr::MOI.VariableName,
                       IdxT::Type{MOI.VariableIndex})
-    return mock.supports_names && MOI.supports(mock, attr, IdxT)
+    return mock.supports_names && MOI.supports(mock.inner_model, attr, IdxT)
 end
 function MOI.set(mock::MockOptimizer,
                  attr::MOI.VariableName,
@@ -198,7 +198,7 @@ function MOI.set(mock::MockOptimizer,
 end
 function MOI.supports(mock::MockOptimizer, attr::MOI.ConstraintName,
                       IdxT::Type{<:MOI.ConstraintIndex})
-    return mock.supports_names && MOI.supports(mock, attr, IdxT)
+    return mock.supports_names && MOI.supports(mock.inner_model, attr, IdxT)
 end
 function MOI.set(mock::MockOptimizer,
                  attr::MOI.ConstraintName,

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -44,7 +44,7 @@ end
     m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), MOIU.MANUAL)
     @test MOIU.state(m) == MOIU.NO_OPTIMIZER
 
-    s = MOIU.MockOptimizer(ModelForMock{Float64}())
+    s = MOIU.MockOptimizer(ModelForMock{Float64}(), supports_names=false)
     @test MOI.is_empty(s)
     MOIU.reset_optimizer(m, s)
     @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
@@ -119,7 +119,7 @@ end
     MOI.set(m, MOI.VariableName(), v, "v")
     @test MOI.get(m, MOI.VariableName(), v) == "v"
 
-    s = MOIU.MockOptimizer(ModelForMock{Float64}())
+    s = MOIU.MockOptimizer(ModelForMock{Float64}(), supports_names=false)
     @test MOI.is_empty(s)
     MOIU.reset_optimizer(m, s)
     @test MOIU.state(m) == MOIU.EMPTY_OPTIMIZER
@@ -221,7 +221,7 @@ end
 
 @testset "CachingOptimizer constructor with optimizer" begin
     @testset "Empty model and optimizer" begin
-        s = MOIU.MockOptimizer(ModelForMock{Float64}())
+        s = MOIU.MockOptimizer(ModelForMock{Float64}(), supports_names=false)
         model = ModelForCachingOptimizer{Float64}()
         m = MOIU.CachingOptimizer(model, s)
         @test m isa MOIU.CachingOptimizer{typeof(s), typeof(model)}
@@ -231,7 +231,7 @@ end
         @test MOI.get(m, MOI.SolverName()) == "Mock"
     end
     @testset "Non-empty optimizer" begin
-        s = MOIU.MockOptimizer(ModelForMock{Float64}())
+        s = MOIU.MockOptimizer(ModelForMock{Float64}(), supports_names=false)
         MOI.add_variable(s)
         model = ModelForCachingOptimizer{Float64}()
         @test MOI.is_empty(model)
@@ -239,7 +239,7 @@ end
         @test_throws AssertionError MOIU.CachingOptimizer(model, s)
     end
     @testset "Non-empty model" begin
-        s = MOIU.MockOptimizer(ModelForMock{Float64}())
+        s = MOIU.MockOptimizer(ModelForMock{Float64}(), supports_names=false)
         model = ModelForCachingOptimizer{Float64}()
         MOI.add_variable(model)
         @test !MOI.is_empty(model)
@@ -252,7 +252,7 @@ for state in (MOIU.NO_OPTIMIZER, MOIU.EMPTY_OPTIMIZER, MOIU.ATTACHED_OPTIMIZER)
     @testset "Optimization tests in state $state and mode $mode" for mode in (MOIU.MANUAL, MOIU.AUTOMATIC)
         m = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(), mode)
         if state != MOIU.NO_OPTIMIZER
-            s = MOIU.MockOptimizer(ModelForMock{Float64}())
+            s = MOIU.MockOptimizer(ModelForMock{Float64}(), supports_names=false)
             MOIU.reset_optimizer(m, s)
             if state == MOIU.ATTACHED_OPTIMIZER
                 MOIU.attach_optimizer(m)


### PR DESCRIPTION
The CachingOptimizer was setting names to the optimizer while it should only do it in the cache.
We were correctly doing it in `get`, `copy` and `supports` but not in `set`