### PR TITLE
Add extension dictionary to MOIU.Model

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -915,6 +915,9 @@ macro model(model_name, ss, sst, vs, vst, sf, sft, vf, vft)
             con_to_name::Dict{$CI, String}
             name_to_con::Union{Dict{String, $CI}, Nothing}
             constrmap::Vector{Int} # Constraint Reference value ci -> index in array in Constraints
+            # A useful dictionary for extensions to store things. These are
+            # _not_ copied between models!
+            ext::Dict{Symbol, Any}
         end
     end
     for f in funs
@@ -947,6 +950,7 @@ macro model(model_name, ss, sst, vs, vst, sf, sft, vf, vft)
             empty!(model.con_to_name)
             model.name_to_con = nothing
             empty!(model.constrmap)
+            empty!(model.ext)
             $(Expr(:block, _callfield.(Ref(:($MOI.empty!)), funs)...))
         end
     end
@@ -1004,7 +1008,7 @@ macro model(model_name, ss, sst, vs, vst, sf, sft, vf, vft)
                               $SAF{T}($MOI.ScalarAffineTerm{T}[], zero(T)), 0,
                               nothing, UInt8[], T[], T[], Dict{$VI, String}(),
                               nothing, 0, Dict{$CI, String}(), nothing, Int[],
-                              $(_getCV.(funs)...))
+                              Dict{Symbol, Any}(), $(_getCV.(funs)...))
         end
 
         $MOI.supports_constraint(model::$esc_model_name{T}, ::Type{<:Union{$(_typedfun.(scalar_funs)...)}}, ::Type{<:Union{$(_typedset.(scalar_sets)...)}}) where T = true

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -265,3 +265,17 @@ end
             [(MOI.SingleVariable, typeof(set))]
     end
 end
+
+@testset "Extension dictionary" begin
+    model = MOIU.Model{Float64}()
+    model.ext[:my_store] = 1
+    @test model.ext[:my_store] == 1
+    MOI.empty!(model)
+    @test !haskey(model.ext, :my_store)
+    model.ext[:my_store] = 2
+    dest = MOIU.Model{Float64}()
+    MOI.copy_to(dest, model)
+    @test !haskey(dest.ext, :my_store)
+    @test haskey(model.ext, :my_store)
+    @test model.ext[:my_store] == 2
+end


### PR DESCRIPTION
I've found myself wanting this a few times. Particular in MathOptFormat to store options. 

We currently use a `UniversalFallback` with a new `AbstractModelAttribute`, but this requires some hacking:
https://github.com/odow/MathOptFormat.jl/blob/03a8d510aed483f1d83b8fc301da468d0ef82879/src/MPS/MPS.jl#L19-L29

There were three options:
1. What we currently do.
2. Defining a new model type in MathOptFormat and forwarding all `add_constraint` etc calls to it
3. Adding this extension dict.

Thoughts? (Mainly @blegat) Am I missing an easier way?