### PR TITLE
Don't empty MOIU.Model ext dict

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -951,7 +951,6 @@ macro model(model_name, ss, sst, vs, vst, sf, sft, vf, vft)
             empty!(model.con_to_name)
             model.name_to_con = nothing
             empty!(model.constrmap)
-            empty!(model.ext)
             $(Expr(:block, _callfield.(Ref(:($MOI.empty!)), funs)...))
         end
     end

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -271,11 +271,10 @@ end
     model.ext[:my_store] = 1
     @test model.ext[:my_store] == 1
     MOI.empty!(model)
-    @test !haskey(model.ext, :my_store)
+    @test model.ext[:my_store] == 1
     model.ext[:my_store] = 2
     dest = MOIU.Model{Float64}()
     MOI.copy_to(dest, model)
     @test !haskey(dest.ext, :my_store)
-    @test haskey(model.ext, :my_store)
     @test model.ext[:my_store] == 2
 end


### PR DESCRIPTION
I changed my mind: I don't want the `model.ext` dict cleared on `MOI.empty!(model)`.

It's more useful to have persistent storage.