### PR TITLE
Remove some Float64 assumptions

### DIFF
--- a/src/Bridges/Constraint/rsoc.jl
+++ b/src/Bridges/Constraint/rsoc.jl
@@ -25,7 +25,7 @@ function rotate_function(f::MOI.AbstractVectorFunction, T::Type)
     t = f_scalars[1]
     u = f_scalars[2]
     x = f_scalars[3:d]
-    s2 = √2
+    s2 = √T(2)
     ts = MOIU.operate!(/, T, t, s2)
     us = MOIU.operate!(/, T, u, s2)
     # Cannot use `operate!` here since `ts` and `us` are needed for the next
@@ -94,7 +94,8 @@ function rotate_result(model,
                        attr::Union{MOI.ConstraintPrimal, MOI.ConstraintDual},
                        ci::MOI.ConstraintIndex)
     x = MOI.get(model, attr, ci)
-    s2 = √2
+    T = eltype(x)
+    s2 = √T(2)
     return [x[1]/s2 + x[2]/s2; x[1]/s2 - x[2]/s2; x[3:end]]
 end
 # Need to define both `get` methods and redirect to `rotate_result` to avoid

--- a/src/Bridges/Constraint/slack.jl
+++ b/src/Bridges/Constraint/slack.jl
@@ -17,7 +17,7 @@ function bridge_constraint(::Type{ScalarSlackBridge{T, F, S}}, model,
                            f::MOI.AbstractScalarFunction, s::S) where {T, F, S}
     slack, slack_in_set = MOI.add_constrained_variable(model, s)
     new_f = MOIU.operate(-, T, f, MOI.SingleVariable(slack))
-    equality = MOI.add_constraint(model, new_f, MOI.EqualTo(0.0))
+    equality = MOI.add_constraint(model, new_f, MOI.EqualTo(zero(T)))
     return ScalarSlackBridge{T, F, S}(slack, slack_in_set, equality)
 end
 

--- a/src/Bridges/Variable/soc_to_rsoc.jl
+++ b/src/Bridges/Variable/soc_to_rsoc.jl
@@ -2,7 +2,8 @@ function rotate_result(
     model, attr::Union{MOI.ConstraintPrimal, MOI.ConstraintDual},
     ci::MOI.ConstraintIndex)
     x = MOI.get(model, attr, ci)
-    s2 = √2
+    T = eltype(x)
+    s2 = √T(2)
     return [x[1]/s2 + x[2]/s2; x[1]/s2 - x[2]/s2; x[3:end]]
 end
 
@@ -75,7 +76,7 @@ function MOI.get(model::MOI.ModelLike, attr::MOI.VariablePrimal,
                  bridge::SOCtoRSOCBridge{T}, i::IndexInVector) where T
     if i.value == 1 || i.value == 2
         t, u = MOI.get(model, attr, bridge.variables[1:2])
-        s2 = convert(T, √2)
+        s2 = √T(2)
         if i.value == 1
             return t/s2 + u/s2
         else
@@ -87,7 +88,7 @@ function MOI.get(model::MOI.ModelLike, attr::MOI.VariablePrimal,
 end
 
 function MOIB.bridged_function(bridge::SOCtoRSOCBridge{T}, i::IndexInVector) where T
-    s2 = convert(T, √2)
+    s2 = √T(2)
     if i.value == 1 || i.value == 2
         t = MOIU.operate(/, T, MOI.SingleVariable(bridge.variables[1]), s2)
         u = MOIU.operate(/, T, MOI.SingleVariable(bridge.variables[2]), s2)
@@ -102,7 +103,7 @@ function MOIB.bridged_function(bridge::SOCtoRSOCBridge{T}, i::IndexInVector) whe
 end
 function unbridged_map(bridge::SOCtoRSOCBridge{T}, vis::Vector{MOI.VariableIndex}) where T
     umap = Pair{MOI.VariableIndex, MOI.ScalarAffineFunction{T}}[]
-    s2 = convert(T, √2)
+    s2 = √T(2)
     t = MOIU.operate(/, T, MOI.SingleVariable(vis[1]), s2)
     u = MOIU.operate(/, T, MOI.SingleVariable(vis[2]), s2)
     push!(umap, bridge.variables[1] => MOIU.operate(+, T, t, u))


### PR DESCRIPTION
Fixes https://github.com/JuliaOpt/MathOptInterface.jl/issues/876. 

I also changed `convert(T, √2)` to `√T(2)` in a few places to improve precision when `T` is a BigFloat (calculate the square-root in the BigFloat domain).