### PR TITLE
Add test for MOI.Silent

### DIFF
--- a/src/Test/UnitTests/attributes.jl
+++ b/src/Test/UnitTests/attributes.jl
@@ -11,6 +11,27 @@ end
 unittests["solver_name"] = solver_name
 
 """
+    silent(model::MOI.ModelLike, config::TestConfig)
+
+Test that the [`MOI.Silent`](@ref) attribute is implemented for `model`.
+"""
+function silent(model::MOI.ModelLike, config::TestConfig)
+    if config.solve
+        @test MOI.supports(model, MOI.Silent())
+        # Get the current value to restore it at the end of the test
+        value = MOI.get(model, MOI.Silent())
+        MOI.set(model, MOI.Silent(), !value)
+        @test !value == MOI.get(model, MOI.Silent())
+        # Check that `set` does not just take `!` of the current value
+        MOI.set(model, MOI.Silent(), !value)
+        @test !value == MOI.get(model, MOI.Silent())
+        MOI.set(model, MOI.Silent(), value)
+        @test value == MOI.get(model, MOI.Silent())
+    end
+end
+unittests["silent"] = silent
+
+"""
     raw_status_string(model::MOI.ModelLike, config::TestConfig)
 
 Test that the [`MOI.RawStatusString`](@ref) attribute is implemented for

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -156,7 +156,9 @@ MOI.set(mock::MockOptimizer, ::MOI.DualObjectiveValue, value::Real) = (mock.dual
 MOI.set(mock::MockOptimizer, ::MOI.PrimalStatus, value::MOI.ResultStatusCode) = (mock.primalstatus = value)
 MOI.set(mock::MockOptimizer, ::MOI.DualStatus, value::MOI.ResultStatusCode) = (mock.dualstatus = value)
 MOI.set(mock::MockOptimizer, ::MockModelAttribute, value::Integer) = (mock.attribute = value)
-function MOI.supports(mock::MockOptimizer, attr::MOI.AbstractModelAttribute)
+function MOI.supports(mock::MockOptimizer, attr::MOI.AbstractOptimizerAttribute)
+    # `supports` is not defined if `is_set_by_optimize(attr)` so we pass it to
+    # `mock.inner_model`.
     return MOI.supports(mock.inner_model, attr)
 end
 function MOI.set(mock::MockOptimizer, attr::MOI.AbstractOptimizerAttribute,
@@ -166,6 +168,11 @@ function MOI.set(mock::MockOptimizer, attr::MOI.AbstractOptimizerAttribute,
     else
         MOI.set(mock.inner_model, attr, value)
     end
+end
+function MOI.supports(mock::MockOptimizer, attr::MOI.AbstractModelAttribute)
+    # `supports` is not defined if `is_set_by_optimize(attr)` so we pass it to
+    # `mock.inner_model`.
+    return MOI.supports(mock.inner_model, attr)
 end
 function MOI.set(mock::MockOptimizer, attr::MOI.AbstractModelAttribute, value)
     if MOI.is_set_by_optimize(attr)

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -36,8 +36,7 @@ UniversalFallback(model::MOI.ModelLike) = UniversalFallback{typeof(model)}(model
 
 function MOI.is_empty(uf::UniversalFallback)
     return MOI.is_empty(uf.model) && isempty(uf.constraints) &&
-        isempty(uf.optattr) && isempty(uf.modattr) && isempty(uf.varattr) &&
-        isempty(uf.conattr)
+        isempty(uf.modattr) && isempty(uf.varattr) && isempty(uf.conattr)
 end
 function MOI.empty!(uf::UniversalFallback)
     MOI.empty!(uf.model)
@@ -45,7 +44,6 @@ function MOI.empty!(uf::UniversalFallback)
     uf.nextconstraintid = 0
     empty!(uf.con_to_name)
     uf.name_to_con = nothing
-    empty!(uf.optattr)
     empty!(uf.modattr)
     empty!(uf.varattr)
     empty!(uf.conattr)

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -15,6 +15,7 @@ end
 @testset "Unit Tests" begin
     # `UniversalFallback` needed for `MOI.Silent`
     mock = MOIU.MockOptimizer(MOIU.UniversalFallback(Model{Float64}()))
+    MOI.set(mock, MOI.Silent(), true)
     config = MOIT.TestConfig()
     MOIT.unittest(mock, config, [
         "solve_blank_obj",

--- a/test/Utilities/universalfallback.jl
+++ b/test/Utilities/universalfallback.jl
@@ -11,9 +11,6 @@ function test_optmodattrs(uf, model, attr, listattr)
     MOI.set(uf, attr, 0)
     @test MOI.get(uf, attr) == 0
     @test MOI.get(uf, listattr) == [attr]
-    @test !MOI.is_empty(uf)
-    MOI.empty!(uf)
-    @test MOI.is_empty(uf)
 end
 function test_varconattrs(uf, model, attr, listattr, I::Type{<:MOI.Index},
                           addfun, x, y, z)
@@ -116,6 +113,9 @@ end
     attr = MOIT.UnknownModelAttribute()
     listattr = MOI.ListOfModelAttributesSet()
     test_optmodattrs(uf, model, attr, listattr)
+    @test !MOI.is_empty(uf)
+    MOI.empty!(uf)
+    @test MOI.is_empty(uf)
 end
 x = MOI.add_variable(uf)
 y, z = MOI.add_variables(uf, 2)


### PR DESCRIPTION
Also fixes `empty!` and `is_empty` with universal fallback and optimizer attributes.