### PR TITLE
Add note about VariableIndex in docstring for nlp expressions.

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -202,12 +202,12 @@ object. All sums and products are flattened out as simple `Expr(:+,...)` and
 vector of decision variables. No other undefined symbols are permitted;
 coefficients are embedded as explicit values. For example, the expression
 ``x_1+\\sin(x_2/\\exp(x_3))`` would be represented as the Julia object
-`:(x[1] + sin(x[2]/exp(x[3])))`. See the
-[Julia manual](https://docs.julialang.org/en/release-0.6/manual/metaprogramming/) for more information
-on the structure of `Expr` objects. There are currently no restrictions on
-recognized functions; typically these will be built-in Julia functions like
-`^`, `exp`, `log`, `cos`, `tan`, `sqrt`, etc., but modeling
-interfaces may choose to extend these basic functions.
+`:(x[1] + sin(x[2]/exp(x[3])))`. Each integer index is wrapped in a [`VariableIndex`](@ref).
+See the [Julia manual](https://docs.julialang.org/en/release-0.6/manual/metaprogramming/)
+for more information on the structure of `Expr` objects.
+There are currently no restrictions on recognized functions; typically these
+will be built-in Julia functions like `^`, `exp`, `log`, `cos`, `tan`, `sqrt`,
+etc., but modeling interfaces may choose to extend these basic functions.
 """
 function objective_expr end
 


### PR DESCRIPTION
I was not able to make the docs locally, so I just hope they still build and the cross-ref works.

Details:

```
ERROR: LoadError: `makedocs` encountered errors. Terminating build
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] runner(::Type{Documenter.Builder.RenderDocument}, ::Documenter.Documents.Document) at /home/rs/.julia/packages/Documenter/J3Jag/src/Builder.jl:204
 [3] dispatch(::Type{Documenter.Builder.DocumentPipeline}, ::Documenter.Documents.Document) at /home/rs/.julia/packages/Documenter/J3Jag/src/Utilities/Selectors.jl:167
 [4] (::getfield(Documenter, Symbol("##3#8")))() at /home/rs/.julia/packages/Documenter/J3Jag/src/Documenter.jl:267
 [5] cd(::getfield(Documenter, Symbol("##3#8")), ::String) at ./file.jl:96
 [6] #makedocs#1(::Bool, ::Documenter.Writers.HTMLWriter.HTML, ::Nothing, ::Nothing, ::Nothing, ::Nothing, ::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol,Symbol},NamedTuple{(:sitename, :strict, :pages),Tuple{String,Bool,Array{Pair{String,String},1}}}}, ::Function) at /home/rs/.julia/packages/Documenter/J3Jag/src/Documenter.jl:266
 [7] (::getfield(Documenter, Symbol("#kw##makedocs")))(::NamedTuple{(:sitename, :format, :strict, :pages),Tuple{String,Documenter.Writers.HTMLWriter.HTML,Bool,Array{Pair{String,String},1}}}, ::typeof(makedocs)) at ./none:0
 [8] top-level scope at none:0
 [9] include at ./boot.jl:326 [inlined]
 [10] include_relative(::Module, ::String) at ./loading.jl:1038
 [11] include(::Module, ::String) at ./sysimg.jl:29
 [12] include(::String) at ./client.jl:403
 [13] top-level scope at none:0
in expression starting at /home/rs/.julia/dev/MathOptInterface/docs/make.jl:3
```