### PR TITLE
overload MOI.set & supports for ConstraintAttribute in bridgeoptimizer

### DIFF
--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -262,7 +262,7 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
 end
 
 function MOI.supports(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
-                      Index::Type{<:CI})
+                      Index::Type{CI{F,S}}) where {F,S}
     if is_bridged(b, Index)
         return MOI.supports(b.bridged, attr, Index)
     else

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -227,25 +227,16 @@ function MOI.get(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractConstraintAttribute,
                  ci::CI)
     if is_bridged(b, typeof(ci))
-        if attr isa MOI.ConstraintName || attr isa MOI.ConstraintFunction ||
-                attr isa MOI.ConstraintSet
-            MOI.get(b.bridged, attr, ci)
-        else
-            MOI.get(b, attr, bridge(b, ci))
-        end
+        return MOI.get(b, attr, bridge(b, ci))
     else
-        MOI.get(b.model, attr, ci)
+        return MOI.get(b.model, attr, ci)
     end
 end
 function MOI.supports(b::AbstractBridgeOptimizer,
                       attr::MOI.AbstractConstraintAttribute,
                       IndexType::Type{CI{F, S}}) where {F,S}
     if is_bridged(b, IndexType)
-        if attr isa MOI.ConstraintName
-            return MOI.supports(b.bridged, attr, IndexType)
-        else
-            return MOI.supports(b, attr, concrete_bridge_type(b, F, S))
-        end
+        return MOI.supports(b, attr, concrete_bridge_type(b, F, S))
     else
         return MOI.supports(b.model, attr, IndexType)
     end
@@ -255,32 +246,53 @@ function MOI.set(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractConstraintAttribute,
                  index::CI, value)
     if is_bridged(b, typeof(index))
-        if attr isa MOI.ConstraintName
-            return MOI.set(b.bridged, attr, index, value)
-        else
-            return MOI.set(b, attr, bridge(b, index), value)
-        end
+        return MOI.set(b, attr, bridge(b, index), value)
     else
         return MOI.set(b.model, attr, index, value)
     end
 end
-## Setting names
-# function MOI.supports(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
-#                       Index::Type{<:CI})
-#     if is_bridged(b, Index)
-#         return MOI.supports(b.bridged, attr, Index)
-#     else
-#         return MOI.supports(b.model, attr, Index)
-#     end
-# end
-# function MOI.set(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
-#                   constraint_index::CI, name::String)
-#     if is_bridged(b, typeof(constraint_index))
-#         MOI.set(b.bridged, attr, constraint_index, name)
-#     else
-#         MOI.set(b.model, attr, constraint_index, name)
-#     end
-# end
+## Getting and Setting names
+function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
+                 constraint_index::CI)
+    if is_bridged(b, typeof(constraint_index))
+        return MOI.get(b.bridged, attr, constraint_index)
+    else
+        return MOI.get(b.model, attr, constraint_index)
+    end
+end
+
+function MOI.supports(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
+                      Index::Type{CI{F, S}}) where {F,S}
+    if is_bridged(b, Index)
+        return MOI.supports(b.bridged, attr, Index)
+    else
+        return MOI.supports(b.model, attr, Index)
+    end
+end
+function MOI.set(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
+                  constraint_index::CI, name::String)
+    if is_bridged(b, typeof(constraint_index))
+        MOI.set(b.bridged, attr, constraint_index, name)
+    else
+        MOI.set(b.model, attr, constraint_index, name)
+    end
+end
+## Getting functions and sets
+function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintSet, ci::CI)
+    if is_bridged(b, typeof(ci))
+        return MOI.get(b.bridged, attr, ci)
+    else
+        return MOI.get(b.model, attr, ci)
+    end
+end
+function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintFunction, 
+        ci::CI)
+    if is_bridged(b, typeof(ci))
+        return MOI.get(b.bridged, attr, ci)
+    else
+        return MOI.get(b.model, attr, ci)
+    end
+end    
 ## Setting functions and sets
 function MOI.set(b::AbstractBridgeOptimizer, ::MOI.ConstraintSet,
                   constraint_index::CI{F, S}, set::S) where {F, S}

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -262,7 +262,7 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
 end
 
 function MOI.supports(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
-                      Index::Type{CI{F, S}}) where {F,S}
+                      Index::Type{<:CI})
     if is_bridged(b, Index)
         return MOI.supports(b.bridged, attr, Index)
     else
@@ -286,7 +286,7 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintSet, ci::CI)
     end
 end
 function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintFunction, 
