### PR TITLE
caching bridge optimizer copy improvement

### DIFF
--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -327,10 +327,7 @@ function MOI.add_constraints(b::AbstractBridgeOptimizer, f::Vector{F},
                              s::Vector{S}) where { F <: MOI.AbstractFunction,
                              S <: MOI.AbstractSet}
     if is_bridged(b, F, S)
-        # We compute `BridgeType` first as `concrete_bridge_type` calls
-        # `bridge_type` which might throw an `UnsupportedConstraint` error in
-        # which case, we do not want any modification to have been done
-        # See add_constraint for why we we call `concrete_bridge_type` separately 
+        # See add_constraint for why we we call `concrete_bridge_type` separately
         # before `add_constraints`
         BridgeType = concrete_bridge_type(b, F, S)
         # `add_constraints` might throw an `UnsupportedConstraint` but no

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -323,6 +323,25 @@ function MOI.add_constraint(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
         return MOI.add_constraint(b.model, f, s)
     end
 end
+function MOI.add_constraints(b::AbstractBridgeOptimizer, f::Vector{F},
+                            s::Vector{S}) where {F <: MOI.AbstractFunction, S <: MOI.AbstractSet}
+    if is_bridged(b, F, S)
+        # We compute `BridgeType` first as `concrete_bridge_type` calls
+        # `bridge_type` which might throw an `UnsupportedConstraint` error in
+        # which case, we do not want any modification to have been done
+        BridgeType = concrete_bridge_type(b, F, S)
+        # `add_constraint` might throw an `UnsupportedConstraint` but no
+        # modification has been done in the previous line
+        cis = MOI.add_constraints(b.bridged, f, s)
+        for (n,ci) in enumerate(cis)
+            @assert !haskey(b.bridges, ci)
+            b.bridges[ci] = BridgeType(b, f[n], s[n])
+        end
+        return cis
+    else
+        return MOI.add_constraints(b.model, f, s)
+    end
+end
 function MOI.modify(b::AbstractBridgeOptimizer, ci::CI,
                      change::MOI.AbstractFunctionModification)
     if is_bridged(b, typeof(ci))

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -324,7 +324,8 @@ function MOI.add_constraint(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
     end
 end
 function MOI.add_constraints(b::AbstractBridgeOptimizer, f::Vector{F},
-                            s::Vector{S}) where {F <: MOI.AbstractFunction, S <: MOI.AbstractSet}
+                             s::Vector{S}) where { F <: MOI.AbstractFunction,
+                             S <: MOI.AbstractSet}
     if is_bridged(b, F, S)
         # We compute `BridgeType` first as `concrete_bridge_type` calls
         # `bridge_type` which might throw an `UnsupportedConstraint` error in

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -330,9 +330,11 @@ function MOI.add_constraints(b::AbstractBridgeOptimizer, f::Vector{F},
         # We compute `BridgeType` first as `concrete_bridge_type` calls
         # `bridge_type` which might throw an `UnsupportedConstraint` error in
         # which case, we do not want any modification to have been done
+        # See add_constraint for why we we call `concrete_bridge_type` separately 
+        # before `add_constraints`
         BridgeType = concrete_bridge_type(b, F, S)
-        # `add_constraint` might throw an `UnsupportedConstraint` but no
-        # modification has been done in the previous line
+        # `add_constraints` might throw an `UnsupportedConstraint` but no
+        #  modification has been done in the previous line
         cis = MOI.add_constraints(b.bridged, f, s)
         for (n,ci) in enumerate(cis)
             @assert !haskey(b.bridges, ci)

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -333,7 +333,7 @@ function MOI.add_constraints(b::AbstractBridgeOptimizer, f::Vector{F},
         # `add_constraints` might throw an `UnsupportedConstraint` but no
         #  modification has been done in the previous line
         cis = MOI.add_constraints(b.bridged, f, s)
-        for (n,ci) in enumerate(cis)
+        for (n, ci) in enumerate(cis)
             @assert !haskey(b.bridges, ci)
             b.bridges[ci] = BridgeType(b, f[n], s[n])
         end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -151,27 +151,14 @@ Copy the constraints of type `F`-in-`S` from the model `src` the model `dest` an
 function copyconstraints!(dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::Bool, idxmap::IndexMap, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
     # Copy constraints
     cis_src = MOI.get(src, MOI.ListOfConstraintIndices{F, S}())
-    # for ci_src in cis_src
-    #     @show ci_src
-    #     f_src = MOI.get(src, MOI.ConstraintFunction(), ci_src)
-    #     f_dest = mapvariables(idxmap, f_src)
-    #     s = MOI.get(src, MOI.ConstraintSet(), ci_src)
-    #     @show ci_dest = MOI.add_constraint(dest, f_dest, s)
-    #     idxmap.conmap[ci_src] = ci_dest
-    # end
-
-
     f_src = MOI.get(src, MOI.ConstraintFunction(), cis_src)
     # idxmap is wraped with [] to signify singlton
     f_dest = mapvariables.([idxmap], f_src)
     s = MOI.get(src, MOI.ConstraintSet(), cis_src)
     cis_dest = MOI.add_constraints(dest, f_dest, s)
-    for (ci_src,ci_dest) in zip(cis_src,cis_dest)
+    for (ci_src,ci_dest) in zip(cis_src, cis_dest)
         idxmap.conmap[ci_src] = ci_dest
     end
-
-
-
     pass_attributes(dest, src, copy_names, idxmap, cis_src)
 end
 

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -184,8 +184,9 @@ function default_copy_to(dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::Bo
 
     # Copy variables
     vis_src = MOI.get(src, MOI.ListOfVariableIndices())
-    for vi in vis_src
-        idxmap.varmap[vi] = MOI.add_variable(dest)
+    vars=MOI.add_variables(dest, length(vis_src))
+    for (vi,var) in zip(vis_src, vars)
+        idxmap.varmap[vi] = var
     end
 
     # Copy variable attributes

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -152,11 +152,10 @@ function copyconstraints!(dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::B
     # Copy constraints
     cis_src = MOI.get(src, MOI.ListOfConstraintIndices{F, S}())
     f_src = MOI.get(src, MOI.ConstraintFunction(), cis_src)
-    # idxmap is wraped with [] to signify singlton
-    f_dest = mapvariables.([idxmap], f_src)
+    f_dest = mapvariables.(Ref(idxmap), f_src)
     s = MOI.get(src, MOI.ConstraintSet(), cis_src)
     cis_dest = MOI.add_constraints(dest, f_dest, s)
-    for (ci_src,ci_dest) in zip(cis_src, cis_dest)
+    for (ci_src, ci_dest) in zip(cis_src, cis_dest)
         idxmap.conmap[ci_src] = ci_dest
     end
     pass_attributes(dest, src, copy_names, idxmap, cis_src)
@@ -184,8 +183,8 @@ function default_copy_to(dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::Bo
 
     # Copy variables
     vis_src = MOI.get(src, MOI.ListOfVariableIndices())
-    vars=MOI.add_variables(dest, length(vis_src))
-    for (vi,var) in zip(vis_src, vars)
+    vars = MOI.add_variables(dest, length(vis_src))
+    for (vi, var) in zip(vis_src, vars)
         idxmap.varmap[vi] = var
     end
 

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -151,13 +151,26 @@ Copy the constraints of type `F`-in-`S` from the model `src` the model `dest` an
 function copyconstraints!(dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::Bool, idxmap::IndexMap, ::Type{F}, ::Type{S}) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
     # Copy constraints
     cis_src = MOI.get(src, MOI.ListOfConstraintIndices{F, S}())
-    for ci_src in cis_src
-        f_src = MOI.get(src, MOI.ConstraintFunction(), ci_src)
-        f_dest = mapvariables(idxmap, f_src)
-        s = MOI.get(src, MOI.ConstraintSet(), ci_src)
-        ci_dest = MOI.add_constraint(dest, f_dest, s)
+    # for ci_src in cis_src
+    #     @show ci_src
+    #     f_src = MOI.get(src, MOI.ConstraintFunction(), ci_src)
+    #     f_dest = mapvariables(idxmap, f_src)
+    #     s = MOI.get(src, MOI.ConstraintSet(), ci_src)
+    #     @show ci_dest = MOI.add_constraint(dest, f_dest, s)
+    #     idxmap.conmap[ci_src] = ci_dest
+    # end
+
+
+    f_src = MOI.get(src, MOI.ConstraintFunction(), cis_src)
+    # idxmap is wraped with [] to signify singlton
+    f_dest = mapvariables.([idxmap], f_src)
+    s = MOI.get(src, MOI.ConstraintSet(), cis_src)
+    cis_dest = MOI.add_constraints(dest, f_dest, s)
+    for (ci_src,ci_dest) in zip(cis_src,cis_dest)
         idxmap.conmap[ci_src] = ci_dest
     end
+
+
 
     pass_attributes(dest, src, copy_names, idxmap, cis_src)
 end


### PR DESCRIPTION
This pull creates a new `add_constraints` method for bridge optimizers than uses it `copyconstraints!`.  The end result is a significant model creation improvement for Clp.  Benchmarks to follow.   

The associated PRs are:
https://github.com/JuliaOpt/Clp.jl/pull/57
https://github.com/JuliaOpt/LinQuadOptInterface.jl/pull/96

The benchmarking results for Clp show a 40x improvement in the time it takes to copy large models from the cache to the solver:
https://github.com/JuliaOpt/Clp.jl/pull/57#issuecomment-471838224