### PR TITLE
Test modification errors

### DIFF
--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -19,7 +19,7 @@ function ModifyConstraintNotAllowed(
     ci::ConstraintIndex{F, S},
     change::AbstractFunctionModification,
     message="") where {F<:AbstractFunction, S<:AbstractSet}
-    ModifyConstraintNotAllowed{F, S, typeof(change)}(ci, change, message)
+    return ModifyConstraintNotAllowed{F, S, typeof(change)}(ci, change, message)
 end
 throw_modify_not_allowed(ci::ConstraintIndex, args...) = throw(ModifyConstraintNotAllowed(ci, args...))
 
@@ -39,7 +39,7 @@ struct ModifyObjectiveNotAllowed{C<:AbstractFunctionModification} <: NotAllowedE
     message::String
 end
 function ModifyObjectiveNotAllowed(change::AbstractFunctionModification)
-    ModifyObjectiveNotAllowed(change, "")
+    return ModifyObjectiveNotAllowed(change, "")
 end
 throw_modify_not_allowed(::ObjectiveFunction, args...) = throw(ModifyObjectiveNotAllowed(args...))
 

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -1,6 +1,6 @@
 """
     struct ModifyConstraintNotAllowed{F<:AbstractFunction, S<:AbstractSet,
-                                             C<:AbstractFunctionModification} <: NotAllowedError
+                                      C<:AbstractFunctionModification} <: NotAllowedError
         constraint_index::ConstraintIndex{F, S}
         change::C
         message::String
@@ -10,15 +10,18 @@ An error indicating that the constraint modification `change` cannot be applied
 to the constraint of index `ci`.
 """
 struct ModifyConstraintNotAllowed{F<:AbstractFunction, S<:AbstractSet,
-                                         C<:AbstractFunctionModification} <: NotAllowedError
+                                  C<:AbstractFunctionModification} <: NotAllowedError
     constraint_index::ConstraintIndex{F, S}
     change::C
     message::String
 end
-function ModifyConstraintNotAllowed(ci::ConstraintIndex{F, S},
-                                change::AbstractFunctionModification) where {F<:AbstractFunction, S<:AbstractSet}
-    ModifyConstraintNotAllowed{F, S, typeof(change)}(ci, change, "")
+function ModifyConstraintNotAllowed(
+    ci::ConstraintIndex{F, S},
+    change::AbstractFunctionModification,
+    message="") where {F<:AbstractFunction, S<:AbstractSet}
+    ModifyConstraintNotAllowed{F, S, typeof(change)}(ci, change, message)
 end
+throw_modify_not_allowed(ci::ConstraintIndex, args...) = throw(ModifyConstraintNotAllowed(ci, args...))
 
 operation_name(err::ModifyConstraintNotAllowed{F, S}) where {F, S} = "Modifying the constraints $(err.constraint_index) with $(err.change)"
 
@@ -38,6 +41,7 @@ end
 function ModifyObjectiveNotAllowed(change::AbstractFunctionModification)
     ModifyObjectiveNotAllowed(change, "")
 end
+throw_modify_not_allowed(::ObjectiveFunction, args...) = throw(ModifyObjectiveNotAllowed(args...))
 
 operation_name(err::ModifyObjectiveNotAllowed) = "Modifying the objective function with $(err.change)"
 
@@ -75,12 +79,12 @@ modify(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(), ScalarConstant
 """
 function modify end
 
-function modify(model::ModelLike, ci::ConstraintIndex{F, S},
-                 change::AbstractFunctionModification) where {F, S}
-    throw(ModifyConstraintNotAllowed(ci, change))
+function modify(model::ModelLike, ci::ConstraintIndex,
+                change::AbstractFunctionModification)
+    throw_modify_not_allowed(ci, change)
 end
 
-function modify(model::ModelLike, ::ObjectiveFunction,
-                 change::AbstractFunctionModification)
-    throw(ModifyObjectiveNotAllowed(change))
+function modify(model::ModelLike, attr::ObjectiveFunction,
+                change::AbstractFunctionModification)
+    throw_modify_not_allowed(attr, change)
 end


### PR DESCRIPTION
Extracted from https://github.com/JuliaOpt/MathOptInterface.jl/pull/759 where the `throw_modify_not_allowed` function is used by `AbstractBridgeOptimizer`.