-        ci::CI)
+                 ci::CI)
     if is_bridged(b, typeof(ci))
         return MOI.get(b.bridged, attr, ci)
     else

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -222,11 +222,6 @@ function MOI.set(b::AbstractBridgeOptimizer,
     return MOI.set(b.model, attr, indices, values)
 end
 
-# function MOI.get(::MOI.ModelLike, attr::MOI.AbstractConstraintAttribute,
-#     bridge::AbstractBridge)
-# throw(ArgumentError("Constraint bridge of type `$(typeof(bridge))` does not support accessing the attribute `$attr`."))
-# end
-
 # Constraint attributes
 function MOI.get(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractConstraintAttribute,
@@ -246,8 +241,7 @@ function MOI.supports(b::AbstractBridgeOptimizer,
                       attr::MOI.AbstractConstraintAttribute,
                       IndexType::Type{CI{F, S}}) where {F,S}
     if is_bridged(b, IndexType)
-        if attr isa MOI.ConstraintName || attr isa MOI.ConstraintFunction ||
-                attr isa MOI.ConstraintSet
+        if attr isa MOI.ConstraintName
             return MOI.supports(b.bridged, attr, IndexType)
         else
             return MOI.supports(b, attr, concrete_bridge_type(b, F, S))
@@ -261,8 +255,7 @@ function MOI.set(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractConstraintAttribute,
                  index::CI, value)
     if is_bridged(b, typeof(index))
-        if attr isa MOI.ConstraintName || attr isa MOI.ConstraintFunction ||
-                attr isa MOI.ConstraintName
+        if attr isa MOI.ConstraintName
             return MOI.set(b.bridged, attr, index, value)
         else
             return MOI.set(b, attr, bridge(b, index), value)

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -239,12 +239,25 @@ end
 function MOI.supports(b::AbstractBridgeOptimizer,
                       attr::MOI.AbstractConstraintAttribute,
                       IndexType::Type{<:MOI.Index})
-    return MOI.supports(b.model, attr, IndexType)
+    if is_bridged(b, IndexType)
+        return MOI.supports(b.bridged, attr, IndexType)
+    else
+        return MOI.supports(b.model, attr, IndexType)
+    end
 end
+
 function MOI.set(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractConstraintAttribute,
                  index::MOI.Index, value)
-    return MOI.set(b.model, attr, index, value)
+    if is_bridged(b, typeof(index))
+        if MOI.is_set_by_optimize(attr)
+            return MOI.set(b, attr, bridge(b, index), value)
+        else
+            return MOI.set(b.bridged, attr, index, value)
+        end
+    else
+        return MOI.set(b.model, attr, index, value)
+    end
 end
 ## Setting names
 function MOI.supports(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -236,6 +236,16 @@ function MOI.get(b::AbstractBridgeOptimizer,
         MOI.get(b.model, attr, ci)
     end
 end
+function MOI.supports(b::AbstractBridgeOptimizer,
+                      attr::MOI.AbstractConstraintAttribute,
+                      IndexType::Type{<:MOI.Index})
+    return MOI.supports(b.model, attr, IndexType)
+end
+function MOI.set(b::AbstractBridgeOptimizer,
+                 attr::MOI.AbstractConstraintAttribute,
+                 index::MOI.Index, value)
+    return MOI.set(b.model, attr, index, value)
+end
 ## Setting names
 function MOI.supports(b::AbstractBridgeOptimizer, attr::MOI.ConstraintName,
                       Index::Type{<:CI})


### PR DESCRIPTION
Hi, this PR follows my message in gitter. 

I'm working on a package that creates variable/constraint attributes in the JuMP model. Then, another package retrieves these attributes through the MOI interface. In the second package, I overloaded `MOI.set` and `MOI.get` to copy/get variable & constraint attributes. 

These are the definitions of MOI.set & MOI.get in my packages :
```julia
MOI.get(dest::MOIU.UniversalFallback, attr::BD.ConstraintDecomposition, ci::MOI.ConstraintIndex)
MOI.set(dest::MOIU.UniversalFallback, attr::BD.ConstraintDecomposition, ci::MOI.ConstraintIndex, annotation)
```

During the copy process, `MOI.set` of `VariableAttribute` receives a `MOIU.CachingOptimizer`as first argument whereas `MOI.set` of `ConstraintAttribute` receives a `MOIU.Bridges.LazyBridgeOptimizer`. Since LazyBridge is not a subtype of UniversalFallback, MOI throws an error. Looking in file bridgeoptimizer.jl, the following functions are defined for `VariableAttribute` but not for `ConstraintAttribute`.

```julia
function MOI.set(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractVariableAttribute,
                  index::MOI.Index, value)
    return MOI.set(b.model, attr, index, value)
end
function MOI.set(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractVariableAttribute,
                  indices::Vector{<:MOI.Index}, values::Vector)
    return MOI.set(b.model, attr, indices, values)
end
```

I overloaded `MOI.set` for `ConstraintAttributes`in bridge optimizer to pass the `MOIU.CachingOptimizer` as first argument.

I also overloaded `MOI.support` because there is no definition of it for `ConstraintAttribute`. However, I'm not sure of it is needed and I don't know how to test it. (I can get the attributes without overloading supports in my packages).

I can retrieve constraints attributes with these changes but is this the reason of my bug?