### PR TITLE
Fix broadcast for scalar sets

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -37,6 +37,8 @@ Abstract supertype for subsets of ``\\mathbb{R}``.
 """
 abstract type AbstractScalarSet <: AbstractSet end
 
+Base.broadcastable(set::AbstractScalarSet) = Ref(set)
+
 dimension(s::AbstractScalarSet) = 1
 
 """

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -1,3 +1,10 @@
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+
+include("dummy.jl")
+
 """
     MutLessThan{T<:Real} <: MOI.AbstractScalarSet
 
@@ -32,7 +39,17 @@ Base.copy(mlt::MutLessThan) = MutLessThan(Base.copy(mlt.upper))
             @test s3.set.upper ≈ 4.0
             s3_copy.set.upper = 5.0
             @test s3.set.upper ≈ 4.0
-            @test s3_copy.set.upper ≈ 5.0    
+            @test s3_copy.set.upper ≈ 5.0
+        end
+    end
+    @testset "Broadcast" begin
+        model = DummyModelWithAdd()
+        x = MOI.add_variables(model, 3)
+        cis = MOI.add_constraint.(model, x, MOI.EqualTo(0.0))
+        @test length(cis) == 3
+        for i in 1:3
+            @test cis[i] == MOI.ConstraintIndex{MOI.SingleVariable,
+                                                MOI.EqualTo{Float64}}(0)
         end
     end
 end

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -46,10 +46,8 @@ Base.copy(mlt::MutLessThan) = MutLessThan(Base.copy(mlt.upper))
         model = DummyModelWithAdd()
         x = MOI.add_variables(model, 3)
         cis = MOI.add_constraint.(model, x, MOI.EqualTo(0.0))
+        @test cis isa Vector{MOI.ConstraintIndex{MOI.SingleVariable,
+                                                 MOI.EqualTo{Float64}}}
         @test length(cis) == 3
-        for i in 1:3
-            @test cis[i] == MOI.ConstraintIndex{MOI.SingleVariable,
-                                                MOI.EqualTo{Float64}}(0)
-        end
     end
 end


### PR DESCRIPTION
Defining scalar sets as 0-dimensional for broadcast seems reasonable.

cc @tweisser