### PR TITLE
Doubled methods removed

### DIFF
--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -82,8 +82,6 @@ function int1test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
-Base.isapprox(a::T, b::T; kwargs...) where T <: Union{MOI.SOS1, MOI.SOS2} = isapprox(a.weights, b.weights; kwargs...)
-
 # sos from CPLEX.jl" begin
 function int2test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -417,8 +417,6 @@ struct SOS1{T <: Real} <: AbstractVectorSet
     weights::Vector{T}
 end
 
-Base.:(==)(a::SOS1{T}, b::SOS1{T}) where T = a.weights == b.weights
-
 """
     SOS2{T <: Real}(weights::Vector{T})
 
@@ -432,10 +430,10 @@ struct SOS2{T <: Real} <: AbstractVectorSet
     weights::Vector{T}
 end
 
-Base.:(==)(a::SOS2{T}, b::SOS2{T}) where T = a.weights == b.weights
+Base.:(==)(a::T, b::T) where {T <: Union{SOS1, SOS2}} = a.weights == b.weights
+Base.isapprox(a::T, b::T; kwargs...) where {T <: Union{SOS1, SOS2}} = isapprox(a.weights, b.weights; kwargs...)
 
 dimension(s::Union{SOS1, SOS2}) = length(s.weights)
-Base.isapprox(a::T, b::T; kwargs...) where T <: Union{MOI.SOS1, MOI.SOS2} = isapprox(a.weights, b.weights; kwargs...)
 
 # isbits types, nothing to copy
 function Base.copy(set::Union{Reals, Zeros, Nonnegatives, Nonpositives,

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -418,7 +418,6 @@ struct SOS1{T <: Real} <: AbstractVectorSet
 end
 
 Base.:(==)(a::SOS1{T}, b::SOS1{T}) where T = a.weights == b.weights
-Base.isapprox(a::SOS1{T}, b::SOS1{T}; kwargs...) where T = isapprox(a.weights, b.weights; kwargs...)
 
 """
     SOS2{T <: Real}(weights::Vector{T})
@@ -434,10 +433,9 @@ struct SOS2{T <: Real} <: AbstractVectorSet
 end
 
 Base.:(==)(a::SOS2{T}, b::SOS2{T}) where T = a.weights == b.weights
-Base.isapprox(a::SOS2{T}, b::SOS2{T}; kwargs...) where T = isapprox(a.weights, b.weights; kwargs...)
 
 dimension(s::Union{SOS1, SOS2}) = length(s.weights)
-
+Base.isapprox(a::T, b::T; kwargs...) where T <: Union{MOI.SOS1, MOI.SOS2} = isapprox(a.weights, b.weights; kwargs...)
 
 # isbits types, nothing to copy
 function Base.copy(set::Union{Reals, Zeros, Nonnegatives, Nonpositives,


### PR DESCRIPTION
Some `SOS{1/2}` methods could be merged.
Also, one was defined in Test for no apparent reason