### PR TITLE
Implements submit for CachingOptimizer and AbstractBridgeOptimizer

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1118,6 +1118,12 @@ function MOI.add_constrained_variable(b::AbstractBridgeOptimizer,
     end
 end
 
+function MOI.supports(b::AbstractBridgeOptimizer, sub::MOI.AbstractSubmittable)
+    return MOI.supports(b.model, sub)
+end
+function MOI.submit(b::AbstractBridgeOptimizer, sub::MOI.AbstractSubmittable, args...)
+    return MOI.submit(b.model, sub, bridged_function.(b, args)...)
+end
 
 """
     bridged_variable_function(b::AbstractBridgeOptimizer,

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -575,17 +575,17 @@ end
 
 function MOI.get(m::CachingOptimizer, attr::AttributeFromOptimizer{T}) where {T <: MOI.AbstractModelAttribute}
     @assert m.state == ATTACHED_OPTIMIZER
-    return map_indices(m.optimizer_to_model_map,MOI.get(m.optimizer, attr.attr))
+    return map_indices(m.optimizer_to_model_map, MOI.get(m.optimizer, attr.attr))
 end
 
 function MOI.get(m::CachingOptimizer, attr::AttributeFromOptimizer{T}, idx::MOI.Index) where {T <: Union{MOI.AbstractVariableAttribute,MOI.AbstractConstraintAttribute}}
     @assert m.state == ATTACHED_OPTIMIZER
-    return map_indices(m.optimizer_to_model_map,MOI.get(m.optimizer, attr.attr, m.model_to_optimizer_map[idx]))
+    return map_indices(m.optimizer_to_model_map, MOI.get(m.optimizer, attr.attr, m.model_to_optimizer_map[idx]))
 end
 
 function MOI.get(m::CachingOptimizer, attr::AttributeFromOptimizer{T}, idx::Vector{<:MOI.Index}) where {T <: Union{MOI.AbstractVariableAttribute,MOI.AbstractConstraintAttribute}}
     @assert m.state == ATTACHED_OPTIMIZER
-    return map_indices(m.optimizer_to_model_map,MOI.get(m.optimizer, attr.attr, getindex.(m.model_to_optimizer_map,idx)))
+    return map_indices(m.optimizer_to_model_map, MOI.get(m.optimizer, attr.attr, getindex.(m.model_to_optimizer_map,idx)))
 end
 
 function MOI.set(m::CachingOptimizer, attr::AttributeFromModelCache{T}, v) where {T <: MOI.AbstractModelAttribute}
@@ -625,6 +625,14 @@ end
 function MOI.supports(m::CachingOptimizer, attr::AttributeFromOptimizer{T}, idxtype::Type{<:MOI.Index}) where {T <: Union{MOI.AbstractVariableAttribute,MOI.AbstractConstraintAttribute}}
     @assert m.state == ATTACHED_OPTIMIZER
     return MOI.supports(m.optimizer, attr.attr, idxtype)
+end
+
+function MOI.supports(caching_opt::CachingOptimizer, sub::MOI.AbstractSubmittable)
+    return caching_opt.optimizer !== nothing && MOI.supports(caching_opt.optimizer, sub)
+end
+function MOI.submit(caching_opt::CachingOptimizer, sub::MOI.AbstractSubmittable, args...)
+    MOI.submit(caching_opt.optimizer, sub,
+               map_indices.(Ref(caching_opt.model_to_optimizer_map), args)...)
 end
 
 # TODO: get and set methods to look up/set name strings

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -73,7 +73,7 @@ function map_indices(variable_map::AbstractDict{T, T}, x) where {T <: MOI.Index}
     return map_indices(vi -> variable_map[vi], x)
 end
 
-const ObjectWithoutIndex = Union{Nothing, DataType, Number, Enum, AbstractString, MOI.AnyAttribute, MOI.AbstractSet}
+const ObjectWithoutIndex = Union{Nothing, DataType, Number, Enum, AbstractString, MOI.AnyAttribute, MOI.AbstractSet, Function}
 const ObjectOrTupleWithoutIndex = Union{ObjectWithoutIndex, Tuple{Vararg{ObjectWithoutIndex}}}
 const ObjectOrTupleOrArrayWithoutIndex = Union{ObjectOrTupleWithoutIndex, AbstractArray{<:ObjectOrTupleWithoutIndex}}
 

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -147,6 +147,18 @@ function substitute_variables end
 substitute_variables(::Function, x::ObjectOrTupleOrArrayWithoutIndex) = x
 substitute_variables(::Function, block::MOI.NLPBlockData) = block
 
+# Used when submitting `HeuristicSolution`.
+function substitute_variables(variable_map::Function, vis::Vector{MOI.VariableIndex})
+    return substitute_variables.(variable_map, vis)
+end
+function substitute_variables(variable_map::Function, vi::MOI.VariableIndex)
+    func = variable_map(vi)
+    if func != MOI.SingleVariable(vi)
+        error("Cannot substitute `$vi` as it is bridged into `$func`.")
+    end
+    return vi
+end
+
 function substitute_variables(variable_map::Function,
                               term::MOI.ScalarQuadraticTerm{T}) where T
     f1 = variable_map(term.variable_index_1)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -951,6 +951,7 @@ the callback identified by `callback_data`.
 struct CallbackVariablePrimal{CallbackDataType} <: AbstractVariableAttribute
     callback_data::CallbackDataType
 end
+is_set_by_optimize(::CallbackVariablePrimal) = true
 
 """
     BasisStatusCode

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -67,6 +67,24 @@ struct DummyConstraintAttribute <: MOI.AbstractConstraintAttribute end
         @test MOI.get(mock, attr, [index])[1] ≈ 3.0fy + 1.0fz + 3.0
     end
 
+    @testset "HeuristicCallback" begin
+        attr = MOI.HeuristicCallback()
+        f(callback_data) = nothing
+        MOI.set(bridged, attr, f)
+        @test MOI.get(bridged, attr) === f
+    end
+
+    @testset "CallbackVariablePrimal" begin
+        attr = MOI.CallbackVariablePrimal(nothing)
+        err = ErrorException("No mock callback primal is set for variable `$z`.")
+        @test_throws err MOI.get(bridged, attr, z)
+        MOI.set(mock, attr, y, 1.0)
+        MOI.set(mock, attr, z, 2.0)
+        @test MOI.get(bridged, attr, z) == 2.0
+        err = ArgumentError("Variable bridge of type `$(typeof(MOIB.bridge(bridged, x)))` does not support accessing the attribute `$attr`.")
+        @test_throws err MOI.get(bridged, attr, x)
+    end
+
     @testset "LazyConstraint" begin
         sub = MOI.LazyConstraint(nothing)
         @test MOI.supports(bridged, sub)

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -67,6 +67,28 @@ struct DummyConstraintAttribute <: MOI.AbstractConstraintAttribute end
         @test MOI.get(mock, attr, [index])[1] ≈ 3.0fy + 1.0fz + 3.0
     end
 
+    @testset "LazyConstraint" begin
+        sub = MOI.LazyConstraint(nothing)
+        @test MOI.supports(bridged, sub)
+        MOI.submit(bridged, sub, 2.0fx, MOI.GreaterThan(1.0))
+        mock.submitted[sub][1][1] ≈ 2.0fy + 2.0
+        mock.submitted[sub][1][2] == MOI.GreaterThan(1.0)
+    end
+    @testset "HeuristicSolution" begin
+        sub = MOI.HeuristicSolution(nothing)
+        @test MOI.supports(bridged, sub)
+        @testset "Non-bridged variable" begin
+            MOI.submit(bridged, sub, [z], [1.0])
+            mock.submitted[sub][1][1] == [z]
+            mock.submitted[sub][1][2] == [1.0]
+        end
+        @testset "Bridged variable" begin
+            err = ErrorException("Cannot substitute `$x` as it is bridged into `$(1.0fy + 1.0)`.")
+            @test_throws err MOI.submit(bridged, sub, [x], [1.0])
+
+        end
+    end
+
     nlp_data = MOI.NLPBlockData(
         [MOI.NLPBoundsPair(1.0, 2.0)],
         DummyEvaluator(), false)

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -156,11 +156,27 @@ struct DummyConstraintAttribute <: MOI.AbstractConstraintAttribute end
         @test MOI.get(mock, attr, [optimizer_index])[1] ≈ 3.0fy
     end
 
+    @testset "HeuristicCallback" begin
+        attr = MOI.HeuristicCallback()
+        f(callback_data) = nothing
+        MOI.set(model, attr, f)
+        @test MOI.get(model, attr) === f
+    end
+
+    @testset "CallbackVariablePrimal" begin
+        attr = MOI.CallbackVariablePrimal(nothing)
+        err = ErrorException("No mock callback primal is set for variable `$y`.")
+        @test_throws err MOI.get(model, attr, x)
+        MOI.set(mock, attr, y, 1.0)
+        @test_throws MOI.InvalidIndex(x) MOI.get(mock, attr, x)
+        @test MOI.get(mock, attr, y) == 1.0
+        @test MOI.get(model, attr, x) == 1.0
+    end
+
     @testset "LazyConstraint" begin
         sub = MOI.LazyConstraint(nothing)
         @test MOI.supports(model, sub)
         MOI.submit(model, sub, 2.0fx, MOI.GreaterThan(1.0))
-        @show mock.submitted[sub]
         @test mock.submitted[sub][1][1] ≈ 2.0fy
         @test mock.submitted[sub][1][2] == MOI.GreaterThan(1.0)
     end


### PR DESCRIPTION
This should allow callbacks to be used with JuMP in `AUTOMATIC` and `MANUAL` mode instead of `DIRECT` mode.
The only thing unsupported is submitting `HeuristicSolution` involving a bridged variable. We could try to determine the value of the solver variables given the value of the bridged variables by solving a linear system but let's keep it simple for now as currently the solvers with callbacks don't need variable bridges.