### PR TITLE
Add Lazy/Heuristic MIP callbacks

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -74,6 +74,13 @@ AbstractSubmittable
 submit
 ```
 
+List of submittables
+
+```@docs
+LazyConstraint
+HeuristicSolution
+```
+
 ## Model Interface
 
 ```@docs
@@ -121,6 +128,9 @@ SolverName
 Silent
 TimeLimitSec
 RawParameter
+AbstractCallback
+LazyCallback
+HeuristicCallback
 ```
 
 List of attributes useful for optimizers
@@ -219,6 +229,8 @@ Calls to `get` and `set` should include as an argument a single `VariableIndex` 
 VariableName
 VariablePrimalStart
 VariablePrimal
+VariablePrimalAtIntegerNode
+VariablePrimalAtFractionalNode
 ```
 
 ### Constraints
@@ -436,6 +448,12 @@ variable:
 ```@docs
 LowerBoundAlreadySet
 UpperBoundAlreadySet
+```
+
+As discussed in [`AbstractCallback`](@ref), trying to [`get`](@ref) attributes
+inside a callback may throw:
+```@docs
+OptimizeInProgress
 ```
 
 The rest of the errors defined in MOI fall in two categories represented by the

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -78,6 +78,7 @@ List of submittables
 
 ```@docs
 LazyConstraint
+HeuristicSolutionStatus
 HeuristicSolution
 UserCut
 ```

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -77,7 +77,6 @@ submit
 List of submittables
 
 ```@docs
-RejectSolution
 LazyConstraint
 HeuristicSolution
 UserCut
@@ -131,8 +130,9 @@ Silent
 TimeLimitSec
 RawParameter
 AbstractCallback
-FeasibleSolutionCallback
-InfeasibleSolutionCallback
+LazyConstraintCallback
+HeuristicCallback
+UserCutCallback
 ```
 
 List of attributes useful for optimizers

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -77,8 +77,10 @@ submit
 List of submittables
 
 ```@docs
+RejectSolution
 LazyConstraint
 HeuristicSolution
+UserCut
 ```
 
 ## Model Interface
@@ -129,8 +131,8 @@ Silent
 TimeLimitSec
 RawParameter
 AbstractCallback
-LazyCallback
-HeuristicCallback
+FeasibleSolutionCallback
+InfeasibleSolutionCallback
 ```
 
 List of attributes useful for optimizers
@@ -229,8 +231,7 @@ Calls to `get` and `set` should include as an argument a single `VariableIndex` 
 VariableName
 VariablePrimalStart
 VariablePrimal
-VariablePrimalAtIntegerNode
-VariablePrimalAtFractionalNode
+CallbackVariablePrimal
 ```
 
 ### Constraints


### PR DESCRIPTION
This PR defines the necessary attributes and submittables for lazy and heuristic callbacks.
The docstrings are based on https://github.com/JuliaOpt/MathOptInterface.jl/pull/670.

Closes https://github.com/JuliaOpt/MathOptInterface.jl/pull/670

cc @mtanneau