### PR TITLE
fix ambiguity

### DIFF
--- a/src/Bridges/indicatorbridge.jl
+++ b/src/Bridges/indicatorbridge.jl
@@ -40,9 +40,9 @@ function bridge_constraint(::Type{<:IndicatorActiveOnFalseBridge}, model::MOI.Mo
     return BT(z2, zo_cons, dcons, ci)
 end
 
-function MOI.supports_constraint(::Type{<:IndicatorActiveOnFalseBridge},
-                                 ::Type{<:MOI.VectorAffineFunction},
-                                 ::Type{<:MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}})
+function MOI.supports_constraint(::Type{IndicatorActiveOnFalseBridge{T,F,S}},
+                                 ::Type{F},
+                                 ::Type{<:MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, S}}) where {T, S, F<:MOI.VectorAffineFunction}
     return true
 end
 
@@ -54,4 +54,10 @@ function concrete_bridge_type(::Type{<:IndicatorActiveOnFalseBridge{T}},
                               ::Type{F},
                               ::Type{MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, S}}) where {T, F<:MOI.VectorAffineFunction, S<:MOI.AbstractScalarSet}
     return IndicatorActiveOnFalseBridge{T, F, S}
+end
+
+function concrete_bridge_type(::Type{<:IndicatorActiveOnFalseBridge},
+                              ::Type{F},
+                              ::Type{MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, S}}) where {F<:MOI.VectorAffineFunction, S<:MOI.AbstractScalarSet}
+    return IndicatorActiveOnFalseBridge{Float64, F, S}
 end

--- a/src/Bridges/indicatorbridge.jl
+++ b/src/Bridges/indicatorbridge.jl
@@ -36,8 +36,8 @@ function bridge_constraint(::Type{<:IndicatorActiveOnFalseBridge}, model::MOI.Mo
         f.constants
     )
     ci = MOI.add_constraint(model, f2, MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(s.set))
-
-    return IndicatorActiveOnFalseBridge{T, MOI.VectorAffineFunction{T}, S}(z2, zo_cons, dcons, ci)
+    BT = concrete_bridge_type(IndicatorActiveOnFalseBridge{T}, typeof(f), typeof(s))
+    return BT(z2, zo_cons, dcons, ci)
 end
 
 function MOI.supports_constraint(::Type{<:IndicatorActiveOnFalseBridge},

--- a/src/Bridges/indicatorbridge.jl
+++ b/src/Bridges/indicatorbridge.jl
@@ -40,8 +40,8 @@ function bridge_constraint(::Type{IndicatorActiveOnFalseBridge{T,F,S}}, model::M
 end
 
 function MOI.supports_constraint(::Type{<:IndicatorActiveOnFalseBridge{T}},
-                                 ::Type{F},
-                                 ::Type{<:MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}}) where {T,F<:MOI.VectorAffineFunction}
+                                 ::Type{<:MOI.VectorAffineFunction},
+                                 ::Type{<:MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}}) where {T}
     return true
 end
 

--- a/src/Bridges/indicatorbridge.jl
+++ b/src/Bridges/indicatorbridge.jl
@@ -40,9 +40,9 @@ function bridge_constraint(::Type{<:IndicatorActiveOnFalseBridge}, model::MOI.Mo
     return BT(z2, zo_cons, dcons, ci)
 end
 
-function MOI.supports_constraint(::Type{IndicatorActiveOnFalseBridge{T,F,S}},
+function MOI.supports_constraint(::Type{<:IndicatorActiveOnFalseBridge{T}},
                                  ::Type{F},
-                                 ::Type{<:MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, S}}) where {T, S, F<:MOI.VectorAffineFunction}
+                                 ::Type{<:MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}}) where {T,F<:MOI.VectorAffineFunction}
     return true
 end
 

--- a/src/Bridges/indicatorbridge.jl
+++ b/src/Bridges/indicatorbridge.jl
@@ -52,6 +52,6 @@ end
 
 function concrete_bridge_type(::Type{<:IndicatorActiveOnFalseBridge{T}},
                               ::Type{F},
-                              ::Type{MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, S}}) where {T, F, S}
+                              ::Type{MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, S}}) where {T, F<:MOI.VectorAffineFunction, S<:MOI.AbstractScalarSet}
     return IndicatorActiveOnFalseBridge{T, F, S}
 end

