### PR TITLE
Add Variable.RSOCtoSOCBridge

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -654,6 +654,7 @@ Bridges.Variable.FreeBridge
 Bridges.Variable.NonposToNonnegBridge
 Bridges.Variable.VectorizeBridge
 Bridges.Variable.SOCtoRSOCBridge
+Bridges.Variable.RSOCtoSOCBridge
 Bridges.Variable.RSOCtoPSDBridge
 ```
 

--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -33,6 +33,8 @@ include("vectorize.jl")
 const Vectorize{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{VectorizeBridge{T}, OT}
 include("soc_to_rsoc.jl")
 const SOCtoRSOC{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{SOCtoRSOCBridge{T}, OT}
+include("rsoc_to_soc.jl")
+const RSOCtoSOC{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{RSOCtoSOCBridge{T}, OT}
 include("rsoc_to_psd.jl")
 const RSOCtoPSD{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{RSOCtoPSDBridge{T}, OT}
 
@@ -48,6 +50,7 @@ function add_all_bridges(bridged_model, T::Type)
     MOIB.add_bridge(bridged_model, NonposToNonnegBridge{T})
     MOIB.add_bridge(bridged_model, VectorizeBridge{T})
     MOIB.add_bridge(bridged_model, SOCtoRSOCBridge{T})
+    MOIB.add_bridge(bridged_model, RSOCtoSOCBridge{T})
     MOIB.add_bridge(bridged_model, RSOCtoPSDBridge{T})
     return
 end

--- a/src/Bridges/Variable/rsoc_to_soc.jl
+++ b/src/Bridges/Variable/rsoc_to_soc.jl
@@ -1,0 +1,136 @@
+function rotate_result(
+    model, attr::Union{MOI.ConstraintPrimal, MOI.ConstraintDual},
+    ci::MOI.ConstraintIndex)
+    x = MOI.get(model, attr, ci)
+    T = eltype(x)
+    s2 = √T(2)
+    return [x[1]/s2 + x[2]/s2; x[1]/s2 - x[2]/s2; x[3:end]]
+end
+
+function rotate_result(
+    model, attr::MOI.VariablePrimal, variables, i::IndexInVector)
+
+    if i.value == 1 || i.value == 2
+        t, u = MOI.get(model, attr, variables[1:2])
+        T = typeof(t)
+        s2 = √T(2)
+        if i.value == 1
+            return t/s2 + u/s2
+        else
+            return t/s2 - u/s2
+        end
+    else
+        return MOI.get(model, attr, variables[i.value])
+    end
+end
+
+function rotate_bridged_function(T::Type, variables, i::IndexInVector)
+    s2 = √T(2)
+    if i.value == 1 || i.value == 2
+        t = MOIU.operate(/, T, MOI.SingleVariable(variables[1]), s2)
+        u = MOIU.operate(/, T, MOI.SingleVariable(variables[2]), s2)
+        if i.value == 1
+            return MOIU.operate!(+, T, t, u)
+        else
+            return MOIU.operate!(-, T, t, u)
+        end
+    else
+        return convert(MOI.ScalarAffineFunction{T}, MOI.SingleVariable(variables[i.value]))
+    end
+end
+
+function rotate_unbridged_map(
+    T::Type,
+    inner_variables::Vector{MOI.VariableIndex},
+    bridged_variables::Vector{MOI.VariableIndex})
+
+    F = MOI.ScalarAffineFunction{T}
+    umap = Pair{MOI.VariableIndex, F}[]
+    s2 = √T(2)
+    t = MOIU.operate(/, T, MOI.SingleVariable(bridged_variables[1]), s2)
+    u = MOIU.operate(/, T, MOI.SingleVariable(bridged_variables[2]), s2)
+    push!(umap, inner_variables[1] => MOIU.operate(+, T, t, u))
+    push!(umap, inner_variables[2] => MOIU.operate(-, T, t, u))
+    for i in 3:length(bridged_variables)
+        func = convert(F, MOI.SingleVariable(bridged_variables[i]))
+        push!(umap, inner_variables[i] => func)
+    end
+    return umap
+end
+
+"""
+    RSOCtoSOCBridge{T} <: Bridges.Variable.AbstractBridge
+
+Same transformation as [`MOI.Bridges.Constraint.RSOCBridge`](@ref).
+"""
+struct RSOCtoSOCBridge{T} <: AbstractBridge
+    variables::Vector{MOI.VariableIndex}
+    constraint::MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.SecondOrderCone}
+end
+function bridge_constrained_variable(
+    ::Type{RSOCtoSOCBridge{T}}, model::MOI.ModelLike,
+    set::MOI.RotatedSecondOrderCone) where T
+    variables, constraint = MOI.add_constrained_variables(
+        model, MOI.SecondOrderCone(MOI.dimension(set)))
+    return RSOCtoSOCBridge{T}(variables, constraint)
+end
+
+function supports_constrained_variable(
+    ::Type{<:RSOCtoSOCBridge}, ::Type{MOI.RotatedSecondOrderCone})
+    return true
+end
+function MOIB.added_constrained_variable_types(::Type{<:RSOCtoSOCBridge})
+    return [(MOI.SecondOrderCone,)]
+end
+function MOIB.added_constraint_types(::Type{<:RSOCtoSOCBridge})
+    return Tuple{DataType, DataType}[]
+end
+
+# Attributes, Bridge acting as a model
+function MOI.get(bridge::RSOCtoSOCBridge, ::MOI.NumberOfVariables)
+    return length(bridge.variables)
+end
+function MOI.get(bridge::RSOCtoSOCBridge, ::MOI.ListOfVariableIndices)
+    return bridge.variables
+end
+function MOI.get(bridge::RSOCtoSOCBridge,
+                 ::MOI.NumberOfConstraints{MOI.VectorOfVariables,
+                                           MOI.SecondOrderCone})
+    return 1
+end
+function MOI.get(bridge::RSOCtoSOCBridge,
+                 ::MOI.ListOfConstraintIndices{MOI.VectorOfVariables,
+                                               MOI.SecondOrderCone})
+    return [bridge.constraint]
+end
+
+# References
+function MOI.delete(model::MOI.ModelLike, bridge::RSOCtoSOCBridge)
+    MOI.delete(model, bridge.variables)
+end
+
+# Attributes, Bridge acting as a constraint
+
+function MOI.get(::MOI.ModelLike, ::MOI.ConstraintSet,
+                 bridge::RSOCtoSOCBridge{T}) where T
+    return MOI.RotatedSecondOrderCone(length(bridge.variables))
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimal, MOI.ConstraintDual},
+    bridge::RSOCtoSOCBridge)
+    return rotate_result(model, attr, bridge.constraint)
+end
+
+function MOI.get(model::MOI.ModelLike, attr::MOI.VariablePrimal,
+                 bridge::RSOCtoSOCBridge, i::IndexInVector)
+    return rotate_result(model, attr, bridge.variables, i)
+end
+
+function MOIB.bridged_function(bridge::RSOCtoSOCBridge{T}, i::IndexInVector) where T
+    return rotate_bridged_function(T, bridge.variables, i)
+end
+function unbridged_map(bridge::RSOCtoSOCBridge{T}, vis::Vector{MOI.VariableIndex}) where T
+    return rotate_unbridged_map(T, bridge.variables, vis)
+end

--- a/src/Bridges/Variable/soc_to_rsoc.jl
+++ b/src/Bridges/Variable/soc_to_rsoc.jl
@@ -1,12 +1,3 @@
-function rotate_result(
-    model, attr::Union{MOI.ConstraintPrimal, MOI.ConstraintDual},
-    ci::MOI.ConstraintIndex)
-    x = MOI.get(model, attr, ci)
-    T = eltype(x)
-    s2 = √T(2)
-    return [x[1]/s2 + x[2]/s2; x[1]/s2 - x[2]/s2; x[3:end]]
-end
-
 """
     SOCtoRSOCBridge{T} <: Bridges.Variable.AbstractBridge
 
@@ -73,44 +64,13 @@ function MOI.get(
 end
 
 function MOI.get(model::MOI.ModelLike, attr::MOI.VariablePrimal,
-                 bridge::SOCtoRSOCBridge{T}, i::IndexInVector) where T
-    if i.value == 1 || i.value == 2
-        t, u = MOI.get(model, attr, bridge.variables[1:2])
-        s2 = √T(2)
-        if i.value == 1
-            return t/s2 + u/s2
-        else
-            return t/s2 - u/s2
-        end
-    else
-        return MOI.get(model, attr, bridge.variables[i.value])
-    end
+                 bridge::SOCtoRSOCBridge, i::IndexInVector)
+    return rotate_result(model, attr, bridge.variables, i)
 end
 
 function MOIB.bridged_function(bridge::SOCtoRSOCBridge{T}, i::IndexInVector) where T
-    s2 = √T(2)
-    if i.value == 1 || i.value == 2
-        t = MOIU.operate(/, T, MOI.SingleVariable(bridge.variables[1]), s2)
-        u = MOIU.operate(/, T, MOI.SingleVariable(bridge.variables[2]), s2)
-        if i.value == 1
-            return MOIU.operate!(+, T, t, u)
-        else
-            return MOIU.operate!(-, T, t, u)
-        end
-    else
-        return convert(MOI.ScalarAffineFunction{T}, MOI.SingleVariable(bridge.variables[i.value]))
-    end
+    return rotate_bridged_function(T, bridge.variables, i)
 end
 function unbridged_map(bridge::SOCtoRSOCBridge{T}, vis::Vector{MOI.VariableIndex}) where T
-    umap = Pair{MOI.VariableIndex, MOI.ScalarAffineFunction{T}}[]
-    s2 = √T(2)
-    t = MOIU.operate(/, T, MOI.SingleVariable(vis[1]), s2)
-    u = MOIU.operate(/, T, MOI.SingleVariable(vis[2]), s2)
-    push!(umap, bridge.variables[1] => MOIU.operate(+, T, t, u))
-    push!(umap, bridge.variables[2] => MOIU.operate(-, T, t, u))
-    for i in 3:length(vis)
-        func = convert(MOI.ScalarAffineFunction{T}, MOI.SingleVariable(vis[i]))
-        push!(umap, bridge.variables[i] => func)
-    end
-    return umap
+    return rotate_unbridged_map(T, bridge.variables, vis)
 end

--- a/test/Bridges/Variable/rsoc_to_soc.jl
+++ b/test/Bridges/Variable/rsoc_to_soc.jl
@@ -1,0 +1,84 @@
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+const MOIT = MathOptInterface.Test
+const MOIU = MathOptInterface.Utilities
+const MOIB = MathOptInterface.Bridges
+
+include("../utilities.jl")
+
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
+config = MOIT.TestConfig()
+
+bridged_mock = MOIB.Variable.RSOCtoSOC{Float64}(mock)
+
+@testset "rotatedsoc4" begin
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+        [√2, 0.0, 1.0, 1.0],
+        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1.0])
+    MOIT.rotatedsoc4test(bridged_mock, config)
+
+    ceqs = MOI.get(mock, MOI.ListOfConstraintIndices{
+        MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+    @test length(ceqs) == 1
+    MOI.set(bridged_mock, MOI.ConstraintName(), ceqs[1], "c")
+
+    @testset "Test mock model" begin
+        var_names = ["a", "b", "c", "d"]
+        MOI.set(
+            mock, MOI.VariableName(),
+            MOI.get(mock, MOI.ListOfVariableIndices()), var_names)
+        socs = MOI.get(mock, MOI.ListOfConstraintIndices{
+            MOI.VectorOfVariables, MOI.SecondOrderCone}())
+        @test length(socs) == 1
+        MOI.set(mock, MOI.ConstraintName(), socs[1], "soc")
+
+        s2 = √2
+        s = """
+        variables: a, b, c, d
+        soc: [a, b, c, d] in MathOptInterface.SecondOrderCone(4)
+        c: $s2*a <= 2.0
+        maxobjective: c + d
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(mock, model, var_names, ["soc", "c"])
+    end
+
+    @testset "Test bridged model" begin
+        var_names = ["t", "u", "x", "y"]
+        MOI.set(
+            bridged_mock, MOI.VariableName(),
+            MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+        rsocs = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{
+            MOI.VectorOfVariables, MOI.RotatedSecondOrderCone}())
+        @test length(rsocs) == 1
+        MOI.set(bridged_mock, MOI.ConstraintName(), rsocs[1], "rsoc")
+
+        s = """
+        variables: t, u, x, y
+        rsoc: [t, u, x, y] in MathOptInterface.RotatedSecondOrderCone(4)
+        c: t + u <= 2.0
+        maxobjective: x + y
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(bridged_mock, model, var_names, ["rsoc", "c"])
+    end
+
+    @testset "Delete" begin
+        tuxy = MOI.get(bridged_mock, MOI.ListOfVariableIndices())
+
+        message = string("Cannot delete variable as it is constrained with other",
+                         " variables in a `MOI.VectorOfVariables`.")
+        for i in eachindex(tuxy)
+            err = MOI.DeleteNotAllowed(tuxy[i], message)
+            @test_throws err MOI.delete(bridged_mock, tuxy[i])
+        end
+
+        test_delete_bridged_variables(bridged_mock, tuxy, MOI.RotatedSecondOrderCone, 4, (
+            (MOI.VectorOfVariables, MOI.SecondOrderCone, 0),
+        ))
+    end
+end


### PR DESCRIPTION
Currently, SDPT3 bridges constrained variables in RSOC into constrained variables in PSD. The bridge selection cannot be blamed, the only other solution is bridging with `Constraint.RSOCBridge` and then `Constraint.VectorSlackBridge` but that's two bridges and it creates slacks so it's not obvious either for the bridge selection algo or for us humans what's the best choice. With this PR, the best choice is clearly the new `Variable.RSOCtoSOCBridge` as it is only one bridge and it does not create any new slack variables :tada: It is added before the `Variable.RSOCtoPSDBridge` in `add_all_bridges` so that it is preferred as both bridging possibilities only use one bridge so they are tied.