### PR TITLE
Fix missing sets from ListOfSupportedConstraints

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -577,12 +577,12 @@ function _add_contraint_type(list, model::AbstractModel,
 end
 function MOI.get(model::AbstractModel{T}, loc::MOI.ListOfConstraints) where T
     list = broadcastvcat(_getloc, model)
-    _add_contraint_type(list, model, MOI.EqualTo{T})
-    _add_contraint_type(list, model, MOI.GreaterThan{T})
-    _add_contraint_type(list, model, MOI.LessThan{T})
-    _add_contraint_type(list, model, MOI.Interval{T})
-    _add_contraint_type(list, model, MOI.Integer)
-    _add_contraint_type(list, model, MOI.ZeroOne)
+    for S in (
+        MOI.EqualTo{T}, MOI.GreaterThan{T}, MOI.LessThan{T}, MOI.Interval{T},
+        MOI.Semicontinuous{T}, MOI.Semiinteger{T}, MOI.Integer, MOI.ZeroOne
+    )
+        _add_contraint_type(list, model, S)
+    end
     return list
 end
 

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -251,3 +251,17 @@ struct SetNotSupportedBySolvers <: MOI.AbstractSet end
         @test_throws Exception MOI.set(model, MOI.ConstraintFunction(), c, FunctionNotSupportedBySolvers(x))
     end
 end
+
+@testset "ListOfSupportedConstraints" begin
+    @testset "$set" for set in (
+        MOI.EqualTo(1.0), MOI.GreaterThan(1.0), MOI.LessThan(1.0),
+        MOI.Interval(1.0, 2.0), MOI.Semicontinuous(1.0, 2.0),
+        MOI.Semiinteger(1.0, 2.0), MOI.Integer(), MOI.ZeroOne()
+    )
+        model = MOIU.Model{Float64}()
+        x = MOI.add_variable(model)
+        MOI.add_constraint(model, MOI.SingleVariable(x), set)
+        @test MOI.get(model, MOI.ListOfConstraints()) ==
+            [(MOI.SingleVariable, typeof(set))]
+    end
+end


### PR DESCRIPTION
It seems we were missing `Semicontinuous` and `Semiinteger` constraints when `SingleVariable` was treated differently.

Closes #879 