### PR TITLE
Add Variable.SOCtoRSOCBridge

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -625,6 +625,7 @@ Bridges.Variable.ZerosBridge
 Bridges.Variable.FreeBridge
 Bridges.Variable.NonposToNonnegBridge
 Bridges.Variable.VectorizeBridge
+Bridges.Variable.SOCtoRSOCBridge
 Bridges.Variable.RSOCtoPSDBridge
 ```
 

--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -31,6 +31,8 @@ include("flip_sign.jl")
 const NonposToNonneg{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{NonposToNonnegBridge{T}, OT}
 include("vectorize.jl")
 const Vectorize{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{VectorizeBridge{T}, OT}
+include("soc_to_rsoc.jl")
+const SOCtoRSOC{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{SOCtoRSOCBridge{T}, OT}
 include("rsoc_to_psd.jl")
 const RSOCtoPSD{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{RSOCtoPSDBridge{T}, OT}
 
@@ -45,6 +47,7 @@ function add_all_bridges(bridged_model, T::Type)
     MOIB.add_bridge(bridged_model, FreeBridge{T})
     MOIB.add_bridge(bridged_model, NonposToNonnegBridge{T})
     MOIB.add_bridge(bridged_model, VectorizeBridge{T})
+    MOIB.add_bridge(bridged_model, SOCtoRSOCBridge{T})
     MOIB.add_bridge(bridged_model, RSOCtoPSDBridge{T})
     return
 end

--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -290,12 +290,12 @@ function add_keys_for_bridge(map::Map, bridge::AbstractBridge,
             push!(map.sets, nothing)
         end
         if map.unbridged_function !== nothing
-            for i in 1:MOI.dimension(set)
-                mappings = unbridged_map(bridge, variables[i], IndexInVector(i))
-                if mappings === nothing
-                    map.unbridged_function = nothing
-                else
-                    push!(map.unbridged_function, mappings...)
+            mappings = unbridged_map(bridge, variables)
+            if mappings === nothing
+                map.unbridged_function = nothing
+            else
+                for mapping in mappings
+                    push!(map.unbridged_function, mapping)
                 end
             end
         end

--- a/src/Bridges/Variable/soc_to_rsoc.jl
+++ b/src/Bridges/Variable/soc_to_rsoc.jl
@@ -1,0 +1,110 @@
+function rotate_result(
+    model, attr::Union{MOI.ConstraintPrimal, MOI.ConstraintDual},
+    ci::MOI.ConstraintIndex)
+    x = MOI.get(model, attr, ci)
+    s2 = √2
+    return [x[1]/s2 + x[2]/s2; x[1]/s2 - x[2]/s2; x[3:end]]
+end
+
+struct SOCtoRSOCBridge{T} <: AbstractBridge
+    variables::Vector{MOI.VariableIndex}
+    constraint::MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.RotatedSecondOrderCone}
+end
+function bridge_constrained_variable(
+    ::Type{SOCtoRSOCBridge{T}}, model::MOI.ModelLike,
+    set::MOI.SecondOrderCone) where T
+    variables, constraint = MOI.add_constrained_variables(
+        model, MOI.RotatedSecondOrderCone(MOI.dimension(set)))
+    return SOCtoRSOCBridge{T}(variables, constraint)
+end
+
+function supports_constrained_variable(
+    ::Type{<:SOCtoRSOCBridge}, ::Type{MOI.SecondOrderCone})
+    return true
+end
+function MOIB.added_constrained_variable_types(::Type{<:SOCtoRSOCBridge})
+    return [(MOI.RotatedSecondOrderCone,)]
+end
+function MOIB.added_constraint_types(::Type{<:SOCtoRSOCBridge})
+    return Tuple{DataType, DataType}[]
+end
+
+# Attributes, Bridge acting as a model
+function MOI.get(bridge::SOCtoRSOCBridge, ::MOI.NumberOfVariables)
+    return length(bridge.variables)
+end
+function MOI.get(bridge::SOCtoRSOCBridge, ::MOI.ListOfVariableIndices)
+    return bridge.variables
+end
+function MOI.get(bridge::SOCtoRSOCBridge,
+                 ::MOI.NumberOfConstraints{MOI.VectorOfVariables,
+                                           MOI.RotatedSecondOrderCone})
+    return 1
+end
+function MOI.get(bridge::SOCtoRSOCBridge,
+                 ::MOI.ListOfConstraintIndices{MOI.VectorOfVariables,
+                                               MOI.RotatedSecondOrderCone})
+    return [bridge.constraint]
+end
+
+# References
+function MOI.delete(model::MOI.ModelLike, bridge::SOCtoRSOCBridge)
+    MOI.delete(model, bridge.variables)
+end
+
+# Attributes, Bridge acting as a constraint
+
+function MOI.get(::MOI.ModelLike, ::MOI.ConstraintSet,
+                 bridge::SOCtoRSOCBridge{T}) where T
+    return MOI.SecondOrderCone(length(bridge.variables))
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimal, MOI.ConstraintDual},
+    bridge::SOCtoRSOCBridge)
+    return rotate_result(model, attr, bridge.constraint)
+end
+
+function MOI.get(model::MOI.ModelLike, attr::MOI.VariablePrimal,
+                 bridge::SOCtoRSOCBridge{T}, i::IndexInVector) where T
+    if i.value == 1 || i.value == 2
+        t, u = MOI.get(model, attr, bridge.variables[1:2])
+        s2 = convert(T, √2)
+        if i.value == 1
+            return t/s2 + u/s2
+        else
+            return t/s2 - u/s2
+        end
+    else
+        return MOI.get(model, attr, bridge.variables[i.value])
+    end
+end
+
+function MOIB.bridged_function(bridge::SOCtoRSOCBridge{T}, i::IndexInVector) where T
+    s2 = convert(T, √2)
+    if i.value == 1 || i.value == 2
+        t = MOIU.operate(/, T, MOI.SingleVariable(bridge.variables[1]), s2)
+        u = MOIU.operate(/, T, MOI.SingleVariable(bridge.variables[2]), s2)
+        if i.value == 1
+            return MOIU.operate!(+, T, t, u)
+        else
+            return MOIU.operate!(-, T, t, u)
+        end
+    else
+        return convert(MOI.ScalarAffineFunction{T}, MOI.SingleVariable(bridge.variables[i.value]))
+    end
+end
+function unbridged_map(bridge::SOCtoRSOCBridge{T}, vis::Vector{MOI.VariableIndex}) where T
+    umap = Pair{MOI.VariableIndex, MOI.ScalarAffineFunction{T}}[]
+    s2 = convert(T, √2)
+    t = MOIU.operate(/, T, MOI.SingleVariable(vis[1]), s2)
+    u = MOIU.operate(/, T, MOI.SingleVariable(vis[2]), s2)
+    push!(umap, bridge.variables[1] => MOIU.operate(+, T, t, u))
+    push!(umap, bridge.variables[2] => MOIU.operate(-, T, t, u))
+    for i in 3:length(vis)
+        func = convert(MOI.ScalarAffineFunction{T}, MOI.SingleVariable(vis[i]))
+        push!(umap, bridge.variables[i] => func)
+    end
+    return umap
+end

--- a/src/Bridges/Variable/soc_to_rsoc.jl
+++ b/src/Bridges/Variable/soc_to_rsoc.jl
@@ -6,6 +6,11 @@ function rotate_result(
     return [x[1]/s2 + x[2]/s2; x[1]/s2 - x[2]/s2; x[3:end]]
 end
 
+"""
+    SOCtoRSOCBridge{T} <: Bridges.Variable.AbstractBridge
+
+Same transformation as [`MOI.Bridges.Constraint.SOCRBridge`](@ref).
+"""
 struct SOCtoRSOCBridge{T} <: AbstractBridge
     variables::Vector{MOI.VariableIndex}
     constraint::MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.RotatedSecondOrderCone}

--- a/test/Bridges/Variable/soc_to_rsoc.jl
+++ b/test/Bridges/Variable/soc_to_rsoc.jl
@@ -1,0 +1,83 @@
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+const MOIT = MathOptInterface.Test
+const MOIU = MathOptInterface.Utilities
+const MOIB = MathOptInterface.Bridges
+
+include("../utilities.jl")
+
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
+config = MOIT.TestConfig()
+
+bridged_mock = MOIB.Variable.SOCtoRSOC{Float64}(mock)
+
+@testset "soc1v" begin
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1/√2 + 1/2, 1/√2 - 1/2, 1/√2],
+        (MOI.VectorAffineFunction{Float64}, MOI.Zeros) => [[-√2]])
+    MOIT.soc1vtest(bridged_mock, config)
+
+    ceqs = MOI.get(mock, MOI.ListOfConstraintIndices{
+        MOI.VectorAffineFunction{Float64}, MOI.Zeros}())
+    @test length(ceqs) == 1
+    MOI.set(bridged_mock, MOI.ConstraintName(), ceqs[1], "ceq")
+
+    @testset "Test mock model" begin
+        var_names = ["a", "b", "c"]
+        MOI.set(
+            mock, MOI.VariableName(),
+            MOI.get(mock, MOI.ListOfVariableIndices()), var_names)
+        rsocs = MOI.get(mock, MOI.ListOfConstraintIndices{
+            MOI.VectorOfVariables, MOI.RotatedSecondOrderCone}())
+        @test length(rsocs) == 1
+        MOI.set(mock, MOI.ConstraintName(), rsocs[1], "rsoc")
+
+        invs2 = 1 / √2
+        s = """
+        variables: a, b, c
+        rsoc: [a, b, c] in MathOptInterface.RotatedSecondOrderCone(3)
+        ceq: [$invs2*a + $invs2*b + -1.0] in MathOptInterface.Zeros(1)
+        maxobjective: $invs2*a + -$invs2*b + c
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(mock, model, var_names, ["rsoc", "ceq"])
+    end
+
+    @testset "Test bridged model" begin
+        var_names = ["x", "y", "z"]
+        MOI.set(
+            bridged_mock, MOI.VariableName(),
+            MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+        socs = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{
+            MOI.VectorOfVariables, MOI.SecondOrderCone}())
+        @test length(socs) == 1
+        MOI.set(bridged_mock, MOI.ConstraintName(), socs[1], "soc")
+
+        s = """
+        variables: x, y, z
+        soc: [x, y, z] in MathOptInterface.SecondOrderCone(3)
+        ceq: [x + -1.0] in MathOptInterface.Zeros(1)
+        maxobjective: y + z
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(bridged_mock, model, var_names, ["soc", "ceq"])
+    end
+
+    @testset "Delete" begin
+        xyz = MOI.get(bridged_mock, MOI.ListOfVariableIndices())
+
+        message = string("Cannot delete variable as it is constrained with other",
+                         " variables in a `MOI.VectorOfVariables`.")
+        for i in eachindex(xyz)
+            err = MOI.DeleteNotAllowed(xyz[i], message)
+            @test_throws err MOI.delete(bridged_mock, xyz[i])
+        end
+
+        test_delete_bridged_variables(bridged_mock, xyz, MOI.SecondOrderCone, 3, (
+            (MOI.VectorOfVariables, MOI.RotatedSecondOrderCone, 0),
+        ))
+    end
+end


### PR DESCRIPTION
Currently, adding SOC variables to PSD solvers not supporting SOC is inefficient as it will go through constraint bridges and create slack variables.
This PR adds SOCtoRSOCBridge to improve the situation.
We also create a different `unbridged_map` as SOCtoRSOCBridge could not implement the current one which fallbacks on the previous one to avoid breakage for bridge implementing it.