### PR TITLE
Disable add_constraints tests for VectorOfVariables

### DIFF
--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -197,8 +197,8 @@ function basic_constraint_test_helper(model::MOI.ModelLike, config::TestConfig, 
         @test length(c_indices) == MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
     end
 
-    if F != MOI.SingleVariable
-        # We can't add multiple single variable constraints as these are
+    if F != MOI.SingleVariable && F != MOI.VectorOfVariables
+        # We can't add multiple variable constraints as these are
         # interpreted as bounds etc.
         @testset "add_constraints" begin
             n = MOI.get(model, MOI.NumberOfConstraints{F,S}())


### PR DESCRIPTION
In Mosek, a variable cannot be part of two different cones.
Another approach would be to create more variables and use different ones in each constraints.