### PR TITLE
Add MOI.submit to add attribute

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -44,10 +44,14 @@ set
 supports
 ```
 
-## Submit
+### Submit
 
-Objects may be submitted using [`submit`](@ref).
-Note that this is currently no supported by [`Utilities.Cac
+Objects may be submitted to an optimizer using [`submit`](@ref).
+```@docs
+AbstractSubmittable
+submit
+```
+
 
 ## Model Interface
 
@@ -407,6 +411,8 @@ AddConstraintNotAllowed
 ModifyConstraintNotAllowed
 ModifyObjectiveNotAllowed
 DeleteNotAllowed
+UnsupportedSubmittable
+SubmitNotAllowed
 ```
 
 ## Models

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -44,6 +44,11 @@ set
 supports
 ```
 
+## Submit
+
+Objects may be submitted using [`submit`](@ref).
+Note that this is currently no supported by [`Utilities.Cac
+
 ## Model Interface
 
 ```@docs

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -377,7 +377,7 @@ end
 
 """
     submit(optimizer::AbstractOptimizer, sub::AbstractSubmittable,
-           value)::Union{Nothing, SubmittedIndex{typeof(sub)}}
+           value)::Nothing
 
 Submit `value` to the submittable `sub` of the optimizer `optimizer`.
 

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -36,20 +36,20 @@ end
 Base.hash(v::VariableIndex, h::UInt) = hash(v.value, h)
 
 """
-    AttributeIndex{AttrType}
+    SubmittedIndex{SubmitType}
 
-A type-safe wrapper for `Int64` for use in referencing elements added for
-attribute of type `AttrType`.
+A type-safe wrapper for `Int64` for use in referencing elements submitted for
+submittable of type `SubmitType`.
 """
-struct AttributeIndex{AttrType}
-    attr::AttrType
+struct SubmittedIndex{SubmitType}
+    attr::SubmitType
     value::Int64
 end
 
 # No need to define isequal because the default matches our implementation of
 # hash.
 
-const Index = Union{ConstraintIndex, VariableIndex, AttributeIndex}
+const Index = Union{ConstraintIndex, VariableIndex, SubmittedIndex}
 
 """
     struct InvalidIndex{IndexType<:Index} <: Exception

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -35,10 +35,21 @@ end
 # https://github.com/JuliaLang/julia/issues/10208
 Base.hash(v::VariableIndex, h::UInt) = hash(v.value, h)
 
+"""
+    AttributeIndex{AttrType}
+
+A type-safe wrapper for `Int64` for use in referencing elements added for
+attribute of type `AttrType`.
+"""
+struct AttributeIndex{AttrType}
+    attr:AttrType
+    value::Int64
+end
+
 # No need to define isequal because the default matches our implementation of
 # hash.
 
-const Index = Union{ConstraintIndex,VariableIndex}
+const Index = Union{ConstraintIndex, VariableIndex, AttributeIndex}
 
 """
     struct InvalidIndex{IndexType<:Index} <: Exception

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -42,7 +42,7 @@ A type-safe wrapper for `Int64` for use in referencing elements added for
 attribute of type `AttrType`.
 """
 struct AttributeIndex{AttrType}
-    attr:AttrType
+    attr::AttrType
     value::Int64
 end
 

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -35,21 +35,10 @@ end
 # https://github.com/JuliaLang/julia/issues/10208
 Base.hash(v::VariableIndex, h::UInt) = hash(v.value, h)
 
-"""
-    SubmittedIndex{SubmitType}
-
-A type-safe wrapper for `Int64` for use in referencing elements submitted for
-submittable of type `SubmitType`.
-"""
-struct SubmittedIndex{SubmitType}
-    attr::SubmitType
-    value::Int64
-end
-
 # No need to define isequal because the default matches our implementation of
 # hash.
 
-const Index = Union{ConstraintIndex, VariableIndex, SubmittedIndex}
+const Index = Union{ConstraintIndex,VariableIndex}
 
 """
     struct InvalidIndex{IndexType<:Index} <: Exception


### PR DESCRIPTION
Some operations do not fall into the category of `set` such as:
* Adding heuristic solutions (https://github.com/JuliaOpt/MathOptInterface.jl/pull/670)
* Adding Lazy constraints (https://github.com/JuliaOpt/MathOptInterface.jl/pull/670)

So when a solver want to expose a solver specific feature like this, we need to create a new `add_...` function in MOI and implement it in every layer + adding a function to JuMP, ...
This PR adds a `MOI.add` function which is similar to `MOI.set` except it returns an `AttributeIndex` which is consistent with `add_variable(s)` and `add_constraint(s)`.
With this PR, if a solver want to expose, say lazy constraints, it just have to define `LazyConstraint <: MOI.AbstractOptimizerAttribute`, implement `MOI.add(::Optimizer, ::LazyConstraint, ...)` and no change is needed either from JuMP or MOI.

This might be the only breaking change needed to add support for callbacks so it might be worth it to include it into v0.9