### PR TITLE
Add substitute_variables

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -660,6 +660,7 @@ Utilities.mode
 The following utilities are available for functions:
 ```@docs
 Utilities.eval_variables
+Utilities.substitute_variables
 Utilities.remove_variable
 Utilities.all_coefficients
 Utilities.unsafe_add

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -681,6 +681,7 @@ Utilities.scalar_type
 Utilities.promote_operation
 Utilities.operate
 Utilities.operate!
+Utilities.operate_output_index!
 Utilities.vectorize
 ```
 

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -86,8 +86,8 @@ function mapvariables(varmap, f::MOI.AbstractFunctionModification)
     return mapvariables(vi -> varmap[vi], f)
 end
 
-# For performance reason, we assume that the type of the function is unchanged
-# `substitute_variables`.
+# For performance reason, we assume that the type of the function does not
+# change in `substitute_variables`.
 """
     substitute_variables(variable_map::Function, x)
 
@@ -700,7 +700,8 @@ function operate! end
 Returns an `MOI.AbstractVectorFunction` where the function at `output_index`
 is the result of the operation `op` applied to the function at `output_index`
 of `func` and `args`. The functions at output index different to `output_index`
-are the same as the functions at the same output index in `func`.
+are the same as the functions at the same output index in `func`. The first
+argument can be modified.
 """
 function operate_output_index! end
 

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -5,7 +5,9 @@
 """
     AbstractSet
 
-Abstract supertype for set objects used to encode constraints.
+Abstract supertype for set objects used to encode constraints. A set object
+should not contain any [`VariableIndex`](@ref) or [`ConstraintIndex`](@ref)
+as the set is passed unmodifed during [`copy_to`](@ref).
 """
 abstract type AbstractSet end
 


### PR DESCRIPTION
- [x] Change coefficients for offdiag vs diag quadratic terms

This also fixes a few bugs in `MOIU.operate` with quadratic terms

Extracted from https://github.com/JuliaOpt/MathOptInterface.jl/pull/759