### PR TITLE
Fix tests from Gurobi #216

### DIFF
--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -30,8 +30,16 @@ function MOIB.supports_bridging_constraint(b::SingleBridgeOptimizer{BT},
                                       S::Type{<:MOI.AbstractSet}) where BT
     return MOI.supports_constraint(BT, F, S)
 end
-function MOIB.is_bridged(b::SingleBridgeOptimizer, F::Type{<:MOI.AbstractFunction},
-                    S::Type{<:MOI.AbstractSet})
+
+function MOIB.is_bridged(
+    b::SingleBridgeOptimizer,
+    F::Type{<:MOI.AbstractFunction},
+    S::Type{<:MOI.AbstractSet}
+)
+    if MOI.supports_constraint(b.model, F, S)
+        return false
+    end
     return MOIB.supports_bridging_constraint(b, F, S)
 end
+
 MOIB.bridge_type(b::SingleBridgeOptimizer{BT}, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI.AbstractSet}) where BT = BT

--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -30,16 +30,8 @@ function MOIB.supports_bridging_constraint(b::SingleBridgeOptimizer{BT},
                                       S::Type{<:MOI.AbstractSet}) where BT
     return MOI.supports_constraint(BT, F, S)
 end
-
-function MOIB.is_bridged(
-    b::SingleBridgeOptimizer,
-    F::Type{<:MOI.AbstractFunction},
-    S::Type{<:MOI.AbstractSet}
-)
-    if MOI.supports_constraint(b.model, F, S)
-        return false
-    end
+function MOIB.is_bridged(b::SingleBridgeOptimizer, F::Type{<:MOI.AbstractFunction},
+                    S::Type{<:MOI.AbstractSet})
     return MOIB.supports_bridging_constraint(b, F, S)
 end
-
 MOIB.bridge_type(b::SingleBridgeOptimizer{BT}, ::Type{<:MOI.AbstractFunction}, ::Type{<:MOI.AbstractSet}) where BT = BT

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -40,8 +40,8 @@ const BasicConstraintTests = Dict(
     (MOI.VectorOfVariables, MOI.GeometricMeanCone)      => ( dummy_vectorofvariables, 3, MOI.GeometricMeanCone(3) ),
     (MOI.VectorOfVariables, MOI.ExponentialCone)        => ( dummy_vectorofvariables, 3, MOI.ExponentialCone() ),
     (MOI.VectorOfVariables, MOI.DualExponentialCone)    => ( dummy_vectorofvariables, 3, MOI.DualExponentialCone() ),
-    (MOI.VectorOfVariables, MOI.PowerCone)              => ( dummy_vectorofvariables, 3, MOI.PowerCone(2.0) ),
-    (MOI.VectorOfVariables, MOI.DualPowerCone)          => ( dummy_vectorofvariables, 3, MOI.DualPowerCone(2.0) ),
+    (MOI.VectorOfVariables, MOI.PowerCone{Float64})     => ( dummy_vectorofvariables, 3, MOI.PowerCone(2.0) ),
+    (MOI.VectorOfVariables, MOI.DualPowerCone{Float64}) => ( dummy_vectorofvariables, 3, MOI.DualPowerCone(2.0) ),
 
     (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle) => ( dummy_vectorofvariables,  7, MOI.PositiveSemidefiniteConeTriangle(3) ),
     (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeSquare)   => ( dummy_vectorofvariables, 10, MOI.PositiveSemidefiniteConeSquare(3) ),

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -1499,9 +1499,6 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
             @test - 3 * cd1 + cd2 ≈ -bndyd atol=atol rtol=rtol
             @test 2 * cd1 ≈ -bndxd atol=atol rtol=rtol
             @test -7 * cd1 + 2 * cd2 > atol
-        else
-            # solver returned nothing
-            @test MOI.get(model, MOI.ResultCount()) == 0
         end
     end
 end

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -303,7 +303,11 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
 
     @test !MOI.supports(dest, MOI.Name()) || MOI.get(dest, MOI.Name()) == ""
     @test MOI.get(dest, MOI.NumberOfVariables()) == 4
-    @test !MOI.supports(dest, MOI.VariableName(), MOI.VariableIndex) || MOI.get(dest, MOI.VariableName(), v) == ["", "", ""]
+    if MOI.supports(dest, MOI.VariableName(), MOI.VariableIndex)
+        for vi in v
+            MOI.get(dest, MOI.VariableName(), dict[vi]) == ""
+        end
+    end
     @test MOI.get(dest, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 1
     @test MOI.get(dest, MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == [dict[csv]]
     @test MOI.get(dest, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -266,6 +266,8 @@ end
 
 function copytest(dest::MOI.ModelLike, src::MOI.ModelLike)
     @test MOIU.supports_default_copy_to(src, #=copy_names=# true)
+    MOI.empty!(src)
+    MOI.empty!(dest)
     MOI.set(src, MOI.Name(), "ModelName")
     v = MOI.add_variables(src, 3)
     w = MOI.add_variable(src)

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -11,6 +11,7 @@ function default_objective_test(model::MOI.ModelLike)
 end
 
 function default_status_test(model::MOI.ModelLike)
+    MOI.empty!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
     @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
     @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
@@ -106,6 +107,7 @@ end
 
 # Taken from https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/41
 function validtest(model::MOI.ModelLike)
+    MOI.empty!(model)
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     v = MOI.add_variables(model, 2)
     @test MOI.is_valid(model, v[1])
@@ -125,6 +127,7 @@ function validtest(model::MOI.ModelLike)
 end
 
 function emptytest(model::MOI.ModelLike)
+    MOI.empty!(model)
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     # Taken from LIN1
     v = MOI.add_variables(model, 3)
@@ -200,6 +203,7 @@ function failcopytestca(dest::MOI.ModelLike)
 end
 
 function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
+    MOI.empty!(dest)
     @test MOIU.supports_default_copy_to(src, #=copy_names=# false)
     x, y, z = MOI.add_variables(src, 3)
     a = MOI.add_constraint(src, x, MOI.EqualTo(1.0))


### PR DESCRIPTION
These two changes were needed to get https://github.com/JuliaOpt/Gurobi.jl/pull/216 passing.

The first is because Gurobi elects to run `infeas_certificates=false`, but still finds a partial certificate so `ResultCount` is 1.

The second is a bug. The variables need to be mapped to be valid.