### PR TITLE
Fix Allocate-Load copy for single variable constraints

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -502,7 +502,7 @@ function allocate_single_variable(dest::MOI.ModelLike, src::MOI.ModelLike,
     for (ci_src, f_src) in zip(cis_src, fs_src)
         if !haskey(idxmap, f_src.variable)
             set = MOI.get(src, MOI.ConstraintSet(), ci_src)::S
-            vi_dest, ci_dest = MOI.add_constrained_variable(dest, set)
+            vi_dest, ci_dest = allocate_constrained_variable(dest, set)
             idxmap[ci_src] = ci_dest
             idxmap[f_src.variable] = vi_dest
             push!(allocated, ci_src)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -18,7 +18,7 @@ mutable struct MockOptimizer{MT<:MOI.ModelLike} <: MOI.AbstractOptimizer
     conattribute::Dict{MOI.ConstraintIndex,Int} # MockConstraintAttribute
     supports_names::Bool # Allows to test with optimizer not supporting names
     needs_allocate_load::Bool # Allows to tests the Allocate-Load interface, see copy_to
-    add_var_allowed::Bool
+    add_var_allowed::Bool # If false, the optimizer throws AddVariableNotAllowed
     add_con_allowed::Bool # If false, the optimizer throws AddConstraintNotAllowed
     modify_allowed::Bool # If false, the optimizer throws Modify...NotAllowed
     delete_allowed::Bool # If false, the optimizer throws DeleteNotAllowed
@@ -58,6 +58,8 @@ xor_indices(x) = map_indices(xor_index, x)
 
 function MockOptimizer(inner_model::MOI.ModelLike; supports_names=true,
                        needs_allocate_load=false,
+                       add_var_allowed=!needs_allocate_load,
+                       add_con_allowed=!needs_allocate_load,
                        eval_objective_value=true,
                        eval_dual_objective_value=true,
                        eval_variable_constraint_dual=true)
@@ -67,8 +69,8 @@ function MockOptimizer(inner_model::MOI.ModelLike; supports_names=true,
                          Dict{MOI.ConstraintIndex,Int}(),
                          supports_names,
                          needs_allocate_load,
-                         true,
-                         true,
+                         add_var_allowed,
+                         add_con_allowed,
                          true,
                          true,
                          (::MockOptimizer) -> begin end,


### PR DESCRIPTION
The change in `MockOptimizer` is to makes
https://github.com/JuliaOpt/MathOptInterface.jl/blob/6ac4e6d6ee47486062ab9a14816aca6d51328760/test/Utilities/copy.jl#L51-L58
fail and the change in `copy.jl` fixes it.
This fixes the bug reported by @lkapelevich in https://gist.github.com/lkapelevich/9942e37d9eb3cef96d6be7eb041ee838