### PR TITLE
Generalize tests for `contlinear`

### DIFF
--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -16,7 +16,7 @@ struct TestConfig{T <: Number}
         infeas_certificates::Bool = true, optimal_status = MOI.OPTIMAL,
         basis::Bool = false) where {T <: Number}
         new(atol, rtol, solve, query, modify_lhs, duals, infeas_certificates,
-            optimal_status, basis) 
+            optimal_status, basis)
     end
     TestConfig(;kwargs...) = TestConfig{Float64}(; kwargs...)
 end

--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -10,13 +10,14 @@ struct TestConfig
     # MOI.OPTIMAL or MOI.LOCALLY_SOLVED.
     optimal_status::MOI.TerminationStatusCode
     basis::Bool # can get variable and constraint basis status
+    number_type::Type{<:Number}
     function TestConfig(;
         atol::Float64 = 1e-8, rtol::Float64 = 1e-8, solve::Bool = true,
         query::Bool = true, modify_lhs::Bool = true, duals::Bool = true,
         infeas_certificates::Bool = true, optimal_status = MOI.OPTIMAL,
-        basis::Bool = false)
+        basis::Bool = false, number_type::Type{<:Number} = Float64)
         new(atol, rtol, solve, query, modify_lhs, duals, infeas_certificates,
-            optimal_status, basis)
+            optimal_status, basis, number_type)
     end
 end
 

--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -1,4 +1,4 @@
-struct TestConfig
+struct TestConfig{T <: Number}
     atol::Float64 # absolute tolerance for ...
     rtol::Float64 # relative tolerance for ...
     solve::Bool # optimize and test result
@@ -10,15 +10,15 @@ struct TestConfig
     # MOI.OPTIMAL or MOI.LOCALLY_SOLVED.
     optimal_status::MOI.TerminationStatusCode
     basis::Bool # can get variable and constraint basis status
-    number_type::Type{<:Number}
-    function TestConfig(;
+    function TestConfig{T}(;
         atol::Float64 = 1e-8, rtol::Float64 = 1e-8, solve::Bool = true,
         query::Bool = true, modify_lhs::Bool = true, duals::Bool = true,
         infeas_certificates::Bool = true, optimal_status = MOI.OPTIMAL,
-        basis::Bool = false, number_type::Type{<:Number} = Float64)
+        basis::Bool = false) where {T <: Number}
         new(atol, rtol, solve, query, modify_lhs, duals, infeas_certificates,
-            optimal_status, basis, number_type)
+            optimal_status, basis) 
     end
