### PR TITLE
Fix Variable/rsoc_to_psd for dimension 2

### DIFF
--- a/test/Bridges/Variable/rsoc_to_psd.jl
+++ b/test/Bridges/Variable/rsoc_to_psd.jl
@@ -13,6 +13,74 @@ config = MOIT.TestConfig()
 
 bridged_mock = MOIB.Variable.RSOCtoPSD{Float64}(mock)
 
+# Can come from a SOC of dimension 2 which makes more sense
+# FIXME should it be moved to contconic or is RSOC of dimension 2 too exotic ?
+@testset "RSOC of dimension 2" begin
+    MOI.empty!(bridged_mock)
+    xy, cxy = MOI.add_constrained_variables(bridged_mock, MOI.RotatedSecondOrderCone(2))
+    x, y = xy
+    fx = MOI.SingleVariable(x)
+    fy = MOI.SingleVariable(y)
+    c = MOI.add_constraint(bridged_mock, 1.0fx + 1.0fy, MOI.LessThan(1.0))
+    obj = 1.0fy
+    MOI.set(bridged_mock, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(bridged_mock, MOI.ObjectiveFunction{typeof(obj)}(), obj)
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [0.0, 2.0],
+        #(MOI.VectorOfVariables) => [0.0, 1.0],
+        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0])
+    MOI.optimize!(bridged_mock)
+    @test MOI.get(bridged_mock, MOI.ObjectiveValue()) == 1.0
+    @test MOI.get(bridged_mock, MOI.DualObjectiveValue()) == 1.0
+    @test MOI.get(bridged_mock, MOI.VariablePrimal(), xy) == [0.0, 1.0]
+    @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), cxy) == [0.0, 1.0]
+    @test MOI.get(bridged_mock, MOI.ConstraintDual(), cxy) == [1.0, 0.0]
+    @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), c) == 1.0
+    @test MOI.get(bridged_mock, MOI.ConstraintDual(), c) == -1.0
+
+    MOI.set(mock, MOI.ConstraintName(), c, "c")
+    @testset "Test mock model" begin
+        var_names = ["a", "b"]
+        MOI.set(mock, MOI.VariableName(),
+                MOI.get(mock, MOI.ListOfVariableIndices()), var_names)
+        nonneg = MOI.get(mock, MOI.ListOfConstraintIndices{
+            MOI.VectorOfVariables, MOI.Nonnegatives}())
+        @test length(nonneg) == 1
+        MOI.set(mock, MOI.ConstraintName(), nonneg[1], "cab")
+
+        s = """
+        variables: a, b
+        cab: [a, b] in MathOptInterface.Nonnegatives(2)
+        c: a + 0.5b <= 1.0
+        maxobjective: 0.5b
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(mock, model, var_names, ["cab", "c"])
+    end
+
+    @testset "Test bridged model" begin
+        var_names = ["x", "y"]
+        MOI.set(bridged_mock, MOI.VariableName(),
+                MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+        MOI.set(bridged_mock, MOI.ConstraintName(), cxy, "cxy")
+
+        s = """
+        variables: x, y
+        cxy: [x, y] in MathOptInterface.RotatedSecondOrderCone(2)
+        c: x + y <= 1.0
+        maxobjective: 1.0y
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(bridged_mock, model, var_names, ["cxy", "c"])
+    end
+
+    test_delete_bridged_variables(bridged_mock, xy, MOI.RotatedSecondOrderCone, 2, (
+        (MOI.VectorOfVariables, MOI.Nonnegatives, 0),
+        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 1)
+    ))
+end
+
 @testset "RSOC4" begin
     mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 1.0, 2.0, 1.0, 0.0, 2.0],
         (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})  => [0.25],


### PR DESCRIPTION
Required for https://github.com/JuliaOpt/MathOptInterface.jl/pull/865 as SOC of dim 2 are bridged into RSOC of dim 2.