### PR TITLE
Add tests, extend docstring for ScalarQuadraticFunction.

### DIFF
--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -385,9 +385,61 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
+function qcp4test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # Max 2x + y
+    # s.t. x*y <= 4 (c)
+    #      x, y >= 1
+
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})
+
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
+    MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(1.0))
+
+    cf = MOI.ScalarQuadraticFunction([MOI.ScalarAffineTerm(0.0, x)], [MOI.ScalarQuadraticTerm(1.0, x, y)], 0.0)
+    c = MOI.add_constraint(model, cf, MOI.LessThan(4.0))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64}}()) == 1
+
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 1.0], [x, y]), 0.0))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
+
+    if config.query
+        @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
+    end
+
+    if config.solve
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 9.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 4.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 4.0 atol=atol rtol=rtol
+    end
+end
+
 const qcptests = Dict("qcp1" => qcp1test,
                       "qcp2" => qcp2test,
-                      "qcp3" => qcp3test)
+                      "qcp3" => qcp3test,
+                      "qcp4" => qcp4test)
 
 @moitestset qcp
 

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -394,7 +394,7 @@ function qcp4test(model::MOI.ModelLike, config::TestConfig)
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
-    @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64},MOI.LessThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, MOI.LessThan{Float64})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -445,7 +445,7 @@ function qcp5test(model::MOI.ModelLike, config::TestConfig)
     #      x, y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64},MOI.EqualTo{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarQuadraticFunction{Float64}, MOI.EqualTo{Float64})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -389,7 +389,7 @@ function qcp4test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # Max 2x + y
-    # s.t. x*y <= 4 (c)
+    # s.t. x * y <= 4 (c)
     #      x, y >= 1
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
@@ -439,9 +439,9 @@ end
 function qcp5test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
-    # Find x,y
-    # s.t. x*y == 4 (c)
-    #      x*x == 4 (c2)
+    # Find x, y
+    # s.t. x * y == 4 (c)
+    #      x * x == 4 (c2)
     #      x, y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -208,7 +208,7 @@ const qptests = Dict("qp1" => qp1test,
 @moitestset qp
 
 #=
-    Quadratically constrained programs
+    Quadratically constrained (convex) programs
 =#
 
 function qcp1test(model::MOI.ModelLike, config::TestConfig)
@@ -385,7 +385,17 @@ function qcp3test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
-function qcp4test(model::MOI.ModelLike, config::TestConfig)
+const qcptests = Dict("qcp1" => qcp1test,
+                      "qcp2" => qcp2test,
+                      "qcp3" => qcp3test)
+
+@moitestset qcp
+
+#=
+    Quadratically constrained (non-convex) programs
+=#
+
+function ncqcp1test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # Max 2x + y
@@ -436,7 +446,7 @@ function qcp4test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
-function qcp5test(model::MOI.ModelLike, config::TestConfig)
+function ncqcp2test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
     # Find x, y
@@ -487,13 +497,10 @@ function qcp5test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
-const qcptests = Dict("qcp1" => qcp1test,
-                      "qcp2" => qcp2test,
-                      "qcp3" => qcp3test,
-                      "qcp4" => qcp4test,
-                      "qcp5" => qcp5test)
+const ncqcptests = Dict("ncqcp1" => ncqcp1test,
+                        "ncqcp2" => ncqcp2test)
 
-@moitestset qcp
+@moitestset ncqcp
 
 #=
     SOCP
@@ -565,6 +572,7 @@ const socptests = Dict("socp1" => socp1test)
 
 const contquadratictests = Dict("qp" => qptest,
                                 "qcp" => qcptest,
+                                "ncqcp" => ncqcptest,
                                 "socp" => socptest)
 
 @moitestset contquadratic true

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -162,6 +162,10 @@ Duplicate indices in ``a`` or ``Q`` are accepted, and the corresponding
 coefficients are summed together. "Mirrored" indices `(q,r)` and `(r,q)` (where
 `r` and `q` are `VariableIndex`es) are considered duplicates; only one need be
 specified.
+
+For example, for two scalar variables ``y, z``, the quadratic expression
+``yz + y^2`` is represented by the terms
+`ScalarQuadraticTerm.([1.0, 2.0], [y, y], [z, y])`.
 """
 mutable struct ScalarQuadraticFunction{T} <: AbstractScalarFunction
     affine_terms::Vector{ScalarAffineTerm{T}}

--- a/test/Test/contquadratic.jl
+++ b/test/Test/contquadratic.jl
@@ -22,12 +22,14 @@
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
         MOIT.qcp3test(mock, config)
+    end
+    @testset "Non-convex QCP" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [4.0, 1.0], MOI.FEASIBLE_POINT))
-        MOIT.qcp4test(mock, config)
+        MOIT.ncqcp1test(mock, config)
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [2.0, 2.0], MOI.FEASIBLE_POINT))
-        MOIT.qcp5test(mock, config)
+        MOIT.ncqcp2test(mock, config)
     end
     @testset "SOCP" begin
         MOIU.set_mock_optimize!(mock,

--- a/test/Test/contquadratic.jl
+++ b/test/Test/contquadratic.jl
@@ -22,6 +22,12 @@
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
         MOIT.qcp3test(mock, config)
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [4.0, 1.0], MOI.FEASIBLE_POINT))
+        MOIT.qcp4test(mock, config)
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [2.0, 2.0], MOI.FEASIBLE_POINT))
+        MOIT.qcp5test(mock, config)
     end
     @testset "SOCP" begin
         MOIU.set_mock_optimize!(mock,

--- a/test/Test/contquadratic.jl
+++ b/test/Test/contquadratic.jl
@@ -22,6 +22,9 @@
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [√2], MOI.FEASIBLE_POINT))
         MOIT.qcp3test(mock, config)
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 1.0], MOI.FEASIBLE_POINT))
+        MOIT.qcp4test(mock, config)
     end
     @testset "Non-convex QCP" begin
         MOIU.set_mock_optimize!(mock,


### PR DESCRIPTION
We just discovered a bug in SCIP.jl ([#106](https://github.com/SCIP-Interfaces/SCIP.jl/issues/106)) in the handling of quadratic coefficients off the diagonal, based on my misunderstanding of the MOI docs.

To add prevent this kind of problem, I've added a small example to the docstring and two QCP tests.