--- a/src/Bridges/indicatorbridge.jl
+++ b/src/Bridges/indicatorbridge.jl
@@ -15,7 +15,7 @@ struct IndicatorActiveOnFalseBridge{T, F <: MOI.AbstractVectorFunction, S <: MOI
     indicator_cons_index::MOI.ConstraintIndex{F, MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE, S}}
 end
 
-function bridge_constraint(::Type{<:IndicatorActiveOnFalseBridge}, model::MOI.ModelLike, f::MOI.VectorAffineFunction{T}, s::IS) where {S <: MOI.AbstractScalarSet, T <: Real, F, IS <: MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, S}}
+function bridge_constraint(::Type{IndicatorActiveOnFalseBridge{T,F,S}}, model::MOI.ModelLike, f::MOI.VectorAffineFunction{T}, s::IS) where {S <: MOI.AbstractScalarSet, T <: Real, F, IS <: MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, S}}
     z1 = f.terms[1].scalar_term.variable_index
     z2 = MOI.add_variable(model)
     zo_cons = MOI.add_constraint(model, MOI.SingleVariable(z2), MOI.ZeroOne())

--- a/src/Bridges/indicatorbridge.jl
+++ b/src/Bridges/indicatorbridge.jl
@@ -36,8 +36,7 @@ function bridge_constraint(::Type{IndicatorActiveOnFalseBridge{T,F,S}}, model::M
         f.constants
     )
     ci = MOI.add_constraint(model, f2, MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(s.set))
-    BT = concrete_bridge_type(IndicatorActiveOnFalseBridge{T}, typeof(f), typeof(s))
-    return BT(z2, zo_cons, dcons, ci)
+    return IndicatorActiveOnFalseBridge{T,F,S}(z2, zo_cons, dcons, ci)
 end
 
 function MOI.supports_constraint(::Type{<:IndicatorActiveOnFalseBridge{T}},

--- a/test/Bridges/indicator_bridge.jl
+++ b/test/Bridges/indicator_bridge.jl
@@ -40,6 +40,12 @@ include("../model.jl")
 
     bridge = MOIB.bridge_constraint(MOIB.IndicatorActiveOnFalseBridge, model, f1, iset1)
 
+    BT = MOIB.concrete_bridge_type(MOIB.IndicatorActiveOnFalseBridge{Float64}, typeof(f1), typeof(iset1))
+    BT2 = MOIB.concrete_bridge_type(MOIB.IndicatorActiveOnFalseBridge, typeof(f1), typeof(iset1))
+
+    @test BT == BT2
+    @test bridge isa BT
+
     z1comp = bridge.variable_index
     @test MOI.get(model, MOI.ConstraintFunction(), bridge.zero_one_cons) == MOI.SingleVariable(z1comp)
     @test MOI.get(model, MOI.ConstraintSet(), bridge.disjunction_cons) == MOI.EqualTo(1.0)

--- a/test/Bridges/indicator_bridge.jl
+++ b/test/Bridges/indicator_bridge.jl
@@ -38,10 +38,10 @@ include("../model.jl")
     )
     iset1 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(8.0))
 
-    bridge = MOIB.bridge_constraint(MOIB.IndicatorActiveOnFalseBridge, model, f1, iset1)
 
     BT = MOIB.concrete_bridge_type(MOIB.IndicatorActiveOnFalseBridge{Float64}, typeof(f1), typeof(iset1))
     BT2 = MOIB.concrete_bridge_type(MOIB.IndicatorActiveOnFalseBridge, typeof(f1), typeof(iset1))
+    bridge = MOIB.bridge_constraint(BT, model, f1, iset1)
 
     @test BT == BT2
     @test bridge isa BT


### PR DESCRIPTION
There was a method ambiguity because of the non-sub-typing in the indicator bridge definition.
