### PR TITLE
Fix == for sets with mutable fields

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -148,6 +148,10 @@ struct EqualTo{T <: Number} <: AbstractScalarSet
     value::T
 end
 
+function Base.:(==)(set1::S, set2::S) where S <: Union{GreaterThan, LessThan, EqualTo}
+    return constant(set1) == constant(set2)
+end
+
 """
     Interval{T <: Real}(lower::T,upper::T)
 
@@ -278,6 +282,10 @@ end
 dual_set(s::DualPowerCone{T}) where T <: Real = PowerCone{T}(s.exponent)
 
 dimension(s::Union{ExponentialCone, DualExponentialCone, PowerCone, DualPowerCone}) = 3
+
+function Base.:(==)(set1::S, set2::S) where S <: Union{PowerCone, DualPowerCone}
+    return set1.exponent == set2.exponent
+end
 
 """
     abstract type AbstractSymmetricMatrixSetTriangle <: AbstractVectorSet end
@@ -573,6 +581,10 @@ struct Semiinteger{T <: Real} <: AbstractScalarSet
     upper::T
 end
 
+function Base.:(==)(set1::S, set2::S) where S <: Union{Interval, Semicontinuous, Semiinteger}
+    return set1.lower == set2.lower && set1.upper == set2.upper
+end
+
 """
     SOS1{T <: Real}(weights::Vector{T})
 
@@ -654,6 +666,8 @@ dimension(::IndicatorSet) = 2
 function Base.copy(set::IndicatorSet{A,S}) where {A,S}
     return IndicatorSet{A}(copy(set.set))
 end
+
+Base.:(==)(set1::IndicatorSet{A, S}, set2::IndicatorSet{A, S}) where {A, S} = set1.set == set2.set
 
 # isbits types, nothing to copy
 function Base.copy(set::Union{Reals, Zeros, Nonnegatives, Nonpositives,

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -18,6 +18,37 @@ end
 Base.copy(mlt::MutLessThan) = MutLessThan(Base.copy(mlt.upper))
 
 @testset "Sets" begin
+    @testset "==" begin
+        # By default, `==` redirects to `===`, it works for bits type
+        # but not for `BigInt`s. We define functions creating different
+        # instances so that `a() !== a()`.
+        a() = big(1)
+        b() = big(2)
+        @test a() !== a()
+        @test b() !== b()
+        for S in [MOI.LessThan, MOI.GreaterThan, MOI.EqualTo, MOI.PowerCone, MOI.DualPowerCone]
+            @test S(a()) == S(a())
+            @test S(a()) != S(b())
+            @test S(b()) == S(b())
+            @test S(b()) == S(b())
+            @test S(b()) == S(b())
+        end
+        for S in [MOI.Interval, MOI.Semicontinuous, MOI.Semiinteger]
+            @test S(a(), b()) == S(a(), b())
+            @test S(a(), b()) != S(b(), a())
+            @test S(a(), b()) != S(b(), b())
+            @test S(a(), b()) != S(a(), a())
+            @test S(a(), a()) != S(b(), b())
+            @test S(a(), a()) == S(a(), a())
+        end
+        S = MOI.IndicatorSet
+        A() = MOI.LessThan(a())
+        B() = MOI.LessThan(b())
+        @test S{MOI.ACTIVATE_ON_ZERO}(A()) == S{MOI.ACTIVATE_ON_ZERO}(A())
+        @test S{MOI.ACTIVATE_ON_ZERO}(A()) != S{MOI.ACTIVATE_ON_ONE}(A())
+        @test S{MOI.ACTIVATE_ON_ZERO}(A()) != S{MOI.ACTIVATE_ON_ZERO}(B())
+        @test S{MOI.ACTIVATE_ON_ONE}(A()) != S{MOI.ACTIVATE_ON_ONE}(B())
+    end
     @testset "Copy" begin
         @testset "for $S" for S in [MOI.SOS1, MOI.SOS2]
             s = S([1.0])

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -30,8 +30,7 @@ Base.copy(mlt::MutLessThan) = MutLessThan(Base.copy(mlt.upper))
             @test S(a()) == S(a())
             @test S(a()) != S(b())
             @test S(b()) == S(b())
-            @test S(b()) == S(b())
-            @test S(b()) == S(b())
+            @test S(b()) != S(a())
         end
         for S in [MOI.Interval, MOI.Semicontinuous, MOI.Semiinteger]
             @test S(a(), b()) == S(a(), b())


### PR DESCRIPTION
This was needed to have CDD pass `contlineartest` for `Rational{BigInt}`.
See also https://github.com/JuliaOpt/MathOptInterface.jl/issues/841