### PR TITLE
Update tests with add_constrained_variable(s)

### DIFF
--- a/test/Bridges/Constraint/flip_sign.jl
+++ b/test/Bridges/Constraint/flip_sign.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 
 @testset "GreaterToLess" begin

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 config_with_basis = MOIT.TestConfig(basis = true)
 

--- a/test/Bridges/Constraint/quad_to_soc.jl
+++ b/test/Bridges/Constraint/quad_to_soc.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 
 @testset "QuadtoSOC" begin

--- a/test/Bridges/Constraint/rsoc.jl
+++ b/test/Bridges/Constraint/rsoc.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 
 @testset "RSOC" begin
@@ -23,7 +21,7 @@ config = MOIT.TestConfig()
                              MOI.VectorQuadraticFunction{Float64}]
                    for S in [MOI.RotatedSecondOrderCone]])
 
-    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/√2, 1/√2, 0.5, 1.0],
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [0.5, 1.0, 1/√2, 1/√2],
                           (MOI.SingleVariable,                MOI.EqualTo{Float64}) => [-√2, -1/√2],
                           (MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)  => [[3/2, 1/2, -1.0, -1.0]])
     MOIT.rotatedsoc1vtest(bridged_mock, config)

--- a/test/Bridges/Constraint/scalarize.jl
+++ b/test/Bridges/Constraint/scalarize.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 
 @testset "Scalarize" begin

--- a/test/Bridges/Constraint/slack.jl
+++ b/test/Bridges/Constraint/slack.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 
 @testset "Scalar slack" begin

--- a/test/Bridges/Constraint/soc_to_psd.jl
+++ b/test/Bridges/Constraint/soc_to_psd.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 
 @testset "SOCtoPSD" begin
@@ -33,7 +31,7 @@ end
                    for F in [MOI.VectorOfVariables, MOI.VectorAffineFunction{Float64}]
                    for S in [MOI.RotatedSecondOrderCone]])
 
-    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/√2, 1/√2, 0.5, 1.0],
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [0.5, 1.0, 1/√2, 1/√2],
                           (MOI.SingleVariable,                MOI.EqualTo{Float64})       => [-√2, -1/√2],
                           (MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle) => [[√2, -1/2, √2/8, -1/2, √2/8, √2/8]])
     MOIT.rotatedsoc1vtest(bridged_mock, config)

--- a/test/Bridges/Constraint/square.jl
+++ b/test/Bridges/Constraint/square.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 
 @testset "Square" begin

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -8,9 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-include("../simple_model.jl")
-
-mock = MOIU.MockOptimizer(SimpleModel{Float64}())
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
 config = MOIT.TestConfig()
 
 @testset "Vectorize" begin

--- a/test/Test/Test.jl
+++ b/test/Test/Test.jl
@@ -1,3 +1,5 @@
+using Test
+
 @testset "Config" begin
     include("config.jl")
 end

--- a/test/Test/contconic.jl
+++ b/test/Test/contconic.jl
@@ -61,7 +61,7 @@ end
     MOIT.soc4test(mock, config)
 end
 @testset "RSOC" begin
-    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/√2, 1/√2, 0.5, 1.0],
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [0.5, 1.0, 1/√2, 1/√2],
                           (MOI.SingleVariable,                MOI.EqualTo{Float64})       => [-√2, -1/√2],
                           (MOI.VectorOfVariables,             MOI.RotatedSecondOrderCone) => [[√2, 1/√2, -1.0, -1.0]])
     # double variable bounds on a and b variables
@@ -92,6 +92,12 @@ end
     mock.eval_variable_constraint_dual = false
     MOIT.rotatedsoc3test(mock, config)
     mock.eval_variable_constraint_dual = true
+
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, ones(4),
+        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})       => [-1.0],
+        (MOI.VectorOfVariables, MOI.RotatedSecondOrderCone) => [[1.0, 1.0, -1.0, -1.0]])
+    MOIT.rotatedsoc4test(mock, config)
+
 end
 @testset "GeoMean" begin
     mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, ones(4))


### PR DESCRIPTION
Use `add_constrained_variable` and `add_constrained_variables` instead of `add_variable`/`add_variables` in a few tests.
Also create a new rotated SOC test.
There is no rule on whether one should use `add_variable` or `add_constrained_variable` in the tests except in some places where using `add_constrained_variable` would not work as the test use modification not supported by the bridge.
The tests are run with an SDPA model in `test/Bridges/lazy_bridge_optimizer.jl` to make sure tests don't do the wrong choice in https://github.com/JuliaOpt/MathOptInterface.jl/pull/759


Extracted from https://github.com/JuliaOpt/MathOptInterface.jl/pull/759