+    TestConfig(;kwargs...) = TestConfig{Float64}(; kwargs...)
 end
 
 """

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -28,7 +28,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     v = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T))
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], v), zero(T))
     c = MOI.add_constraint(model, cf, MOI.LessThan(one(T)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
@@ -42,7 +42,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T),zero(T),-one(T),zero(T),zero(T),zero(T)], [v; v; v]), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T), zero(T), -one(T), zero(T), zero(T), zero(T)], [v; v; v]), zero(T))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
@@ -94,7 +94,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     # change objective to Max +x
 
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),zero(T)], v), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), zero(T)], v), zero(T))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
@@ -149,7 +149,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         MOI.modify(model, c, MOI.ScalarCoefficientChange{T}(z, one(T)))
     else
         MOI.delete(model, c)
-        cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T),one(T)], v), zero(T))
+        cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T), one(T)], v), zero(T))
         c = MOI.add_constraint(model, cf, MOI.LessThan(one(T)))
     end
 
@@ -245,7 +245,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # x,y >= 0, z = 0
     MOI.delete(model, c)
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
-    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T),zero(T),zero(T),one(T),one(T),one(T),zero(T),zero(T),zero(T)], [v; v; v]), zero(T))
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T), zero(T), zero(T), one(T), one(T), one(T), zero(T), zero(T), zero(T)], [v; v; v]), zero(T))
     c = MOI.add_constraint(model, cf, MOI.EqualTo(T(2)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 0
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}()) == 1
@@ -269,7 +269,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # s.t. x + y + z == 2 (c)
     # x,y >= 0, z = 0
 
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),T(2),zero(T)], v), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), T(2), zero(T)], v), zero(T))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
@@ -392,7 +392,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], [x, y]), zero(T))
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T))
     c = MOI.add_constraint(model, cf, MOI.LessThan(one(T)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
@@ -402,7 +402,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     @test vc2.value == y.value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T),zero(T)], [x, y]), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), zero(T)], [x, y]), zero(T))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
@@ -561,7 +561,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # s.t. zero(T) <= x          (c1)
     #             y <= zero(T)   (c2)
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x,y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
@@ -646,8 +646,8 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x, y]), zero(T))
-    cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),T(2)], [x, y]), zero(T))
+    cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), one(T)], [x, y]), zero(T))
+    cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), T(2)], [x, y]), zero(T))
 
     c1 = MOI.add_constraint(model, cf1, MOI.LessThan(T(4)))
     c2 = MOI.add_constraint(model, cf2, MOI.LessThan(T(4)))
@@ -661,7 +661,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], [x, y]), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
@@ -695,7 +695,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         MOI.modify(model, c1, MOI.ScalarCoefficientChange(y, T(3)))
     else
         MOI.delete(model, c1)
-        cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T))
+        cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), T(3)], [x, y]), zero(T))
         c1 = MOI.add_constraint(model, cf1, MOI.LessThan(T(4)))
     end
 
@@ -890,7 +890,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # s.t. zero(T) <= x          (c1)
     #             y <= zero(T)   (c2)
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x,y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     c1 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), x))], [zero(T)]), MOI.Nonnegatives(1))
@@ -971,7 +971,7 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x,y]), zero(T)), MOI.LessThan(-one(T)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), one(T)], [x, y]), zero(T)), MOI.LessThan(-one(T)))
     bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test bndx.value == x.value
     bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
@@ -1027,7 +1027,7 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T),T(2)], [x,y]), zero(T)), MOI.LessThan(zero(T)))
+    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), T(2)], [x, y]), zero(T)), MOI.LessThan(zero(T)))
     vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test vc1.value == x.value
     vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
@@ -1073,7 +1073,7 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo(zero(T)))
+    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x, y]), zero(T)), MOI.EqualTo(zero(T)))
     vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test vc1.value == x.value
     vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
@@ -1093,7 +1093,7 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.INFEASIBILITY_CERTIFICATE
-            ray = MOI.get(model, MOI.VariablePrimal(), [x,y])
+            ray = MOI.get(model, MOI.VariablePrimal(), [x, y])
             @test ray[1] ≈ ray[2] atol=atol rtol=rtol
         else
             # solver returned nothing
@@ -1207,7 +1207,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
     @test vc[1].value == x.value
     @test vc[2].value == y.value
 
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x,y]), zero(T)), MOI.Interval(T(5), T(10)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)), MOI.Interval(T(5), T(10)))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
@@ -1340,7 +1340,7 @@ function linear10btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: 
     @test vc[1].value == x.value
     @test vc[2].value == y.value
 
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x,y]), zero(T)), MOI.Interval(-one(T), T(10)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)), MOI.Interval(-one(T), T(10)))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
@@ -1418,10 +1418,10 @@ function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     v = MOI.add_variables(model, 2)
 
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan(one(T)))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan(T(2)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], v), zero(T)), MOI.GreaterThan(one(T)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], v), zero(T)), MOI.GreaterThan(T(2)))
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], v), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1469,7 +1469,7 @@ function linear12test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),-T(3)], [x,y]), zero(T)), MOI.LessThan(-T(7)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), -T(3)], [x, y]), zero(T)), MOI.LessThan(-T(7)))
     c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), y)], zero(T)), MOI.LessThan(T(2)))
     bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test bndx.value == x.value
@@ -1520,8 +1520,8 @@ function linear13test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T)), MOI.GreaterThan(one(T)))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo(zero(T)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), T(3)], [x, y]), zero(T)), MOI.GreaterThan(one(T)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x, y]), zero(T)), MOI.EqualTo(zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE
 

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -333,12 +333,12 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
             @test MOI.get(model, MOI.DualStatus(1)) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -T(3)/T(2) atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ T(1)/T(2) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -T(3//2) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ T(1//2) atol=atol rtol=rtol
 
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 0 atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), vc3) ≈ T(3)/T(2) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), vc3) ≈ T(3//2) atol=atol rtol=rtol
         end
     end
 
@@ -674,9 +674,9 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(8)/T(3) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(8//3) atol=atol rtol=rtol
 
-        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(4)/T(3), T(4)/T(3)] atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(4//3), T(4//3)] atol=atol rtol=rtol
     end
 
     # copy and solve again
@@ -1138,7 +1138,7 @@ function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     @test vc12[2].value == y.value
 
     c1 = MOI.add_constraints(model,
-        [MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -T(3)/T(2)], [x, y]), zero(T))],
+        [MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -T(3//2)], [x, y]), zero(T))],
         [MOI.GreaterThan{T}(zero(T))]
     )
 

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -1,7 +1,7 @@
 # Continuous linear problems
 
 # Basic solver, query, resolve
-function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # simple 2 variable, 1 constraint problem
@@ -371,7 +371,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 end
 
 # add_variable (one by one)
-function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # Min -x
@@ -444,7 +444,7 @@ function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 end
 
 # Issue #40 from Gurobi.jl
-function linear3test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear3test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # min  x
@@ -541,7 +541,7 @@ function linear3test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 end
 
 # Modify GreaterThan{T} and LessThan{T} sets as bounds
-function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
 
@@ -612,7 +612,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 end
 
 # Change coeffs, del constr, del var
-function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     #@test MOI.get(model, MOI.SupportsDeleteVariable())
@@ -755,7 +755,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 end
 
 # Modify GreaterThan{T} and LessThan{T} sets as linear constraints
-function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
 
@@ -853,7 +853,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 end
 
 # Modify constants in Nonnegatives and Nonpositives
-function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
 
@@ -953,7 +953,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 end
 
 # infeasible problem
-function linear8atest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear8atest(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # min x
@@ -1009,7 +1009,7 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 end
 
 # unbounded problem
-function linear8btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear8btest(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # min -x-y
@@ -1055,7 +1055,7 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 end
 
 # unbounded problem with unique ray
-function linear8ctest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear8ctest(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # min -x-y
@@ -1103,7 +1103,7 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 end
 
 # add_constraints
-function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     #   maximize 1000 x + 350 y
@@ -1180,7 +1180,7 @@ function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 end
 
 # ranged constraints
-function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     #   maximize x + y
@@ -1313,7 +1313,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 end
 
 # inactive ranged constraints
-function linear10btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear10btest(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     #   minimize x + y
@@ -1372,7 +1372,7 @@ function linear10btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: 
 end
 
 # changing constraint sense
-function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # simple 2 variable, 1 constraint problem
@@ -1450,7 +1450,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 end
 
 # infeasible problem with 2 linear constraints
-function linear12test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear12test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # min x
@@ -1504,7 +1504,7 @@ function linear12test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 end
 
 # feasibility problem
-function linear13test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear13test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # find x, y
@@ -1556,7 +1556,7 @@ function linear13test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 end
 
 # Deletion of vector of variables
-function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # max x + 2y + 3z + 4
@@ -1658,7 +1658,7 @@ function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 end
 
 # Empty vector affine function rows (LQOI Issue #48)
-function linear15test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function linear15test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # minimize 0
@@ -1711,7 +1711,7 @@ end
 
 # This test can be passed by solvers that don't support VariablePrimalStart
 # because copy_to drops start information with a warning.
-function partial_start_test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
+function partial_start_test(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
     # maximize 2x + y

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -4,19 +4,20 @@
 function linear1test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # simple 2 variable, 1 constraint problem
     # min -x
     # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
     #       x, y >= 0   (x, y ∈ Nonnegatives)
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.EqualTo{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.EqualTo{T})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.EqualTo{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     #@test MOI.get(model, MOI.SupportsAddConstraintAfterSolve())
     #@test MOI.get(model, MOI.SupportsAddVariableAfterSolve())
@@ -28,22 +29,22 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     v = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0)
-    c = MOI.add_constraint(model, cf, MOI.LessThan(1.0))
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T))
+    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.GreaterThan(0.0))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.GreaterThan{T}(zero(T)))
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test vc1.value == v[1].value
     # test fallback
-    vc2 = MOI.add_constraint(model, v[2], MOI.GreaterThan(0.0))
+    vc2 = MOI.add_constraint(model, v[2], MOI.GreaterThan{T}(zero(T)))
     @test vc2.value == v[2].value
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
-    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,0.0,-1.0,0.0,0.0,0.0], [v; v; v]), 0.0)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T),zero(T),-one(T),zero(T),zero(T),zero(T)], [v; v; v]), zero(T))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
@@ -52,18 +53,18 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         vrs = MOI.get(model, MOI.ListOfVariableIndices())
         @test vrs == v || vrs == reverse(v)
 
-        @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
 
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
 
         s = MOI.get(model, MOI.ConstraintSet(), c)
-        @test s == MOI.LessThan(1.0)
+        @test s == MOI.LessThan{T}(one(T))
 
         s = MOI.get(model, MOI.ConstraintSet(), vc1)
-        @test s == MOI.GreaterThan(0.0)
+        @test s == MOI.GreaterThan{T}(zero(T))
 
         s = MOI.get(model, MOI.ConstraintSet(), vc2)
-        @test s == MOI.GreaterThan(0.0)
+        @test s == MOI.GreaterThan{T}(zero(T))
     end
 
     if config.solve
@@ -94,12 +95,12 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 
     # change objective to Max +x
 
-    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,0.0], v), 0.0)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),zero(T)], v), zero(T))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.query
-        @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     end
 
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
@@ -138,28 +139,28 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         # Test that the modification of v has not affected the model
         vars = map(t -> t.variable_index, MOI.get(model, MOI.ConstraintFunction(), c).terms)
         @test vars == [v[1], v[2]] || vars == [v[2], v[1]]
-        @test MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[1])], 0.0) ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), v[1])], zero(T)) ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     end
 
-    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.GreaterThan(0.0))
+    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.GreaterThan{T}(zero(T)))
     @test vc3.value == v[3].value
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 3
 
     if config.modify_lhs
-        MOI.modify(model, c, MOI.ScalarCoefficientChange{Float64}(z, 1.0))
+        MOI.modify(model, c, MOI.ScalarCoefficientChange{T}(z, one(T)))
     else
         MOI.delete(model, c)
-        cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0,1.0], v), 0.0)
-        c = MOI.add_constraint(model, cf, MOI.LessThan(1.0))
+        cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T),one(T)], v), zero(T))
+        c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
     end
 
     MOI.modify(model,
-        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-        MOI.ScalarCoefficientChange{Float64}(z, 2.0)
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+        MOI.ScalarCoefficientChange{T}(z, T(2))
     )
 
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 3
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 3
 
     if config.solve
         MOI.optimize!(model)
@@ -192,7 +193,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x + y + z <= 1
     # x >= -1
     # y,z >= 0
-    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(-1.0))
+    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan{T}(-one(T)))
 
     if config.solve
         MOI.optimize!(model)
@@ -217,13 +218,13 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # max x + 2z
     # s.t. x + y + z <= 1
     # x, y >= 0, z = 0 (vc3)
-    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(0.0))
+    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan{T}(zero(T)))
 
     MOI.delete(model, vc3)
 
-    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.EqualTo(0.0))
+    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.EqualTo{T}(zero(T)))
     @test vc3.value == v[3].value
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
     if config.solve
         MOI.optimize!(model)
@@ -245,10 +246,10 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # x,y >= 0, z = 0
     MOI.delete(model, c)
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
-    cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0,0.0,0.0,1.0,1.0,1.0,0.0,0.0,0.0], [v; v; v]), 0.0)
-    c = MOI.add_constraint(model, cf, MOI.EqualTo(2.0))
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T),zero(T),zero(T),one(T),one(T),one(T),zero(T),zero(T),zero(T)], [v; v; v]), zero(T))
+    c = MOI.add_constraint(model, cf, MOI.EqualTo{T}(T(2)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 0
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}()) == 1
 
     if config.solve
         MOI.optimize!(model)
@@ -269,12 +270,12 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # s.t. x + y + z == 2 (c)
     # x,y >= 0, z = 0
 
-    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,2.0,0.0], v), 0.0)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),T(2),zero(T)], v), zero(T))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.query
-        @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+        @test objf ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     end
 
     if config.solve
@@ -297,14 +298,14 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # x - y >= 0 (c2)
     # x,y >= 0 (vc1,vc2), z = 0 (vc3)
 
-    cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0, 0.0], v), 0.0)
-    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(0.0))
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}()) == 1
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 0
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{Float64}}()) == 1
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 0
+    cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T), zero(T)], v), zero(T))
+    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan{T}(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 0
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{T}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{T}}()) == 0
 
     if config.solve
         MOI.optimize!(model)
@@ -333,12 +334,12 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
             @test MOI.get(model, MOI.DualStatus(1)) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
-            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1.5 atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ 0.5 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -T(3)/T(2) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ T(1)/T(2) atol=atol rtol=rtol
 
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ 0 atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), vc3) ≈ 1.5 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), vc3) ≈ T(3)/T(2) atol=atol rtol=rtol
         end
     end
 
@@ -352,9 +353,9 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
     # - y >= 0
     # y >= 0, z = 0
 
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
     MOI.delete(model, v[1])
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 1
 
     if config.query
         err = MOI.InvalidIndex(vc1)
@@ -362,11 +363,11 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
         @test_throws err MOI.get(model, MOI.ConstraintFunction(), vc1)
         @test_throws err MOI.get(model, MOI.ConstraintSet(), vc1)
 
-        @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0, 0.0], [v[2], z]), 0.0)
+        @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), zero(T)], [v[2], z]), zero(T))
 
         vrs = MOI.get(model, MOI.ListOfVariableIndices())
         @test vrs == [v[2], z] || vrs == [z, v[2]]
-        @test MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()) ≈ MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 0.0], [v[2], z]), 0.0)
+        @test MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}()) ≈ MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), zero(T)], [v[2], z]), zero(T))
     end
 end
 
@@ -374,15 +375,16 @@ end
 function linear2test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # Min -x
     # s.t. x + y <= 1
     # x, y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -392,18 +394,18 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
 
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [x, y]), 0.0)
-    c = MOI.add_constraint(model, cf, MOI.LessThan(1.0))
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], [x, y]), zero(T))
+    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
     @test vc2.value == y.value
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
-    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0,0.0], [x, y]), 0.0)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T),zero(T)], [x, y]), zero(T))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
@@ -447,17 +449,18 @@ end
 function linear3test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # min  x
     # s.t. x >= 0
     #      x >= 3
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -465,16 +468,16 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
-    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test vc.value == x.value
-    cf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    c = MOI.add_constraint(model, cf, MOI.GreaterThan(3.0))
+    cf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
+    c = MOI.add_constraint(model, cf, MOI.GreaterThan{T}(T(3)))
 
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 1
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.GreaterThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
 
-    objf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    objf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -506,16 +509,16 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
-    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(0.0))
+    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan{T}(zero(T)))
     @test vc.value == x.value
-    cf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    c = MOI.add_constraint(model, cf, MOI.LessThan(3.0))
+    cf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
+    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(T(3)))
 
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{Float64}}()) == 1
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{T}}()) == 1
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
-    objf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    objf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -540,16 +543,17 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
-# Modify GreaterThan and LessThan sets as bounds
+# Modify GreaterThan{T} and LessThan{T} sets as bounds
 function linear4test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -558,15 +562,15 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
     y = MOI.add_variable(model)
 
     # Min  x - y
-    # s.t. 0.0 <= x          (c1)
-    #             y <= 0.0   (c2)
+    # s.t. zero(T) <= x          (c1)
+    #             y <= zero(T)   (c2)
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x,y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x,y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
-    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test c1.value == x.value
-    c2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.LessThan(0.0))
+    c2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.LessThan{T}(zero(T)))
     @test c2.value == y.value
 
     if config.solve
@@ -577,37 +581,37 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
     end
 
     # Min  x - y
-    # s.t. 100.0 <= x
-    #               y <= 0.0
-    MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(100.0))
+    # s.t. T(100) <= x
+    #               y <= zero(T)
+    MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan{T}(T(100)))
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
     end
 
     # Min  x - y
-    # s.t. 100.0 <= x
-    #               y <= -100.0
-    MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan(-100.0))
+    # s.t. T(100) <= x
+    #               y <= -T(100)
+    MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan{T}(-T(100)))
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(200) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -T(100) atol=atol rtol=rtol
     end
 end
 
@@ -615,6 +619,7 @@ end
 function linear5test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     #@test MOI.get(model, MOI.SupportsDeleteVariable())
     #####################################
     # Start from simple LP
@@ -633,10 +638,10 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #   solution: x = 1.3333333, y = 1.3333333, objv = 2.66666666
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -646,23 +651,23 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,1.0], [x, y]), 0.0)
-    cf2 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,2.0], [x, y]), 0.0)
+    cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x, y]), zero(T))
+    cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),T(2)], [x, y]), zero(T))
 
-    c1 = MOI.add_constraint(model, cf1, MOI.LessThan(4.0))
-    c2 = MOI.add_constraint(model, cf2, MOI.LessThan(4.0))
+    c1 = MOI.add_constraint(model, cf1, MOI.LessThan{T}(T(4)))
+    c2 = MOI.add_constraint(model, cf2, MOI.LessThan{T}(T(4)))
 
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{Float64},MOI.LessThan{Float64}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 2
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
     @test vc2.value == y.value
 
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}()) == 2
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
-    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], [x, y]), 0.0)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], [x, y]), zero(T))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -674,9 +679,9 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 8/3 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(8)/T(3) atol=atol rtol=rtol
 
-        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [4/3, 4/3] atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(4)/T(3), T(4)/T(3)] atol=atol rtol=rtol
     end
 
     # copy and solve again
@@ -692,11 +697,11 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
     #   solution: x = 2, y = 0, objv = 2
 
     if config.modify_lhs
-        MOI.modify(model, c1, MOI.ScalarCoefficientChange(y, 3.0))
+        MOI.modify(model, c1, MOI.ScalarCoefficientChange(y, T(3)))
     else
         MOI.delete(model, c1)
-        cf1 = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0)
-        c1 = MOI.add_constraint(model, cf1, MOI.LessThan(4.0))
+        cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T))
+        c1 = MOI.add_constraint(model, cf1, MOI.LessThan{T}(T(4)))
     end
 
     if config.solve
@@ -708,7 +713,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [2.0, 0.0] atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(2), zero(T)] atol=atol rtol=rtol
     end
 
     # delconstrs and solve
@@ -729,7 +734,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
-        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [4.0, 0.0] atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(4), zero(T)] atol=atol rtol=rtol
     end
 
     # delvars and solve
@@ -750,20 +755,21 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 2.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ T(2) atol=atol rtol=rtol
     end
 end
 
-# Modify GreaterThan and LessThan sets as linear constraints
+# Modify GreaterThan{T} and LessThan{T} sets as linear constraints
 function linear6test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -772,26 +778,26 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
     y = MOI.add_variable(model)
 
     # Min  x - y
-    # s.t. 0.0 <= x          (c1)
-    #             y <= 0.0   (c2)
+    # s.t. zero(T) <= x          (c1)
+    #             y <= zero(T)   (c2)
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x, y]),
-                                     0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x, y]),
+                                     zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
-    fx = convert(MOI.ScalarAffineFunction{Float64},
+    fx = convert(MOI.ScalarAffineFunction{T},
                  MOI.SingleVariable(x))
-    c1 = MOI.add_constraint(model, fx, MOI.GreaterThan(0.0))
-    fy = convert(MOI.ScalarAffineFunction{Float64},
+    c1 = MOI.add_constraint(model, fx, MOI.GreaterThan{T}(zero(T)))
+    fy = convert(MOI.ScalarAffineFunction{T},
                  MOI.SingleVariable(y))
-    c2 = MOI.add_constraint(model, fy, MOI.LessThan(0.0))
+    c2 = MOI.add_constraint(model, fy, MOI.LessThan{T}(zero(T)))
 
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c1) ≈ fx
-        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan(0.0)
+        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(zero(T))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ fy
-        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan(0.0)
+        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(zero(T))
     end
 
     if config.solve
@@ -802,21 +808,21 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
     end
 
     # Min  x - y
-    # s.t. 100.0 <= x
-    #               y <= 0.0
-    MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(100.0))
+    # s.t. T(100) <= x
+    #               y <= zero(T)
+    MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan{T}(T(100)))
 
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c1) ≈ fx
-        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan(100.0)
+        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(T(100))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ fy
-        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan(0.0)
+        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(zero(T))
     end
 
     if config.solve
@@ -824,21 +830,21 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
     end
 
     # Min  x - y
-    # s.t. 100.0 <= x
-    #               y <= -100.0
-    MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan(-100.0))
+    # s.t. T(100) <= x
+    #               y <= -T(100)
+    MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan{T}(-T(100)))
 
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c1) ≈ fx
-        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan(100.0)
+        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(T(100))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ fy
-        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan(-100.0)
+        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(-T(100))
     end
 
     if config.solve
@@ -846,9 +852,9 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(200) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -T(100) atol=atol rtol=rtol
     end
 end
 
@@ -856,6 +862,7 @@ end
 function linear7test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
 
     # Min  x - y
     # s.t. bx <= x          (c1)
@@ -875,10 +882,10 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     # i.e. z == w == 1
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives)
-    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives)
+    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{T}, MOI.Nonnegatives)
+    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{T}, MOI.Nonpositives)
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -887,14 +894,14 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
     y = MOI.add_variable(model)
 
     # Min  x - y
-    # s.t. 0.0 <= x          (c1)
-    #             y <= 0.0   (c2)
+    # s.t. zero(T) <= x          (c1)
+    #             y <= zero(T)   (c2)
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.0], [x,y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x,y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
-    c1 = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [0.0]), MOI.Nonnegatives(1))
-    c2 = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [0.0]), MOI.Nonpositives(1))
+    c1 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), x))], [zero(T)]), MOI.Nonnegatives(1))
+    c2 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), y))], [zero(T)]), MOI.Nonpositives(1))
 
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
@@ -904,20 +911,20 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
     end
 
     # Min  x - y
-    # s.t. 100.0 <= x
-    #               y <= 0.0
+    # s.t. T(100) <= x
+    #               y <= zero(T)
 
     if config.modify_lhs
-        MOI.modify(model, c1, MOI.VectorConstantChange([-100.0]))
+        MOI.modify(model, c1, MOI.VectorConstantChange([-T(100)]))
     else
         MOI.delete(model, c1)
-        c1 = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, x))], [-100.0]), MOI.Nonnegatives(1))
+        c1 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), x))], [-T(100)]), MOI.Nonnegatives(1))
     end
 
     if config.solve
@@ -925,20 +932,20 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
     end
 
     # Min  x - y
-    # s.t. 100.0 <= x
-    #               y <= -100.0
+    # s.t. T(100) <= x
+    #               y <= -T(100)
 
     if config.modify_lhs
-        MOI.modify(model, c2, MOI.VectorConstantChange([100.0]))
+        MOI.modify(model, c2, MOI.VectorConstantChange([T(100)]))
     else
         MOI.delete(model, c2)
-        c2 = MOI.add_constraint(model, MOI.VectorAffineFunction([MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, y))], [100.0]), MOI.Nonpositives(1))
+        c2 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), y))], [T(100)]), MOI.Nonpositives(1))
     end
 
     if config.solve
@@ -946,9 +953,9 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 200.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 100.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -100.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(200) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -T(100) atol=atol rtol=rtol
     end
 end
 
@@ -956,28 +963,29 @@ end
 function linear8atest(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # min x
     # s.t. 2x+y <= -1
     # x,y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,1.0], [x,y]), 0.0), MOI.LessThan(-1.0))
-    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x,y]), zero(T)), MOI.LessThan{T}(-one(T)))
+    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test bndx.value == x.value
-    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
     @test bndy.value == y.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1012,28 +1020,29 @@ end
 function linear8btest(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # min -x-y
     # s.t. -x+2y <= 0
     # x,y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0,2.0], [x,y]), 0.0), MOI.LessThan(0.0))
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T),T(2)], [x,y]), zero(T)), MOI.LessThan{T}(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
     @test vc2.value == y.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0, -1.0], [x, y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), -one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1058,28 +1067,29 @@ end
 function linear8ctest(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # min -x-y
     # s.t. x-y == 0
     # x,y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.EqualTo{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,-1.0], [x,y]), 0.0), MOI.EqualTo(0.0))
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo{T}(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
     @test vc2.value == y.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([-1.0, -1.0], [x, y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), -one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1106,6 +1116,7 @@ end
 function linear9test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     #   maximize 1000 x + 350 y
     #
     #       s.t.                x >= 30
@@ -1118,11 +1129,11 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
     #   objv: 71818.1818
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -1132,29 +1143,29 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
 
     vc12 = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan(30.0), MOI.GreaterThan(0.0)]
+        [MOI.GreaterThan{T}(T(30)), MOI.GreaterThan{T}(zero(T))]
     )
     @test vc12[1].value == x.value
     @test vc12[2].value == y.value
 
     c1 = MOI.add_constraints(model,
-        [MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, -1.5], [x, y]), 0.0)],
-        [MOI.GreaterThan(0.0)]
+        [MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -T(3)/T(2)], [x, y]), zero(T))],
+        [MOI.GreaterThan{T}(zero(T))]
     )
 
     c23 = MOI.add_constraints(model,
         [
-            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([12.0, 8.0], [x, y]), 0.0),
-            MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1_000.0, 300.0], [x, y]), 0.0)
+            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(12), T(8)], [x, y]), zero(T)),
+            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1_000), T(300)], [x, y]), zero(T))
         ],
         [
-            MOI.LessThan(1_000.0),
-            MOI.LessThan(70_000.0)
+            MOI.LessThan{T}(T(1_000)),
+            MOI.LessThan{T}(T(70_000))
         ]
     )
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-                      MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1_000.0, 350.0], [x, y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+                      MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1_000), T(350)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -1183,16 +1194,17 @@ end
 function linear10test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     #   maximize x + y
     #
     #       s.t.  5 <= x + y <= 10
     #                  x,  y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.Interval{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -1202,14 +1214,14 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
 
     vc = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan(0.0), MOI.GreaterThan(0.0)]
+        [MOI.GreaterThan{T}(zero(T)), MOI.GreaterThan{T}(zero(T))]
     )
     @test vc[1].value == x.value
     @test vc[2].value == y.value
 
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x,y]), 0.0), MOI.Interval(5.0, 10.0))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x,y]), zero(T)), MOI.Interval(T(5), T(10)))
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -1219,13 +1231,13 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(10) atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 10.0 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(10) atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
         end
 
@@ -1237,7 +1249,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         end
     end
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1245,11 +1257,11 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(5) atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 5 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 5.0 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(5) atol=atol rtol=rtol
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
@@ -1263,10 +1275,10 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         end
     end
 
-    MOI.set(model, MOI.ConstraintSet(), c, MOI.Interval(2.0, 12.0))
+    MOI.set(model, MOI.ConstraintSet(), c, MOI.Interval(T(2), T(12)))
 
     if config.query
-        @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.Interval(2.0, 12.0)
+        @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.Interval(T(2), T(12))
     end
 
     if config.solve
@@ -1274,7 +1286,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
 
         if config.basis
@@ -1287,12 +1299,12 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
         end
     end
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -1300,7 +1312,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 12.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(12) atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 12 atol=atol rtol=rtol
 
         if config.basis
@@ -1316,16 +1328,17 @@ end
 function linear10btest(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     #   minimize x + y
     #
     #       s.t.  -1 <= x + y <= 10
     #                   x,  y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.Interval{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -1335,14 +1348,14 @@ function linear10btest(model::MOI.ModelLike, config::TestConfig)
 
     vc = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan(0.0), MOI.GreaterThan(0.0)]
+        [MOI.GreaterThan{T}(zero(T)), MOI.GreaterThan{T}(zero(T))]
     )
     @test vc[1].value == x.value
     @test vc[2].value == y.value
 
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x,y]), 0.0), MOI.Interval(-1.0, 10.0))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x,y]), zero(T)), MOI.Interval(-one(T), T(10)))
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1352,15 +1365,15 @@ function linear10btest(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ zero(T) atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 0.0 atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), vc[1]) ≈ 1.0 atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), vc[2]) ≈ 1.0 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ zero(T) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), vc[1]) ≈ one(T) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), vc[2]) ≈ one(T) atol=atol rtol=rtol
         end
 
         if config.basis
@@ -1375,6 +1388,7 @@ end
 function linear11test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # simple 2 variable, 1 constraint problem
     #
     # starts with
@@ -1408,20 +1422,20 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
     # sol: w = 1, z = 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     v = MOI.add_variables(model, 2)
 
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.GreaterThan(1.0))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0), MOI.GreaterThan(2.0))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan{T}(one(T)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan{T}(T(2)))
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,1.0], v), 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1431,12 +1445,12 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
     end
 
-    c3 = MOI.transform(model, c2, MOI.LessThan(2.0))
+    c3 = MOI.transform(model, c2, MOI.LessThan{T}(T(2)))
 
-    @test isa(c3, MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}})
+    @test isa(c3, MOI.ConstraintIndex{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}})
     @test MOI.is_valid(model, c2) == false
     @test MOI.is_valid(model, c3) == true
 
@@ -1445,7 +1459,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ one(T) atol=atol rtol=rtol
     end
 end
 
@@ -1453,30 +1467,31 @@ end
 function linear12test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # min x
     # s.t. 2x-3y <= -7
     #      y <= 2
     # x,y >= 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,-3.0], [x,y]), 0.0), MOI.LessThan(-7.0))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, y)], 0.0), MOI.LessThan(2.0))
-    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),-T(3)], [x,y]), zero(T)), MOI.LessThan{T}(-T(7)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), y)], zero(T)), MOI.LessThan{T}(T(2)))
+    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test bndx.value == x.value
-    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
     @test bndy.value == y.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1507,21 +1522,22 @@ end
 function linear13test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # find x, y
     # s.t. 2x + 3y >= 1
     #      x - y == 0
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.EqualTo{T})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0,3.0], [x,y]), 0.0), MOI.GreaterThan(1.0))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0,-1.0], [x,y]), 0.0), MOI.EqualTo(0.0))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T)), MOI.GreaterThan{T}(one(T)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo{T}(zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE
 
@@ -1539,11 +1555,11 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
         ysol = MOI.get(model, MOI.VariablePrimal(), y)
 
         c1sol = 2 * xsol + 3 * ysol
-        @test c1sol >= 1 || isapprox(c1sol, 1.0, atol=atol, rtol=rtol)
+        @test c1sol >= 1 || isapprox(c1sol, one(T), atol=atol, rtol=rtol)
         @test xsol - ysol ≈ 0 atol=atol rtol=rtol
 
         c1primval = MOI.get(model, MOI.ConstraintPrimal(), c1)
-        @test c1primval >= 1 || isapprox(c1sol, 1.0, atol=atol, rtol=rtol)
+        @test c1primval >= 1 || isapprox(c1sol, one(T), atol=atol, rtol=rtol)
 
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 0 atol=atol rtol=rtol
 
@@ -1559,33 +1575,34 @@ end
 function linear14test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # max x + 2y + 3z + 4
     # s.t. 3x + 2y + z <= 2
     #      x, y, z >= 0
     #      z <= 1
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{T}, MOI.LessThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{T})
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     x, y, z = MOI.add_variables(model, 3)
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([3.0, 2.0, 1.0], [x, y, z]), 0.0), MOI.LessThan(2.0))
-    clbx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(3), T(2), one(T)], [x, y, z]), zero(T)), MOI.LessThan{T}(T(2)))
+    clbx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
     @test clbx.value == x.value
-    clby = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
+    clby = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
     @test clby.value == y.value
-    clbz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.GreaterThan(0.0))
+    clbz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.GreaterThan{T}(zero(T)))
     @test clbz.value == z.value
-    cubz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.LessThan(1.0))
+    cubz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.LessThan{T}(one(T)))
     @test cubz.value == z.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], [x, y, z]), 4.0))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), T(2), T(3)], [x, y, z]), T(4)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -1661,13 +1678,14 @@ end
 function linear15test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # minimize 0
     # s.t. 0 == 0
     #      x == 1
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.Zeros)
+    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{T}, MOI.Zeros)
 
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -1677,16 +1695,16 @@ function linear15test(model::MOI.ModelLike, config::TestConfig)
     # one term, belonging to the second row. The first row,
     # which is empty, is essentially a constraint that 0 == 0.
     c = MOI.add_constraint(model,
-        MOI.VectorAffineFunction(
-            MOI.VectorAffineTerm.(2, MOI.ScalarAffineTerm.([1.0], x)),
+        MOI.VectorAffineFunction{T}(
+            MOI.VectorAffineTerm{T}.(2, MOI.ScalarAffineTerm{T}.([one(T)], x)),
             zeros(2)
         ),
         MOI.Zeros(2)
     )
 
     MOI.set(model,
-        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
-        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([0.0], x), 0.0))
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+        MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T)], x), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1714,34 +1732,35 @@ end
 function partial_start_test(model::MOI.ModelLike, config::TestConfig)
     atol = config.atol
     rtol = config.rtol
+    T = config.number_type
     # maximize 2x + y
     # s.t. x + y <= 1
     #      x, y >= 0
-    #      x starts at 1.0. Start point for y is unspecified.
+    #      x starts at one(T). Start point for y is unspecified.
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
 
-    MOI.set(model, MOI.VariablePrimalStart(), x, 1.0)
+    MOI.set(model, MOI.VariablePrimalStart(), x, one(T))
 
-    MOI.add_constraint(model, x, MOI.GreaterThan(0.0))
-    MOI.add_constraint(model, y, MOI.GreaterThan(0.0))
-    obj = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 1.0], [x, y]),
-                                   0.0)
+    MOI.add_constraint(model, x, MOI.GreaterThan{T}(zero(T)))
+    MOI.add_constraint(model, y, MOI.GreaterThan{T}(zero(T)))
+    obj = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), one(T)], [x, y]),
+                                   zero(T))
     MOI.set(model, MOI.ObjectiveFunction{typeof(obj)}(), obj)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-    x_plus_y = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, [x, y]), 0.0)
-    MOI.add_constraint(model, x_plus_y, MOI.LessThan(1.0))
+    x_plus_y = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.(one(T), [x, y]), zero(T))
+    MOI.add_constraint(model, x_plus_y, MOI.LessThan{T}(one(T)))
 
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ one(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
     end
 end
 

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -1,10 +1,9 @@
 # Continuous linear problems
 
 # Basic solver, query, resolve
-function linear1test(model::MOI.ModelLike, config::TestConfig)
+function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # simple 2 variable, 1 constraint problem
     # min -x
     # st   x + y <= 1   (x + y - 1 ∈ Nonpositives)
@@ -372,10 +371,9 @@ function linear1test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # add_variable (one by one)
-function linear2test(model::MOI.ModelLike, config::TestConfig)
+function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # Min -x
     # s.t. x + y <= 1
     # x, y >= 0
@@ -446,10 +444,9 @@ function linear2test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # Issue #40 from Gurobi.jl
-function linear3test(model::MOI.ModelLike, config::TestConfig)
+function linear3test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # min  x
     # s.t. x >= 0
     #      x >= 3
@@ -544,10 +541,9 @@ function linear3test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # Modify GreaterThan{T} and LessThan{T} sets as bounds
-function linear4test(model::MOI.ModelLike, config::TestConfig)
+function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
@@ -616,10 +612,9 @@ function linear4test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # Change coeffs, del constr, del var
-function linear5test(model::MOI.ModelLike, config::TestConfig)
+function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     #@test MOI.get(model, MOI.SupportsDeleteVariable())
     #####################################
     # Start from simple LP
@@ -760,10 +755,9 @@ function linear5test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # Modify GreaterThan{T} and LessThan{T} sets as linear constraints
-function linear6test(model::MOI.ModelLike, config::TestConfig)
+function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
@@ -859,10 +853,9 @@ function linear6test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # Modify constants in Nonnegatives and Nonpositives
-function linear7test(model::MOI.ModelLike, config::TestConfig)
+function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
 
     # Min  x - y
     # s.t. bx <= x          (c1)
@@ -960,10 +953,9 @@ function linear7test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # infeasible problem
-function linear8atest(model::MOI.ModelLike, config::TestConfig)
+function linear8atest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # min x
     # s.t. 2x+y <= -1
     # x,y >= 0
@@ -1017,10 +1009,9 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig)
 end
 
 # unbounded problem
-function linear8btest(model::MOI.ModelLike, config::TestConfig)
+function linear8btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # min -x-y
     # s.t. -x+2y <= 0
     # x,y >= 0
@@ -1064,10 +1055,9 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig)
 end
 
 # unbounded problem with unique ray
-function linear8ctest(model::MOI.ModelLike, config::TestConfig)
+function linear8ctest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # min -x-y
     # s.t. x-y == 0
     # x,y >= 0
@@ -1113,10 +1103,9 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig)
 end
 
 # add_constraints
-function linear9test(model::MOI.ModelLike, config::TestConfig)
+function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     #   maximize 1000 x + 350 y
     #
     #       s.t.                x >= 30
@@ -1191,10 +1180,9 @@ function linear9test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # ranged constraints
-function linear10test(model::MOI.ModelLike, config::TestConfig)
+function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     #   maximize x + y
     #
     #       s.t.  5 <= x + y <= 10
@@ -1325,10 +1313,9 @@ function linear10test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # inactive ranged constraints
-function linear10btest(model::MOI.ModelLike, config::TestConfig)
+function linear10btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     #   minimize x + y
     #
     #       s.t.  -1 <= x + y <= 10
@@ -1385,10 +1372,9 @@ function linear10btest(model::MOI.ModelLike, config::TestConfig)
 end
 
 # changing constraint sense
-function linear11test(model::MOI.ModelLike, config::TestConfig)
+function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # simple 2 variable, 1 constraint problem
     #
     # starts with
@@ -1464,10 +1450,9 @@ function linear11test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # infeasible problem with 2 linear constraints
-function linear12test(model::MOI.ModelLike, config::TestConfig)
+function linear12test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # min x
     # s.t. 2x-3y <= -7
     #      y <= 2
@@ -1519,10 +1504,9 @@ function linear12test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # feasibility problem
-function linear13test(model::MOI.ModelLike, config::TestConfig)
+function linear13test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # find x, y
     # s.t. 2x + 3y >= 1
     #      x - y == 0
@@ -1572,10 +1556,9 @@ function linear13test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # Deletion of vector of variables
-function linear14test(model::MOI.ModelLike, config::TestConfig)
+function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # max x + 2y + 3z + 4
     # s.t. 3x + 2y + z <= 2
     #      x, y, z >= 0
@@ -1675,10 +1658,9 @@ function linear14test(model::MOI.ModelLike, config::TestConfig)
 end
 
 # Empty vector affine function rows (LQOI Issue #48)
-function linear15test(model::MOI.ModelLike, config::TestConfig)
+function linear15test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # minimize 0
     # s.t. 0 == 0
     #      x == 1
@@ -1729,10 +1711,9 @@ end
 
 # This test can be passed by solvers that don't support VariablePrimalStart
 # because copy_to drops start information with a warning.
-function partial_start_test(model::MOI.ModelLike, config::TestConfig)
+function partial_start_test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Number}
     atol = config.atol
     rtol = config.rtol
-    T = config.number_type
     # maximize 2x + y
     # s.t. x + y <= 1
     #      x, y >= 0

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -28,21 +28,21 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     v = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T))
-    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(1)], v), T(0))
+    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(T(1)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.GreaterThan{T}(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.GreaterThan{T}(T(0)))
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test vc1.value == v[1].value
     # test fallback
-    vc2 = MOI.add_constraint(model, v[2], MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, v[2], MOI.GreaterThan{T}(T(0)))
     @test vc2.value == v[2].value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T),zero(T),-one(T),zero(T),zero(T),zero(T)], [v; v; v]), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(0),T(0),-T(1),T(0),T(0),T(0)], [v; v; v]), T(0))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
@@ -57,13 +57,13 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
 
         s = MOI.get(model, MOI.ConstraintSet(), c)
-        @test s == MOI.LessThan{T}(one(T))
+        @test s == MOI.LessThan{T}(T(1))
 
         s = MOI.get(model, MOI.ConstraintSet(), vc1)
-        @test s == MOI.GreaterThan{T}(zero(T))
+        @test s == MOI.GreaterThan{T}(T(0))
 
         s = MOI.get(model, MOI.ConstraintSet(), vc2)
-        @test s == MOI.GreaterThan{T}(zero(T))
+        @test s == MOI.GreaterThan{T}(T(0))
     end
 
     if config.solve
@@ -94,7 +94,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     # change objective to Max +x
 
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),zero(T)], v), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(0)], v), T(0))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
@@ -138,19 +138,19 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         # Test that the modification of v has not affected the model
         vars = map(t -> t.variable_index, MOI.get(model, MOI.ConstraintFunction(), c).terms)
         @test vars == [v[1], v[2]] || vars == [v[2], v[1]]
-        @test MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), v[1])], zero(T)) ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
+        @test MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(T(1), v[1])], T(0)) ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     end
 
-    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.GreaterThan{T}(zero(T)))
+    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.GreaterThan{T}(T(0)))
     @test vc3.value == v[3].value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 3
 
     if config.modify_lhs
-        MOI.modify(model, c, MOI.ScalarCoefficientChange{T}(z, one(T)))
+        MOI.modify(model, c, MOI.ScalarCoefficientChange{T}(z, T(1)))
     else
         MOI.delete(model, c)
-        cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T),one(T)], v), zero(T))
-        c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
+        cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(1),T(1)], v), T(0))
+        c = MOI.add_constraint(model, cf, MOI.LessThan{T}(T(1)))
     end
 
     MOI.modify(model,
@@ -192,7 +192,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # s.t. x + y + z <= 1
     # x >= -1
     # y,z >= 0
-    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan{T}(-one(T)))
+    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan{T}(-T(1)))
 
     if config.solve
         MOI.optimize!(model)
@@ -217,11 +217,11 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # max x + 2z
     # s.t. x + y + z <= 1
     # x, y >= 0, z = 0 (vc3)
-    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan{T}(zero(T)))
+    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan{T}(T(0)))
 
     MOI.delete(model, vc3)
 
-    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.EqualTo{T}(zero(T)))
+    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.EqualTo{T}(T(0)))
     @test vc3.value == v[3].value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
@@ -245,7 +245,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # x,y >= 0, z = 0
     MOI.delete(model, c)
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
-    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T),zero(T),zero(T),one(T),one(T),one(T),zero(T),zero(T),zero(T)], [v; v; v]), zero(T))
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(0),T(0),T(0),T(1),T(1),T(1),T(0),T(0),T(0)], [v; v; v]), T(0))
     c = MOI.add_constraint(model, cf, MOI.EqualTo{T}(T(2)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 0
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}()) == 1
@@ -269,7 +269,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # s.t. x + y + z == 2 (c)
     # x,y >= 0, z = 0
 
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),T(2),zero(T)], v), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(2),T(0)], v), T(0))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
@@ -297,8 +297,8 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # x - y >= 0 (c2)
     # x,y >= 0 (vc1,vc2), z = 0 (vc3)
 
-    cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T), zero(T)], v), zero(T))
-    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan{T}(zero(T)))
+    cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), -T(1), T(0)], v), T(0))
+    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan{T}(T(0)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 0
@@ -362,11 +362,11 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         @test_throws err MOI.get(model, MOI.ConstraintFunction(), vc1)
         @test_throws err MOI.get(model, MOI.ConstraintSet(), vc1)
 
-        @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), zero(T)], [v[2], z]), zero(T))
+        @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-T(1), T(0)], [v[2], z]), T(0))
 
         vrs = MOI.get(model, MOI.ListOfVariableIndices())
         @test vrs == [v[2], z] || vrs == [z, v[2]]
-        @test MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}()) ≈ MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), zero(T)], [v[2], z]), zero(T))
+        @test MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}()) ≈ MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), T(0)], [v[2], z]), T(0))
     end
 end
 
@@ -392,17 +392,17 @@ function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], [x, y]), zero(T))
-    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(1)], [x, y]), T(0))
+    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(T(1)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(T(0)))
     @test vc2.value == y.value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T),zero(T)], [x, y]), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-T(1),T(0)], [x, y]), T(0))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
@@ -465,15 +465,15 @@ function linear3test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
-    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test vc.value == x.value
-    cf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
+    cf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(T(1), x)], T(0))
     c = MOI.add_constraint(model, cf, MOI.GreaterThan{T}(T(3)))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
 
-    objf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
+    objf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(T(1), x)], T(0))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
@@ -506,15 +506,15 @@ function linear3test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
-    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan{T}(zero(T)))
+    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan{T}(T(0)))
     @test vc.value == x.value
-    cf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
+    cf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(T(1), x)], T(0))
     c = MOI.add_constraint(model, cf, MOI.LessThan{T}(T(3)))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{T}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
-    objf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
+    objf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(T(1), x)], T(0))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
@@ -558,15 +558,15 @@ function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     y = MOI.add_variable(model)
 
     # Min  x - y
-    # s.t. zero(T) <= x          (c1)
-    #             y <= zero(T)   (c2)
+    # s.t. T(0) <= x          (c1)
+    #             y <= T(0)   (c2)
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x,y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), -T(1)], [x,y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
-    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test c1.value == x.value
-    c2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.LessThan{T}(zero(T)))
+    c2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.LessThan{T}(T(0)))
     @test c2.value == y.value
 
     if config.solve
@@ -577,14 +577,14 @@ function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ zero(T) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ zero(T) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(0) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(0) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ T(0) atol=atol rtol=rtol
     end
 
     # Min  x - y
     # s.t. T(100) <= x
-    #               y <= zero(T)
+    #               y <= T(0)
     MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan{T}(T(100)))
     if config.solve
         MOI.optimize!(model)
@@ -593,7 +593,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(100) atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ T(0) atol=atol rtol=rtol
     end
 
     # Min  x - y
@@ -646,22 +646,22 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
-    cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x, y]), zero(T))
-    cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),T(2)], [x, y]), zero(T))
+    cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(1)], [x, y]), T(0))
+    cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(2)], [x, y]), T(0))
 
     c1 = MOI.add_constraint(model, cf1, MOI.LessThan{T}(T(4)))
     c2 = MOI.add_constraint(model, cf2, MOI.LessThan{T}(T(4)))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 2
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(T(0)))
     @test vc2.value == y.value
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
-    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], [x, y]), zero(T))
+    objf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(1)], [x, y]), T(0))
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), objf)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
@@ -695,7 +695,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         MOI.modify(model, c1, MOI.ScalarCoefficientChange(y, T(3)))
     else
         MOI.delete(model, c1)
-        cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T))
+        cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), T(0))
         c1 = MOI.add_constraint(model, cf1, MOI.LessThan{T}(T(4)))
     end
 
@@ -708,7 +708,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
 
-        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(2), zero(T)] atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(2), T(0)] atol=atol rtol=rtol
     end
 
     # delconstrs and solve
@@ -729,7 +729,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol=atol rtol=rtol
 
-        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(4), zero(T)] atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [T(4), T(0)] atol=atol rtol=rtol
     end
 
     # delvars and solve
@@ -772,26 +772,26 @@ function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     y = MOI.add_variable(model)
 
     # Min  x - y
-    # s.t. zero(T) <= x          (c1)
-    #             y <= zero(T)   (c2)
+    # s.t. T(0) <= x          (c1)
+    #             y <= T(0)   (c2)
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
-            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x, y]),
-                                     zero(T)))
+            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), -T(1)], [x, y]),
+                                     T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     fx = convert(MOI.ScalarAffineFunction{T},
                  MOI.SingleVariable(x))
-    c1 = MOI.add_constraint(model, fx, MOI.GreaterThan{T}(zero(T)))
+    c1 = MOI.add_constraint(model, fx, MOI.GreaterThan{T}(T(0)))
     fy = convert(MOI.ScalarAffineFunction{T},
                  MOI.SingleVariable(y))
-    c2 = MOI.add_constraint(model, fy, MOI.LessThan{T}(zero(T)))
+    c2 = MOI.add_constraint(model, fy, MOI.LessThan{T}(T(0)))
 
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c1) ≈ fx
-        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(zero(T))
+        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(T(0))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ fy
-        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(zero(T))
+        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(T(0))
     end
 
     if config.solve
@@ -802,21 +802,21 @@ function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ zero(T) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ zero(T) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(0) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(0) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ T(0) atol=atol rtol=rtol
     end
 
     # Min  x - y
     # s.t. T(100) <= x
-    #               y <= zero(T)
+    #               y <= T(0)
     MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan{T}(T(100)))
 
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c1) ≈ fx
         @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(T(100))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ fy
-        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(zero(T))
+        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(T(0))
     end
 
     if config.solve
@@ -826,7 +826,7 @@ function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(100) atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ T(0) atol=atol rtol=rtol
     end
 
     # Min  x - y
@@ -887,14 +887,14 @@ function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     y = MOI.add_variable(model)
 
     # Min  x - y
-    # s.t. zero(T) <= x          (c1)
-    #             y <= zero(T)   (c2)
+    # s.t. T(0) <= x          (c1)
+    #             y <= T(0)   (c2)
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x,y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), -T(1)], [x,y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
-    c1 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), x))], [zero(T)]), MOI.Nonnegatives(1))
-    c2 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), y))], [zero(T)]), MOI.Nonpositives(1))
+    c1 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(T(1), x))], [T(0)]), MOI.Nonnegatives(1))
+    c2 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(T(1), y))], [T(0)]), MOI.Nonpositives(1))
 
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
@@ -904,20 +904,20 @@ function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ zero(T) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ zero(T) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(0) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(0) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ T(0) atol=atol rtol=rtol
     end
 
     # Min  x - y
     # s.t. T(100) <= x
-    #               y <= zero(T)
+    #               y <= T(0)
 
     if config.modify_lhs
         MOI.modify(model, c1, MOI.VectorConstantChange([-T(100)]))
     else
         MOI.delete(model, c1)
-        c1 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), x))], [-T(100)]), MOI.Nonnegatives(1))
+        c1 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(T(1), x))], [-T(100)]), MOI.Nonnegatives(1))
     end
 
     if config.solve
@@ -927,7 +927,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(100) atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(100) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ T(0) atol=atol rtol=rtol
     end
 
     # Min  x - y
@@ -938,7 +938,7 @@ function linear7test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         MOI.modify(model, c2, MOI.VectorConstantChange([T(100)]))
     else
         MOI.delete(model, c2)
-        c2 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(one(T), y))], [T(100)]), MOI.Nonpositives(1))
+        c2 = MOI.add_constraint(model, MOI.VectorAffineFunction{T}([MOI.VectorAffineTerm{T}(1, MOI.ScalarAffineTerm{T}(T(1), y))], [T(100)]), MOI.Nonpositives(1))
     end
 
     if config.solve
@@ -971,13 +971,13 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x,y]), zero(T)), MOI.LessThan{T}(-one(T)))
-    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(1)], [x,y]), T(0)), MOI.LessThan{T}(-T(1)))
+    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test bndx.value == x.value
-    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(T(0)))
     @test bndy.value == y.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(T(1), x)], T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1027,13 +1027,13 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T),T(2)], [x,y]), zero(T)), MOI.LessThan{T}(zero(T)))
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-T(1),T(2)], [x,y]), T(0)), MOI.LessThan{T}(T(0)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(T(0)))
     @test vc2.value == y.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), -one(T)], [x, y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-T(1), -T(1)], [x, y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1073,13 +1073,13 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo{T}(zero(T)))
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),-T(1)], [x,y]), T(0)), MOI.EqualTo{T}(T(0)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(T(0)))
     @test vc2.value == y.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), -one(T)], [x, y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-T(1), -T(1)], [x, y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1132,20 +1132,20 @@ function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     vc12 = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan{T}(T(30)), MOI.GreaterThan{T}(zero(T))]
+        [MOI.GreaterThan{T}(T(30)), MOI.GreaterThan{T}(T(0))]
     )
     @test vc12[1].value == x.value
     @test vc12[2].value == y.value
 
     c1 = MOI.add_constraints(model,
-        [MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -T(3//2)], [x, y]), zero(T))],
-        [MOI.GreaterThan{T}(zero(T))]
+        [MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), -T(3//2)], [x, y]), T(0))],
+        [MOI.GreaterThan{T}(T(0))]
     )
 
     c23 = MOI.add_constraints(model,
         [
-            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(12), T(8)], [x, y]), zero(T)),
-            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1_000), T(300)], [x, y]), zero(T))
+            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(12), T(8)], [x, y]), T(0)),
+            MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1_000), T(300)], [x, y]), T(0))
         ],
         [
             MOI.LessThan{T}(T(1_000)),
@@ -1154,7 +1154,7 @@ function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     )
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
-                      MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1_000), T(350)], [x, y]), zero(T)))
+                      MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1_000), T(350)], [x, y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -1202,14 +1202,14 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     vc = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan{T}(zero(T)), MOI.GreaterThan{T}(zero(T))]
+        [MOI.GreaterThan{T}(T(0)), MOI.GreaterThan{T}(T(0))]
     )
     @test vc[1].value == x.value
     @test vc[2].value == y.value
 
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x,y]), zero(T)), MOI.Interval(T(5), T(10)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), T(1)], [x,y]), T(0)), MOI.Interval(T(5), T(10)))
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), T(1)], [x, y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -1237,7 +1237,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
         end
     end
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), T(1)], [x, y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1292,7 +1292,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
         end
     end
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), T(1)], [x, y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -1335,14 +1335,14 @@ function linear10btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: 
 
     vc = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan{T}(zero(T)), MOI.GreaterThan{T}(zero(T))]
+        [MOI.GreaterThan{T}(T(0)), MOI.GreaterThan{T}(T(0))]
     )
     @test vc[1].value == x.value
     @test vc[2].value == y.value
 
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x,y]), zero(T)), MOI.Interval(-one(T), T(10)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), T(1)], [x,y]), T(0)), MOI.Interval(-T(1), T(10)))
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), one(T)], [x, y]), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), T(1)], [x, y]), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1352,15 +1352,15 @@ function linear10btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: 
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ zero(T) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(0) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ T(0) atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ zero(T) atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), vc[1]) ≈ one(T) atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), vc[2]) ≈ one(T) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ T(0) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), vc[1]) ≈ T(1) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), vc[2]) ≈ T(1) atol=atol rtol=rtol
         end
 
         if config.basis
@@ -1418,10 +1418,10 @@ function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     v = MOI.add_variables(model, 2)
 
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan{T}(one(T)))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan{T}(T(2)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(1)], v), T(0)), MOI.GreaterThan{T}(T(1)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(1)], v), T(0)), MOI.GreaterThan{T}(T(2)))
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),T(1)], v), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1445,7 +1445,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ one(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(1) atol=atol rtol=rtol
     end
 end
 
@@ -1469,14 +1469,14 @@ function linear12test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),-T(3)], [x,y]), zero(T)), MOI.LessThan{T}(-T(7)))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), y)], zero(T)), MOI.LessThan{T}(T(2)))
-    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),-T(3)], [x,y]), T(0)), MOI.LessThan{T}(-T(7)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(T(1), y)], T(0)), MOI.LessThan{T}(T(2)))
+    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test bndx.value == x.value
-    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(T(0)))
     @test bndy.value == y.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(T(1), x)], T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1520,8 +1520,8 @@ function linear13test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T)), MOI.GreaterThan{T}(one(T)))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo{T}(zero(T)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), T(0)), MOI.GreaterThan{T}(T(1)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1),-T(1)], [x,y]), T(0)), MOI.EqualTo{T}(T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE
 
@@ -1539,11 +1539,11 @@ function linear13test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
         ysol = MOI.get(model, MOI.VariablePrimal(), y)
 
         c1sol = 2 * xsol + 3 * ysol
-        @test c1sol >= 1 || isapprox(c1sol, one(T), atol=atol, rtol=rtol)
+        @test c1sol >= 1 || isapprox(c1sol, T(1), atol=atol, rtol=rtol)
         @test xsol - ysol ≈ 0 atol=atol rtol=rtol
 
         c1primval = MOI.get(model, MOI.ConstraintPrimal(), c1)
-        @test c1primval >= 1 || isapprox(c1sol, one(T), atol=atol, rtol=rtol)
+        @test c1primval >= 1 || isapprox(c1sol, T(1), atol=atol, rtol=rtol)
 
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 0 atol=atol rtol=rtol
 
@@ -1575,17 +1575,17 @@ function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
     @test MOI.is_empty(model)
 
     x, y, z = MOI.add_variables(model, 3)
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(3), T(2), one(T)], [x, y, z]), zero(T)), MOI.LessThan{T}(T(2)))
-    clbx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(3), T(2), T(1)], [x, y, z]), T(0)), MOI.LessThan{T}(T(2)))
+    clbx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(T(0)))
     @test clbx.value == x.value
-    clby = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    clby = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(T(0)))
     @test clby.value == y.value
-    clbz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.GreaterThan{T}(zero(T)))
+    clbz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.GreaterThan{T}(T(0)))
     @test clbz.value == z.value
-    cubz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.LessThan{T}(one(T)))
+    cubz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.LessThan{T}(T(1)))
     @test cubz.value == z.value
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), T(2), T(3)], [x, y, z]), T(4)))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1), T(2), T(3)], [x, y, z]), T(4)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
     if config.solve
@@ -1678,7 +1678,7 @@ function linear15test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
     # which is empty, is essentially a constraint that 0 == 0.
     c = MOI.add_constraint(model,
         MOI.VectorAffineFunction{T}(
-            MOI.VectorAffineTerm{T}.(2, MOI.ScalarAffineTerm{T}.([one(T)], x)),
+            MOI.VectorAffineTerm{T}.(2, MOI.ScalarAffineTerm{T}.([T(1)], x)),
             zeros(2)
         ),
         MOI.Zeros(2)
@@ -1686,7 +1686,7 @@ function linear15test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     MOI.set(model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
-        MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T)], x), zero(T)))
+        MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(0)], x), T(0)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
     if config.solve
@@ -1717,31 +1717,31 @@ function partial_start_test(model::MOI.ModelLike, config::TestConfig{T}) where {
     # maximize 2x + y
     # s.t. x + y <= 1
     #      x, y >= 0
-    #      x starts at one(T). Start point for y is unspecified.
+    #      x starts at T(1). Start point for y is unspecified.
     MOI.empty!(model)
     @test MOI.is_empty(model)
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
 
-    MOI.set(model, MOI.VariablePrimalStart(), x, one(T))
+    MOI.set(model, MOI.VariablePrimalStart(), x, T(1))
 
-    MOI.add_constraint(model, x, MOI.GreaterThan{T}(zero(T)))
-    MOI.add_constraint(model, y, MOI.GreaterThan{T}(zero(T)))
-    obj = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), one(T)], [x, y]),
-                                   zero(T))
+    MOI.add_constraint(model, x, MOI.GreaterThan{T}(T(0)))
+    MOI.add_constraint(model, y, MOI.GreaterThan{T}(T(0)))
+    obj = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), T(1)], [x, y]),
+                                   T(0))
     MOI.set(model, MOI.ObjectiveFunction{typeof(obj)}(), obj)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-    x_plus_y = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.(one(T), [x, y]), zero(T))
-    MOI.add_constraint(model, x_plus_y, MOI.LessThan{T}(one(T)))
+    x_plus_y = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.(T(1), [x, y]), T(0))
+    MOI.add_constraint(model, x_plus_y, MOI.LessThan{T}(T(1)))
 
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ one(T) atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ zero(T) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x) ≈ T(1) atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), y) ≈ T(0) atol=atol rtol=rtol
     end
 end
 

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -29,15 +29,15 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
     cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T))
-    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
+    c = MOI.add_constraint(model, cf, MOI.LessThan(one(T)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.GreaterThan{T}(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.GreaterThan(zero(T)))
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test vc1.value == v[1].value
     # test fallback
-    vc2 = MOI.add_constraint(model, v[2], MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, v[2], MOI.GreaterThan(zero(T)))
     @test vc2.value == v[2].value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
@@ -57,13 +57,13 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
 
         s = MOI.get(model, MOI.ConstraintSet(), c)
-        @test s == MOI.LessThan{T}(one(T))
+        @test s == MOI.LessThan(one(T))
 
         s = MOI.get(model, MOI.ConstraintSet(), vc1)
-        @test s == MOI.GreaterThan{T}(zero(T))
+        @test s == MOI.GreaterThan(zero(T))
 
         s = MOI.get(model, MOI.ConstraintSet(), vc2)
-        @test s == MOI.GreaterThan{T}(zero(T))
+        @test s == MOI.GreaterThan(zero(T))
     end
 
     if config.solve
@@ -141,7 +141,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
         @test MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), v[1])], zero(T)) ≈ MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     end
 
-    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.GreaterThan{T}(zero(T)))
+    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.GreaterThan(zero(T)))
     @test vc3.value == v[3].value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 3
 
@@ -150,7 +150,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     else
         MOI.delete(model, c)
         cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T),one(T)], v), zero(T))
-        c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
+        c = MOI.add_constraint(model, cf, MOI.LessThan(one(T)))
     end
 
     MOI.modify(model,
@@ -192,7 +192,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # s.t. x + y + z <= 1
     # x >= -1
     # y,z >= 0
-    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan{T}(-one(T)))
+    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(-one(T)))
 
     if config.solve
         MOI.optimize!(model)
@@ -217,11 +217,11 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # max x + 2z
     # s.t. x + y + z <= 1
     # x, y >= 0, z = 0 (vc3)
-    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan{T}(zero(T)))
+    MOI.set(model, MOI.ConstraintSet(), vc1, MOI.GreaterThan(zero(T)))
 
     MOI.delete(model, vc3)
 
-    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.EqualTo{T}(zero(T)))
+    vc3 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.EqualTo(zero(T)))
     @test vc3.value == v[3].value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
@@ -246,7 +246,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     MOI.delete(model, c)
     # note: adding some redundant zero coefficients to catch solvers that don't handle duplicate coefficients correctly:
     cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([zero(T),zero(T),zero(T),one(T),one(T),one(T),zero(T),zero(T),zero(T)], [v; v; v]), zero(T))
-    c = MOI.add_constraint(model, cf, MOI.EqualTo{T}(T(2)))
+    c = MOI.add_constraint(model, cf, MOI.EqualTo(T(2)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 0
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}()) == 1
 
@@ -298,7 +298,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # x,y >= 0 (vc1,vc2), z = 0 (vc3)
 
     cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T), zero(T)], v), zero(T))
-    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan{T}(zero(T)))
+    c2 = MOI.add_constraint(model, cf2, MOI.GreaterThan(zero(T)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 0
@@ -393,12 +393,12 @@ function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
 
     cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], [x, y]), zero(T))
-    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(one(T)))
+    c = MOI.add_constraint(model, cf, MOI.LessThan(one(T)))
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
     @test vc2.value == y.value
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
 
@@ -465,10 +465,10 @@ function linear3test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
-    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test vc.value == x.value
     cf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
-    c = MOI.add_constraint(model, cf, MOI.GreaterThan{T}(T(3)))
+    c = MOI.add_constraint(model, cf, MOI.GreaterThan(T(3)))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
@@ -506,10 +506,10 @@ function linear3test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
 
-    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan{T}(zero(T)))
+    vc = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(zero(T)))
     @test vc.value == x.value
     cf = MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T))
-    c = MOI.add_constraint(model, cf, MOI.LessThan{T}(T(3)))
+    c = MOI.add_constraint(model, cf, MOI.LessThan(T(3)))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{T}}()) == 1
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 1
@@ -564,9 +564,9 @@ function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], [x,y]), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
 
-    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test c1.value == x.value
-    c2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.LessThan{T}(zero(T)))
+    c2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.LessThan(zero(T)))
     @test c2.value == y.value
 
     if config.solve
@@ -585,7 +585,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # Min  x - y
     # s.t. T(100) <= x
     #               y <= zero(T)
-    MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan{T}(T(100)))
+    MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(T(100)))
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
@@ -599,7 +599,7 @@ function linear4test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # Min  x - y
     # s.t. T(100) <= x
     #               y <= -T(100)
-    MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan{T}(-T(100)))
+    MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan(-T(100)))
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
@@ -649,14 +649,14 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x, y]), zero(T))
     cf2 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),T(2)], [x, y]), zero(T))
 
-    c1 = MOI.add_constraint(model, cf1, MOI.LessThan{T}(T(4)))
-    c2 = MOI.add_constraint(model, cf2, MOI.LessThan{T}(T(4)))
+    c1 = MOI.add_constraint(model, cf1, MOI.LessThan(T(4)))
+    c2 = MOI.add_constraint(model, cf2, MOI.LessThan(T(4)))
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}()) == 2
 
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
     @test vc2.value == y.value
 
     @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}()) == 2
@@ -696,7 +696,7 @@ function linear5test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     else
         MOI.delete(model, c1)
         cf1 = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T))
-        c1 = MOI.add_constraint(model, cf1, MOI.LessThan{T}(T(4)))
+        c1 = MOI.add_constraint(model, cf1, MOI.LessThan(T(4)))
     end
 
     if config.solve
@@ -782,16 +782,16 @@ function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     fx = convert(MOI.ScalarAffineFunction{T},
                  MOI.SingleVariable(x))
-    c1 = MOI.add_constraint(model, fx, MOI.GreaterThan{T}(zero(T)))
+    c1 = MOI.add_constraint(model, fx, MOI.GreaterThan(zero(T)))
     fy = convert(MOI.ScalarAffineFunction{T},
                  MOI.SingleVariable(y))
-    c2 = MOI.add_constraint(model, fy, MOI.LessThan{T}(zero(T)))
+    c2 = MOI.add_constraint(model, fy, MOI.LessThan(zero(T)))
 
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c1) ≈ fx
-        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(zero(T))
+        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan(zero(T))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ fy
-        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(zero(T))
+        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan(zero(T))
     end
 
     if config.solve
@@ -810,13 +810,13 @@ function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # Min  x - y
     # s.t. T(100) <= x
     #               y <= zero(T)
-    MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan{T}(T(100)))
+    MOI.set(model, MOI.ConstraintSet(), c1, MOI.GreaterThan(T(100)))
 
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c1) ≈ fx
-        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(T(100))
+        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan(T(100))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ fy
-        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(zero(T))
+        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan(zero(T))
     end
 
     if config.solve
@@ -832,13 +832,13 @@ function linear6test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
     # Min  x - y
     # s.t. T(100) <= x
     #               y <= -T(100)
-    MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan{T}(-T(100)))
+    MOI.set(model, MOI.ConstraintSet(), c2, MOI.LessThan(-T(100)))
 
     if config.query
         @test MOI.get(model, MOI.ConstraintFunction(), c1) ≈ fx
-        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan{T}(T(100))
+        @test MOI.get(model, MOI.ConstraintSet(), c1) == MOI.GreaterThan(T(100))
         @test MOI.get(model, MOI.ConstraintFunction(), c2) ≈ fy
-        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan{T}(-T(100))
+        @test MOI.get(model, MOI.ConstraintSet(), c2) == MOI.LessThan(-T(100))
     end
 
     if config.solve
@@ -971,10 +971,10 @@ function linear8atest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x,y]), zero(T)), MOI.LessThan{T}(-one(T)))
-    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),one(T)], [x,y]), zero(T)), MOI.LessThan(-one(T)))
+    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test bndx.value == x.value
-    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
     @test bndy.value == y.value
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T)))
@@ -1027,10 +1027,10 @@ function linear8btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T),T(2)], [x,y]), zero(T)), MOI.LessThan{T}(zero(T)))
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T),T(2)], [x,y]), zero(T)), MOI.LessThan(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
     @test vc2.value == y.value
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), -one(T)], [x, y]), zero(T)))
@@ -1073,10 +1073,10 @@ function linear8ctest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo{T}(zero(T)))
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo(zero(T)))
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test vc1.value == x.value
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
     @test vc2.value == y.value
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([-one(T), -one(T)], [x, y]), zero(T)))
@@ -1132,14 +1132,14 @@ function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
 
     vc12 = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan{T}(T(30)), MOI.GreaterThan{T}(zero(T))]
+        [MOI.GreaterThan(T(30)), MOI.GreaterThan(zero(T))]
     )
     @test vc12[1].value == x.value
     @test vc12[2].value == y.value
 
     c1 = MOI.add_constraints(model,
         [MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -T(3//2)], [x, y]), zero(T))],
-        [MOI.GreaterThan{T}(zero(T))]
+        [MOI.GreaterThan(zero(T))]
     )
 
     c23 = MOI.add_constraints(model,
@@ -1148,8 +1148,8 @@ function linear9test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: Nu
             MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(1_000), T(300)], [x, y]), zero(T))
         ],
         [
-            MOI.LessThan{T}(T(1_000)),
-            MOI.LessThan{T}(T(70_000))
+            MOI.LessThan(T(1_000)),
+            MOI.LessThan(T(70_000))
         ]
     )
 
@@ -1202,7 +1202,7 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     vc = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan{T}(zero(T)), MOI.GreaterThan{T}(zero(T))]
+        [MOI.GreaterThan(zero(T)), MOI.GreaterThan(zero(T))]
     )
     @test vc[1].value == x.value
     @test vc[2].value == y.value
@@ -1335,7 +1335,7 @@ function linear10btest(model::MOI.ModelLike, config::TestConfig{T}) where {T <: 
 
     vc = MOI.add_constraints(model,
         [MOI.SingleVariable(x), MOI.SingleVariable(y)],
-        [MOI.GreaterThan{T}(zero(T)), MOI.GreaterThan{T}(zero(T))]
+        [MOI.GreaterThan(zero(T)), MOI.GreaterThan(zero(T))]
     )
     @test vc[1].value == x.value
     @test vc[2].value == y.value
@@ -1418,8 +1418,8 @@ function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     v = MOI.add_variables(model, 2)
 
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan{T}(one(T)))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan{T}(T(2)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan(one(T)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)), MOI.GreaterThan(T(2)))
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),one(T)], v), zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
@@ -1434,7 +1434,7 @@ function linear11test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
     end
 
-    c3 = MOI.transform(model, c2, MOI.LessThan{T}(T(2)))
+    c3 = MOI.transform(model, c2, MOI.LessThan(T(2)))
 
     @test isa(c3, MOI.ConstraintIndex{MOI.ScalarAffineFunction{T}, MOI.LessThan{T}})
     @test MOI.is_valid(model, c2) == false
@@ -1469,11 +1469,11 @@ function linear12test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),-T(3)], [x,y]), zero(T)), MOI.LessThan{T}(-T(7)))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), y)], zero(T)), MOI.LessThan{T}(T(2)))
-    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),-T(3)], [x,y]), zero(T)), MOI.LessThan(-T(7)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), y)], zero(T)), MOI.LessThan(T(2)))
+    bndx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test bndx.value == x.value
-    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    bndy = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
     @test bndy.value == y.value
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}([MOI.ScalarAffineTerm{T}(one(T), x)], zero(T)))
@@ -1520,8 +1520,8 @@ function linear13test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
 
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T)), MOI.GreaterThan{T}(one(T)))
-    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo{T}(zero(T)))
+    c1 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2),T(3)], [x,y]), zero(T)), MOI.GreaterThan(one(T)))
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T),-one(T)], [x,y]), zero(T)), MOI.EqualTo(zero(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE
 
@@ -1575,14 +1575,14 @@ function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where {T <: N
     @test MOI.is_empty(model)
 
     x, y, z = MOI.add_variables(model, 3)
-    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(3), T(2), one(T)], [x, y, z]), zero(T)), MOI.LessThan{T}(T(2)))
-    clbx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan{T}(zero(T)))
+    c = MOI.add_constraint(model, MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(3), T(2), one(T)], [x, y, z]), zero(T)), MOI.LessThan(T(2)))
+    clbx = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(zero(T)))
     @test clbx.value == x.value
-    clby = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan{T}(zero(T)))
+    clby = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(zero(T)))
     @test clby.value == y.value
-    clbz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.GreaterThan{T}(zero(T)))
+    clbz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.GreaterThan(zero(T)))
     @test clbz.value == z.value
-    cubz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.LessThan{T}(one(T)))
+    cubz = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.LessThan(one(T)))
     @test cubz.value == z.value
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(), MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), T(2), T(3)], [x, y, z]), T(4)))
@@ -1726,14 +1726,14 @@ function partial_start_test(model::MOI.ModelLike, config::TestConfig{T}) where {
 
     MOI.set(model, MOI.VariablePrimalStart(), x, one(T))
 
-    MOI.add_constraint(model, x, MOI.GreaterThan{T}(zero(T)))
-    MOI.add_constraint(model, y, MOI.GreaterThan{T}(zero(T)))
+    MOI.add_constraint(model, x, MOI.GreaterThan(zero(T)))
+    MOI.add_constraint(model, y, MOI.GreaterThan(zero(T)))
     obj = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([T(2), one(T)], [x, y]),
                                    zero(T))
     MOI.set(model, MOI.ObjectiveFunction{typeof(obj)}(), obj)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     x_plus_y = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.(one(T), [x, y]), zero(T))
-    MOI.add_constraint(model, x_plus_y, MOI.LessThan{T}(one(T)))
+    MOI.add_constraint(model, x_plus_y, MOI.LessThan(one(T)))
 
     if config.solve
         MOI.optimize!(model)


### PR DESCRIPTION
I tried starting to address #841. I haven't incorporated @blegat's suggestion to use a type parameter for `TestConfig` but that should be easy to change. I run into a problem, however, when trying to run the `contlinear` tests with `BigFloat`s for SDPA-GMP, which is that `Float64`'s are used internally in a few places in MOI. For example,

https://github.com/JuliaOpt/MathOptInterface.jl/blob/6ac4e6d6ee47486062ab9a14816aca6d51328760/src/Bridges/Constraint/slack.jl#L20

causes
```julia
  MethodError: no method matching shift_constant(::MathOptInterface.EqualTo{Float64}, ::BigFloat)
```
in the test on line `1539` of `contlinear.jl`. I imagine this is why it's important to test with other numeric types if we want to use them with MOI! I think therefore something beyond changing the tests here is needed. Perhaps auditing the codebase for `Float64` usage and replacing it with an appropriate type? It looks easy to fix in the slack.jl#L20 case. I saw also `Float64`'s here:

https://github.com/JuliaOpt/MathOptInterface.jl/blob/6ac4e6d6ee47486062ab9a14816aca6d51328760/src/Bridges/bridge_optimizer.jl#L724

and I'm not sure what the replacement would be, because `SingleVariable`'s don't carry a type parameter.

Regarding the changes in this PR:

My technique for updating the file was lots of find-and-replace. There are four types of constructors which need to be parametrized (VAFs, SAFs, SATs, and VATs), and integers written as floating point numbers (`3.0`) can be regex replaced by finding `(\d*?_?\d+?)\.0` and replacing by `T($1)` (assuming `T` is the numeric type). I also first replaced `0.0`'s by `zero(T)` and `1.0` by `one(T)`, although I'm not sure if that's better than `T(0)` and `T(1)`. Then I searched for remaining decimal points and replaced them with fractions by hand (e.g. `T(1)/T(2)`).

I'm not sure if replacing the constant literals was desired; @odow suggested just checking that they promote correctly. But because I was running into lots of promotion-related errors when running the `contlinear` test with SDPA-GMP, I decided to replace them. I think that helped isolate which problems were coming from MOI's internal use of Float64 numbers, versus ones introduced in `contlinear.jl`.
