### PR TITLE
Remove variables instead of substracting it

### DIFF
--- a/src/Bridges/slackbridge.jl
+++ b/src/Bridges/slackbridge.jl
@@ -93,8 +93,7 @@ end
 
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintFunction,
                  b::ScalarSlackBridge{T}) where T
-    return MOIU.operate(+, T, MOI.get(model, attr, b.equality),
-                        MOI.SingleVariable(b.slack))
+    return MOIU.removevariable(MOI.get(model, attr, b.equality), b.slack)
 end
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintSet,
                  b::ScalarSlackBridge)
@@ -192,8 +191,7 @@ end
 
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintFunction,
                  b::VectorSlackBridge{T}) where T
-    return MOIU.operate(+, T, MOI.get(model, attr, b.equality),
-                        MOI.VectorOfVariables(b.slacks))
+    return MOIU.removevariable(MOI.get(model, attr, b.equality), b.slacks)
 end
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintSet,
                  b::VectorSlackBridge)

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -449,12 +449,13 @@ function test_models_equal(model1::MOI.ModelLike, model2::MOI.ModelLike, variabl
 end
 
 
+_hasvar(v::VI, vi::Vector{VI}) = v in vi
 _hasvar(v::VI, vi::VI) = v == vi
-_hasvar(t::MOI.ScalarAffineTerm, vi::VI) = t.variable_index == vi
-_hasvar(t::MOI.ScalarQuadraticTerm, vi::VI) = t.variable_index_1 == vi || t.variable_index_2 == vi
-_hasvar(t::Union{MOI.VectorAffineTerm, MOI.VectorQuadraticTerm}, vi::VI) = _hasvar(t.scalar_term, vi)
+_hasvar(t::MOI.ScalarAffineTerm, vi) = _hasvar(t.variable_index, vi)
+_hasvar(t::MOI.ScalarQuadraticTerm, vi) = _hasvar(t.variable_index_1, vi) || _hasvar(t.variable_index_2, vi)
+_hasvar(t::Union{MOI.VectorAffineTerm, MOI.VectorQuadraticTerm}, vi) = _hasvar(t.scalar_term, vi)
 # Removes terms or variables in `vis_or_terms` that contains the variable of index `vi`
-function _rmvar(vis_or_terms::Vector, vi::VI)
+function _rmvar(vis_or_terms::Vector, vi)
     return vis_or_terms[.!_hasvar.(vis_or_terms, Ref(vi))]
 end
 

--- a/test/Bridges/slackbridge.jl
+++ b/test/Bridges/slackbridge.jl
@@ -16,6 +16,7 @@ config = MOIT.TestConfig()
 @testset "Scalar slack" begin
     MOI.empty!(mock)
     bridged_mock = MOIB.ScalarSlack{Float64}(mock)
+
     x = MOI.add_variable(bridged_mock)
     y = MOI.add_variable(bridged_mock)
     f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}.([1.0, 2.0], [x, y]), 0.0)
@@ -37,8 +38,7 @@ config = MOIT.TestConfig()
                                 F in [MOI.ScalarAffineFunction{Float64},
                                       MOI.ScalarQuadraticFunction{Float64}],
                                 S in [MOI.GreaterThan{Float64},
-                                      MOI.LessThan{Float64}]
-                                      ])
+                                      MOI.LessThan{Float64}]])
 
     # There are extra variables due to the bridge
     MOIU.set_mock_optimize!(mock,
@@ -88,6 +88,7 @@ end
 @testset "Vector slack" begin
     MOI.empty!(mock)
     bridged_mock = MOIB.VectorSlack{Float64}(mock)
+
     x = MOI.add_variable(bridged_mock)
     y = MOI.add_variable(bridged_mock)
     f = MOI.VectorAffineFunction(MOI.VectorAffineTerm.(1, MOI.ScalarAffineTerm.([1.0, 2.0], [x, y])), [0.0])


### PR DESCRIPTION
Otherwise, the caller will get slack variables in the function that should not exists even if their terms sum to 0.