### PR TITLE
Fix deletion of constrained variables for CachingOptimizer

### DIFF
--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -113,6 +113,18 @@ function delete_nonnegative_variables(model::MOI.ModelLike, config::TestConfig)
     @test_throws MOI.InvalidIndex(v[1]) MOI.delete(model, v[1])
     @test !MOI.is_valid(model, cv)
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
+end
+unittests["delete_nonnegative_variables"] = delete_nonnegative_variables
+
+"""
+    update_dimension_nonnegative_variables(model::MOI.ModelLike, config::TestConfig)
+
+Test adding, and then deleting one by one, nonnegative variables.
+"""
+function update_dimension_nonnegative_variables(model::MOI.ModelLike, config::TestConfig)
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 0
     v, cv = MOI.add_constrained_variables(model, MOI.Nonnegatives(2))
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
     MOI.delete(model, v[1])
@@ -130,12 +142,12 @@ function delete_nonnegative_variables(model::MOI.ModelLike, config::TestConfig)
     @test_throws MOI.InvalidIndex(v[2]) MOI.delete(model, v[2])
     @test !MOI.is_valid(model, cv)
 end
-unittests["delete_nonnegative_variables"] = delete_nonnegative_variables
+unittests["update_dimension_nonnegative_variables"] = update_dimension_nonnegative_variables
 
 """
     delete_soc_variables(model::MOI.ModelLike, config::TestConfig)
 
-Test adding, and then deleting, nonnegative variables.
+Test adding, and then deleting, second-order cone variables.
 """
 function delete_soc_variables(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -89,6 +89,74 @@ end
 unittests["delete_variables"] = delete_variable
 
 """
+    delete_nonnegative_variables(model::MOI.ModelLike, config::TestConfig)
+
+Test adding, and then deleting, nonnegative variables.
+"""
+function delete_nonnegative_variables(model::MOI.ModelLike, config::TestConfig)
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 0
+    v, cv = MOI.add_constrained_variables(model, MOI.Nonnegatives(2))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+    MOI.delete(model, v)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 0
+    @test !MOI.is_valid(model, v[1])
+    @test_throws MOI.InvalidIndex(v[1]) MOI.delete(model, v[1])
+    @test !MOI.is_valid(model, v[2])
+    @test_throws MOI.InvalidIndex(v[2]) MOI.delete(model, v[2])
+    @test !MOI.is_valid(model, cv)
+    v, cv = MOI.add_constrained_variables(model, MOI.Nonnegatives(1))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+    MOI.delete(model, v[1])
+    @test !MOI.is_valid(model, v[1])
+    @test_throws MOI.InvalidIndex(v[1]) MOI.delete(model, v[1])
+    @test !MOI.is_valid(model, cv)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 0
+    v, cv = MOI.add_constrained_variables(model, MOI.Nonnegatives(2))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+    MOI.delete(model, v[1])
+    @test !MOI.is_valid(model, v[1])
+    @test_throws MOI.InvalidIndex(v[1]) MOI.delete(model, v[1])
+    @test MOI.is_valid(model, cv)
+    @test MOI.is_valid(model, v[2])
+    @test MOI.get(model, MOI.ConstraintFunction(), cv) == MOI.VectorOfVariables([v[2]])
+    @test MOI.get(model, MOI.ConstraintSet(), cv) == MOI.Nonnegatives(1)
+    MOI.delete(model, v[2])
+    @test MOI.get(model, MOI.NumberOfVariables()) == 0
+    @test !MOI.is_valid(model, v[1])
+    @test_throws MOI.InvalidIndex(v[1]) MOI.delete(model, v[1])
+    @test !MOI.is_valid(model, v[2])
+    @test_throws MOI.InvalidIndex(v[2]) MOI.delete(model, v[2])
+    @test !MOI.is_valid(model, cv)
+end
+unittests["delete_nonnegative_variables"] = delete_nonnegative_variables
+
+"""
+    delete_soc_variables(model::MOI.ModelLike, config::TestConfig)
+
+Test adding, and then deleting, nonnegative variables.
+"""
+function delete_soc_variables(model::MOI.ModelLike, config::TestConfig)
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 0
+    v, cv = MOI.add_constrained_variables(model, MOI.SecondOrderCone(3))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 3
+    MOI.delete(model, v)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 0
+    @test !MOI.is_valid(model, v[1])
+    @test_throws MOI.InvalidIndex(v[1]) MOI.delete(model, v[1])
+    @test !MOI.is_valid(model, v[2])
+    @test_throws MOI.InvalidIndex(v[2]) MOI.delete(model, v[2])
+    @test !MOI.is_valid(model, cv)
+    v, cv = MOI.add_constrained_variables(model, MOI.SecondOrderCone(3))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 3
+    @test_throws MOI.DeleteNotAllowed MOI.delete(model, v[1])
+end
+unittests["delete_soc_variables"] = delete_soc_variables
+
+"""
     getvariable(model::MOI.ModelLike, config::TestConfig)
 
 Test getting variables by name.


### PR DESCRIPTION
To delete constrained variables, you need to delete the whole vector of variables at once if the set dimension cannot change like `MOI.SecondOrderCone`. For this reason, it is important for `CachingOptimizer` to implement the deletion of vector of variables instead of relying on the fallback functions which deletes variable one by one otherwise you get the error:
```
delete_soc_variables: Error During Test at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:46
  Got exception outside of a @test
  MathOptInterface.DeleteNotAllowed{MathOptInterface.VariableIndex}: Deleting the index MathOptInterface.VariableIndex(1) cannot be performed: Cannot delete variable as it is constrained with other variables in a `MOI.VectorOfVariables`. You may want to use a `CachingOptimizer` in `AUTOMATIC` mode or you may need to call `reset_optimizer` before doing this operation if the `CachingOptimizer` is in `MANUAL` mode.
  Stacktrace:
   [1] throw_delete_variable_in_vov(::MathOptInterface.VariableIndex) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:137
   [2] _vector_of_variables_with(::Array{Tuple{MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables,MathOptInterface.SecondOrderCone},MathOptInterface.VectorOfVariables,MathOptInterface.SecondOrderCone},1}, ::MathOptInterface.VariableIndex) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:148
   [3] #152 at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:175 [inlined]
   [4] broadcastvcat(::getfield(MathOptInterface.Utilities, Symbol("##152#154")){MathOptInterface.VariableIndex}, ::MathOptInterface.Utilities.ModelVectorConstraints{Float64,MathOptInterface.VectorOfVariables}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:964
   [5] broadcastvcat(::Function, ::MathOptInterface.Utilities.Model{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:935
   [6] delete(::MathOptInterface.Utilities.Model{Float64}, ::MathOptInterface.VariableIndex) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/model.jl:175
   [7] delete(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.Model{Float64}}, ::MathOptInterface.VariableIndex) at /home/blegat/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:375
   [8] delete at /home/blegat/.julia/dev/MathOptInterface/src/indextypes.jl:126 [inlined]
   [9] delete_soc_variables(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.Model{Float64}}, ::MathOptInterface.Test.TestConfig{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/UnitTests/variables.jl:146
   [10] macro expansion at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:47 [inlined]
   [11] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113 [inlined]
   [12] unittest(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.Model{Float64}}, ::MathOptInterface.Test.TestConfig{Float64}, ::Array{String,1}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:47
   [13] unittest(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.Model{Float64}}, ::MathOptInterface.Test.TestConfig{Float64}) at /home/blegat/.julia/dev/MathOptInterface/src/Test/config.jl:42
   [14] top-level scope at /home/blegat/.julia/dev/MathOptInterface/test/Utilities/cachingoptimizer.jl:419
   [15] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1113
   [16] top-level scope at /home/blegat/.julia/dev/MathOptInterface/test/Utilities/cachingoptimizer.jl:419
   [17] top-level scope at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.2/Test/src/Test.jl:1186
   [18] top-level scope at /home/blegat/.julia/dev/MathOptInterface/test/Utilities/cachingoptimizer.jl:393
```