### PR TITLE
Only ask for dual infeasibility certificate if duals is true

### DIFF
--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -5,7 +5,7 @@ struct TestConfig
     query::Bool # can get objective function, and constraint functions, and constraint sets
     modify_lhs::Bool # can modify function of a constraint
     duals::Bool # test dual solutions
-    infeas_certificates::Bool # check for infeasibility certificates when appropriate
+    infeas_certificates::Bool # check for primal or dual infeasibility certificates when appropriate
     # The expected "optimal" status returned by the solver. Either
     # MOI.OPTIMAL or MOI.LOCALLY_SOLVED.
     optimal_status::MOI.TerminationStatusCode

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -927,7 +927,7 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
             MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
-        if config.infeas_certificates
+        if config.duals && config.infeas_certificates
             # solver returned an infeasibility ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
 
@@ -1405,7 +1405,7 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
             MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
-        if config.infeas_certificates
+        if config.duals && config.infeas_certificates
             # solver returned an infeasibility ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.INFEASIBILITY_CERTIFICATE


### PR DESCRIPTION
I was under the impression that `config.infeas_certificates` means that we can expect `INFEASIBILITY_CERTIFICATE` both for `DUAL_INFEASIBLE` and `INFEASIBLE`.
So for a solver that support infeasibility certificates for `DUAL_INFEASIBLE` but not for `INFEASIBLE`, it should just set `duals` to `false` and the tests shouldn't expect infeasibility certificates for `INFEASIBLE`.
What do you think ?