### PR TITLE
✨ Add iszero

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -363,10 +363,10 @@ returns `false` is encountered (short-circuiting). Similar to `all`.
 function all_coefficients end
 
 function all_coefficients(p::Function, f::MOI.ScalarAffineFunction)
-    p(f.constant) && all(t -> p(MOI.coefficient(t)), f.terms)
+    return p(f.constant) && all(t -> p(MOI.coefficient(t)), f.terms)
 end
 function all_coefficients(p::Function, f::MOI.ScalarQuadraticFunction)
-    p(f.constant) &&
+    return p(f.constant) &&
         all(t -> p(MOI.coefficient(t)), f.affine_terms) &&
         all(t -> p(MOI.coefficient(t)), f.quadratic_terms)
 end

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -157,6 +157,7 @@
         @testset "Affine" begin
             @testset "zero" begin
                 f = @inferred MOIU.zero(MOI.ScalarAffineFunction{Float64})
+                @test iszero(f)
                 @test MOIU.isapprox_zero(f, 1e-16)
             end
             @testset "promote_operation" begin
@@ -169,7 +170,7 @@
                                              MOI.ScalarAffineFunction{Int},
                                              MOI.ScalarAffineFunction{Int}) == MOI.ScalarAffineFunction{Int}
             end
-            @testset "Comparison tolerance" begin
+            @testset "Comparison" begin
                 @test MOIU.operate(+, Float64, MOI.SingleVariable(x),
                                    MOI.SingleVariable(z)) + 1.0 ≈
                       MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1, 1e-7, 1], [x, y, z]), 1.0) atol=1e-6
@@ -177,9 +178,16 @@
                 f2 = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 1.0)
                 @test f1 ≈ f2 atol=1e-6
                 fdiff = f1 - f2
-                MOIU.canonicalize!(fdiff)
-                @test !MOIU.isapprox_zero(fdiff, 1e-8)
-                @test MOIU.isapprox_zero(fdiff, 1e-6)
+                @testset "With iszero" begin
+                    @test !iszero(fdiff)
+                    @test iszero(f1 - f1)
+                    @test iszero(f2 - f2)
+                end
+                @testset "With tolerance" begin
+                    MOIU.canonicalize!(fdiff)
+                    @test !MOIU.isapprox_zero(fdiff, 1e-8)
+                    @test MOIU.isapprox_zero(fdiff, 1e-6)
+                end
             end
             @testset "canonical" begin
                 f = MOIU.canonical(MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2, 1, 3, -2, -3], [y, x, z, x, z]), 5))
@@ -264,14 +272,21 @@
             f = 7 + 3fx + 1fx * fx + 2fy * fy + 3fx * fy
             MOIU.canonicalize!(f)
             @test MOI.output_dimension(f) == 1
-            @testset "isapprox_zero" begin
-                @test !MOIU.isapprox_zero(f, 1e-8)
-                # Test isapprox_zero with zero terms
-                @test MOIU.isapprox_zero(0 * f, 1e-8)
-                g = 1.0fx * fy - (1 + 1e-6) * fy * fx
-                MOIU.canonicalize!(g)
-                @test MOIU.isapprox_zero(g, 1e-5)
-                @test !MOIU.isapprox_zero(g, 1e-7)
+            @testset "Comparison" begin
+                @testset "With iszero" begin
+                    @test !iszero(f)
+                    @test iszero(0 * f)
+                    @test iszero(f - f)
+                end
+                @testset "With tolerance" begin
+                    @test !MOIU.isapprox_zero(f, 1e-8)
+                    # Test isapprox_zero with zero terms
+                    @test MOIU.isapprox_zero(0 * f, 1e-8)
+                    g = 1.0fx * fy - (1 + 1e-6) * fy * fx
+                    MOIU.canonicalize!(g)
+                    @test MOIU.isapprox_zero(g, 1e-5)
+                    @test !MOIU.isapprox_zero(g, 1e-7)
+                end
             end
             @testset "convert" begin
                 @test_throws InexactError convert(MOI.SingleVariable, f)


### PR DESCRIPTION
Fallbacks to `zero(f)` by default which is not implemented (only implemented for its type) and is disputed https://github.com/JuliaOpt/MathOptInterface.jl/issues/636.
Required by https://github.com/JuliaOpt/SumOfSquares.jl/pull/71