### PR TITLE
Fix operator overload with SingleVariable

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1168,7 +1168,10 @@ function operate!(::typeof(*), ::Type{T}, f::MOI.SingleVariable, α::T) where T
     return operate(*, T, α, f)
 end
 function operate(::typeof(*), ::Type{T}, α::T, f::MOI.SingleVariable) where T
-    MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm(α, f.variable)], zero(T))
+    return MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm(α, f.variable)], zero(T))
+end
+function operate(::typeof(*), ::Type{T}, f::MOI.SingleVariable, α::T) where T
+    return operate(*, T, α, f)
 end
 
 function operate!(::typeof(*), ::Type{T},

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1307,10 +1307,6 @@ function operate(::typeof(/), ::Type{T},
     return operate!(/, T, copy(f), α)
 end
 
-# To avoid type piracy, we add at least one `ScalarLike` outside of the `...`.
-function Base.:/(arg::ScalarLike{T}, args::ScalarLike{T}...) where T
-    return operate(/, T, arg, args...)
-end
 function Base.:/(f::TypedScalarLike{T}, g::T) where T
     return operate(/, T, f, g)
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -710,6 +710,11 @@ const ScalarQuadraticLike{T} = Union{ScalarAffineLike{T}, MOI.ScalarQuadraticFun
 # avoid overloading e.g. `+(::Float64, ::Float64)`
 const ScalarLike{T} = Union{MOI.SingleVariable, MOI.ScalarAffineFunction{T},
                             MOI.ScalarQuadraticFunction{T}}
+# `ScalarLike` for which `T` is defined to avoid defining, e.g.,
+# `+(::SingleVariable, ::Any)` which should rather be
+# `+(::SingleVariable, ::Number)`.
+const TypedScalarLike{T} = Union{MOI.ScalarAffineFunction{T},
+                                 MOI.ScalarQuadraticFunction{T}}
 
 # Functions convertible to a VectorAffineFunction
 const VectorAffineLike{T} = Union{Vector{T}, MOI.VectorOfVariables, MOI.VectorAffineFunction{T}}
@@ -905,21 +910,34 @@ end
 function Base.:+(arg::ScalarLike{T}, args::ScalarLike{T}...) where T
     return operate(+, T, arg, args...)
 end
-function Base.:+(α::T, arg::ScalarLike{T}, args::ScalarLike{T}...) where T
+function Base.:+(α::T, arg::TypedScalarLike{T}, args::ScalarLike{T}...) where T
     return operate(+, T, α, arg, args...)
 end
-function Base.:+(f::ScalarLike{T}, α::T) where T
+function Base.:+(α::Number, f::MOI.SingleVariable)
+    return operate(+, typeof(α), α, f)
+end
+function Base.:+(f::TypedScalarLike{T}, α::T) where T
     return operate(+, T, f, α)
+end
+function Base.:+(f::MOI.SingleVariable, α::Number)
+    return operate(+, typeof(α), f, α)
 end
 function Base.:-(arg::ScalarLike{T}, args::ScalarLike{T}...) where T
     return operate(-, T, arg, args...)
 end
-function Base.:-(f::ScalarLike{T}, α::T) where T
+function Base.:-(f::TypedScalarLike{T}, α::T) where T
     return operate(-, T, f, α)
 end
-function Base.:-(α::T, f::ScalarLike{T}) where T
+function Base.:-(f::MOI.SingleVariable, α::Number)
+    return operate(-, typeof(α), f, α)
+end
+function Base.:-(α::T, f::TypedScalarLike{T}) where T
     return operate(-, T, α, f)
 end
+function Base.:-(α::Number, f::MOI.SingleVariable)
+    return operate(-, typeof(α), α, f)
+end
+
 
 # Vector +/-
 ###############################################################################
@@ -1223,15 +1241,23 @@ function operate(::typeof(*), ::Type{T}, f::MOI.ScalarAffineFunction{T},
     return MOI.ScalarQuadraticFunction(aff_terms, quad_terms, constant)
 end
 
-function Base.:*(args::ScalarLike{T}...) where T
-    return operate(*, T, args...)
+# To avoid type piracy, we add at least one `ScalarLike` outside of the `...`.
+function Base.:*(arg::ScalarLike{T}, args::ScalarLike{T}...) where T
+    return operate(*, T, arg, args...)
 end
-function Base.:*(f::T, g::ScalarLike{T}) where T
+function Base.:*(f::T, g::TypedScalarLike{T}) where T
     return operate(*, T, f, g)
 end
-function Base.:*(f::ScalarLike{T}, g::T) where T
+function Base.:*(f::Number, g::MOI.SingleVariable)
+    return operate(*, typeof(f), f, g)
+end
+function Base.:*(f::TypedScalarLike{T}, g::T) where T
     return operate(*, T, g, f)
 end
+function Base.:*(f::MOI.SingleVariable, g::Number)
+    return operate(*, typeof(g), f, g)
+end
+
 
 ####################################### / ######################################
 function promote_operation(::typeof(/), ::Type{T},
@@ -1278,11 +1304,15 @@ function operate(::typeof(/), ::Type{T},
     return operate!(/, T, copy(f), α)
 end
 
-function Base.:/(args::ScalarLike{T}...) where T
-    return operate(/, T, args...)
+# To avoid type piracy, we add at least one `ScalarLike` outside of the `...`.
+function Base.:/(arg::ScalarLike{T}, args::ScalarLike{T}...) where T
+    return operate(/, T, arg, args...)
 end
-function Base.:/(f::ScalarLike{T}, g::T) where T
+function Base.:/(f::TypedScalarLike{T}, g::T) where T
     return operate(/, T, f, g)
+end
+function Base.:/(f::MOI.SingleVariable, g::Number)
+    return operate(/, typeof(g), f, g)
 end
 
 ## sum

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -199,6 +199,11 @@ end
             g = MOI.SingleVariable(MOI.VariableIndex(1))
             @test !iszero(f)
             @test !iszero(g)
+            @test f + 1 ≈ 1 + f
+            @test (f + 1.0) - 1.0 ≈ (2.0f) / 2.0
+            @test (f - 1.0) + 1.0 ≈ (2.0f) / 2.0
+            @test (1.0 + f) - 1.0 ≈ (f * 2.0) / 2.0
+            @test 1.0 - (1.0 - f) ≈ (f / 2.0) * 2.0
         end
     end
     @testset "Affine" begin


### PR DESCRIPTION
This PR fixes two types piracies and avoid defining operation between `SingleVariable` and `Any`, defining instead operations between `SingleVariable` and `Number`.