### PR TITLE
 Add AbstractCallback and OptimizeInProgress

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -99,6 +99,7 @@ List of optimizers attributes
 SolverName
 Silent
 RawParameter
+AbstractCallback
 ```
 
 List of attributes useful for optimizers
@@ -391,6 +392,12 @@ variable:
 ```@docs
 LowerBoundAlreadySet
 UpperBoundAlreadySet
+```
+
+As discussed in [`AbstractCallback`](@ref), trying to [`get`](@ref) attributes
+inside a callback may throw:
+```@docs
+OptimizeInProgress
 ```
 
 The rest of the errors defined in MOI fall in two categories represented by the

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -470,6 +470,7 @@ end
 
 """
     abstract type AbstractCallback <: AbstractOptimizerAttribute end
+
 Abstract type for optimizer attribute representing a callback functions. The
 value set to subtypes of `AbstractCallback` is a function that may be called
 during [`optimize!`](@ref). As [`optimize!`](@ref) is in progress, the result
@@ -477,8 +478,7 @@ attributes (i.e, the attributes `attr` such that `is_set_by_optimize(attr)`)
 may not be accessible from the callback hence trying to get result attributes
 might throw a [`OptimizeInProgress`](@ref) error.
 The value of the attribute should be a function taking only one argument, that
-is commonly called `callback_data`, that can be used for instance in
-[`LazyCallback`](@ref), [`HeuristicSolution`](@ref).
+is commonly called `callback_data`.
 """
 abstract type AbstractCallback <: AbstractOptimizerAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -376,6 +376,14 @@ function throw_set_error_fallback(model::ModelLike,
 end
 
 """
+    SettingSingleVariableFunctionNotAllowed()
+
+Error type that should be thrown when the user [`set`](@ref) the
+[`ConstraintFunction`](@ref) of a [`SingleVariable`](@ref) constraint.
+"""
+struct SettingSingleVariableFunctionNotAllowed <: Exception end
+
+"""
     submit(optimizer::AbstractOptimizer, sub::AbstractSubmittable,
            value)::Nothing
 
@@ -393,14 +401,6 @@ function submit(model::ModelLike, sub::AbstractSubmittable, args...)
         throw(UnsupportedSubmittable(sub))
     end
 end
-
-"""
-    SettingSingleVariableFunctionNotAllowed()
-
-Error type that should be thrown when the user [`set`](@ref) the
-[`ConstraintFunction`](@ref) of a [`SingleVariable`](@ref) constraint.
-"""
-struct SettingSingleVariableFunctionNotAllowed <: Exception end
 
 ## Optimizer attributes
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -449,6 +449,39 @@ struct RawParameter <: AbstractOptimizerAttribute
     name::Any
 end
 
+### Callbacks
+
+"""
+    struct OptimizeInProgress{AttrType<:AnyAttribute} <: Exception
+        attr::AttrType
+    end
+Error thrown from optimizer when `MOI.get(optimizer, attr)` is called inside an
+[`AbstractCallback`](@ref) while it is only defined once [`optimize!`](@ref) has
+completed. This is only defined if `is_set_by_optimize(attr)` is `true`.
+"""
+struct OptimizeInProgress{AttrType<:AnyAttribute} <: Exception
+    attr::AttrType
+end
+
+function Base.showerror(io::IO, err::OptimizeInProgress)
+    print(io, typeof(err), ": Cannot get result as the `MOI.optimize!` has not",
+          " finished.")
+end
+
+"""
+    abstract type AbstractCallback <: AbstractOptimizerAttribute end
+Abstract type for optimizer attribute representing a callback functions. The
+value set to subtypes of `AbstractCallback` is a function that may be called
+during [`optimize!`](@ref). As [`optimize!`](@ref) is in progress, the result
+attributes (i.e, the attributes `attr` such that `is_set_by_optimize(attr)`)
+may not be accessible from the callback hence trying to get result attributes
+might throw a [`OptimizeInProgress`](@ref) error.
+The value of the attribute should be a function taking only one argument, that
+is commonly called `callback_data`, that can be used for instance in
+[`LazyCallback`](@ref), [`HeuristicSolution`](@ref).
+"""
+abstract type AbstractCallback <: AbstractOptimizerAttribute end
+
 ## Model attributes
 
 """

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -378,7 +378,7 @@ end
 """
     SettingSingleVariableFunctionNotAllowed()
 
-Error type that should be thrown when the user [`set`](@ref) the
+Error type that should be thrown when the user calls [`set`](@ref) on a
 [`ConstraintFunction`](@ref) of a [`SingleVariable`](@ref) constraint.
 """
 struct SettingSingleVariableFunctionNotAllowed <: Exception end


### PR DESCRIPTION
This is a subset of https://github.com/JuliaOpt/MathOptInterface.jl/pull/782 that should be less subject to bikeshedding and that would allow solver specific callbacks to start using `AbstractCallback` and `OptimizeInProgress`.

cc @mtanneau