### PR TITLE
typos in PSD square testset definition

### DIFF
--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1406,11 +1406,11 @@ const psdttests = Dict("psdt0v" => psdt0vtest,
                        "psdt1f" => psdt1ftest,
                        "psdt2"  => psdt2test)
 
-# PSDConeSquare
 @moitestset psdt
 
-const psdstests = Dict("psds0v" => psdt0vtest,
-                       "psds0v" => psdt0vtest,
+# PSDConeSquare
+const psdstests = Dict("psds0v" => psds0vtest,
+                       "psds0v" => psds0vtest,
                        "psds1v" => psds1vtest,
                        "psds1f" => psds1ftest)
 

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1410,7 +1410,7 @@ const psdttests = Dict("psdt0v" => psdt0vtest,
 
 # PSDConeSquare
 const psdstests = Dict("psds0v" => psds0vtest,
-                       "psds0v" => psds0vtest,
+                       "psds0f" => psds0ftest,
                        "psds1v" => psds1vtest,
                        "psds1f" => psds1ftest)
 


### PR DESCRIPTION
it was calling PSD triangle tests for PSD square tests