### PR TITLE
Fix deletion of variables in bridged VectorOfVariables constraints

### DIFF
--- a/src/Bridges/Constraint/bridge.jl
+++ b/src/Bridges/Constraint/bridge.jl
@@ -6,6 +6,16 @@ bridges.
 """
 abstract type AbstractBridge <: MOIB.AbstractBridge end
 
+# TODO [breaking] merge with `Bridges.Variable.IndexInVector` into `Bridges.IndexInVector`
+"""
+    IndexInVector
+
+Index of variable in vector of variables.
+"""
+struct IndexInVector
+    value::Int
+end
+
 """
     bridge_constraint(BT::Type{<:AbstractBridge}, model::MOI.ModelLike,
                       func::AbstractFunction, set::MOI.AbstractSet)

--- a/src/Bridges/Constraint/map.jl
+++ b/src/Bridges/Constraint/map.jl
@@ -211,19 +211,16 @@ function variable_constraints(map::Map, vi::MOI.VariableIndex)
 end
 
 """
-    variable_constraints(map::Map, vis::Vector{MOI.VariableIndex})
+    vector_of_variables_constraints(map::Map)
 
-Return the list of all keys that *may* correspond to
-[`MathOptInterface.VectorOfVariables`](@ref) constraints on the variables `vis`.
+Return the list of all keys that correspond to
+[`MathOptInterface.VectorOfVariables`](@ref) constraints.
 """
-function variable_constraints(map::Map, vis::Vector{MOI.VariableIndex})
-    cis = MOI.ConstraintIndex{MOI.VectorOfVariables}[]
-    for key in keys(map.vector_of_variables_constraints)
-        if key[1] == first(vis).value
-            push!(cis, MOI.ConstraintIndex{MOI.VectorOfVariables, key[2]}(key[1]))
-        end
-    end
-    return cis
+function vector_of_variables_constraints(map::Map)
+    return MOIU.LazyMap{MOI.ConstraintIndex{MOI.VectorOfVariables}}(
+        key -> MOI.ConstraintIndex{MOI.VectorOfVariables, key[2]}(key[1]),
+        keys(map.vector_of_variables_constraints)
+    )
 end
 
 """

--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -49,8 +49,16 @@ end
 
 # References
 function MOI.delete(model::MOI.ModelLike, bridge::ScalarizeBridge)
-    MOI.delete.(model, bridge.scalar_constraints)
-    nothing
+    for ci in bridge.scalar_constraints
+        MOI.delete(model, ci)
+    end
+end
+function MOI.delete(model::MOI.ModelLike, bridge::ScalarizeBridge,
+                    i::IndexInVector)
+    MOI.delete(model, bridge.scalar_constraints[i.value])
+    deleteat!(bridge.scalar_constraints, i.value)
+    deleteat!(bridge.constants, i.value)
+    return
 end
 
 # Attributes, Bridge acting as a constraint

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -253,20 +253,42 @@ function MOI.is_valid(b::AbstractBridgeOptimizer, ci::MOI.ConstraintIndex{F, S})
         return MOI.is_valid(b.model, ci)
     end
 end
+function _delete_variables_in_vector_of_variables_constraint(
+    b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex},
+    ci::MOI.ConstraintIndex{MOI.VectorOfVariables, S}) where S
+    func = MOI.get(b, MOI.ConstraintFunction(), ci)
+    variables = copy(func.variables)
+    if vis == variables
+        MOI.delete(b, ci)
+    else
+        for vi in vis
+            i = findfirst(isequal(vi), variables)
+            if i !== nothing
+                if MOI.supports_dimension_update(S)
+                    MOI.delete(b, bridge(b, ci), Constraint.IndexInVector(i))
+                else
+                    MOIU.throw_delete_variable_in_vov(vi)
+                end
+            end
+        end
+    end
+end
+function _delete_variables_in_variables_constraints(
+    b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
+    # Delete all `MOI.VectorOfVariables` constraints of these variables.
+    for ci in Constraint.vector_of_variables_constraints(Constraint.bridges(b))
+        _delete_variables_in_vector_of_variables_constraint(b, vis, ci)
+    end
+    # Delete all `MOI.SingleVariable` constraints of these variables.
+    for vi in vis
+        for ci in Constraint.variable_constraints(Constraint.bridges(b), vi)
+            MOI.delete(b, ci)
+        end
+    end
+end
 function MOI.delete(b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
     if Constraint.has_bridges(Constraint.bridges(b))
-        # Delete all `MOI.VectorOfVariables` constraints of these variables.
-        for ci in Constraint.variable_constraints(Constraint.bridges(b), vis)
-            if vis == MOI.get(b, MOI.ConstraintFunction(), ci).variables
-                MOI.delete(b, ci)
-            end
-        end
-        # Delete all `MOI.SingleVariable` constraints of these variables.
-        for vi in vis
-            for ci in Constraint.variable_constraints(Constraint.bridges(b), vi)
-                MOI.delete(b, ci)
-            end
-        end
+        _delete_variables_in_variables_constraints(b, vis)
     end
     if any(vi -> is_bridged(b, vi), vis)
         for vi in vis
@@ -293,16 +315,7 @@ function MOI.delete(b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
 end
 function MOI.delete(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex)
     if Constraint.has_bridges(Constraint.bridges(b))
-        # Delete all `MOI.VectorOfVariables` constraints of this variables.
-        for ci in Constraint.variable_constraints(Constraint.bridges(b), [vi])
-            if [vi] == MOI.get(b, MOI.ConstraintFunction(), ci).variables
-                MOI.delete(b, ci)
-            end
-        end
-        # Delete all `MOI.SingleVariable` constraints of this variable
-        for ci in Constraint.variable_constraints(Constraint.bridges(b), vi)
-            MOI.delete(b, ci)
-        end
+        _delete_variables_in_variables_constraints(b, [vi])
     end
     if is_bridged(b, vi)
         MOI.throw_if_not_valid(b, vi)

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -293,6 +293,12 @@ function MOI.delete(b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
 end
 function MOI.delete(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex)
     if Constraint.has_bridges(Constraint.bridges(b))
+        # Delete all `MOI.VectorOfVariables` constraints of this variables.
+        for ci in Constraint.variable_constraints(Constraint.bridges(b), [vi])
+            if [vi] == MOI.get(b, MOI.ConstraintFunction(), ci).variables
+                MOI.delete(b, ci)
+            end
+        end
         # Delete all `MOI.SingleVariable` constraints of this variable
         for ci in Constraint.variable_constraints(Constraint.bridges(b), vi)
             MOI.delete(b, ci)

--- a/test/Bridges/Constraint/flip_sign.jl
+++ b/test/Bridges/Constraint/flip_sign.jl
@@ -97,6 +97,19 @@ end
     test_delete_bridge(bridged_mock, ci, 2,
                        ((MOI.VectorAffineFunction{Float64},
                          MOI.Nonpositives, 1),))
+
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 0.0, 2.0],
+        (MOI.VectorAffineFunction{Float64}, MOI.Nonpositives) => [[0, -2, 0]],
+        (MOI.VectorAffineFunction{Float64}, MOI.Zeros)        => [[-3, -1]])
+    MOIT.lin1vtest(bridged_mock, config)
+    ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorOfVariables, MOI.Nonnegatives}()))
+    func = MOI.get(bridged_mock, MOI.ConstraintFunction(), ci)
+    MOI.delete(bridged_mock, func.variables[2])
+    new_func = MOI.VectorOfVariables(func.variables[[1, 3]])
+    @test MOI.get(bridged_mock, MOI.ConstraintFunction(), ci) == new_func
+    @test MOI.get(bridged_mock, MOI.ConstraintSet(), ci) == MOI.Nonnegatives(2)
+    test_delete_bridge(bridged_mock, ci, 2,
+        ((MOI.VectorAffineFunction{Float64}, MOI.Nonpositives, 0),))
 end
 
 @testset "NonposToNonneg" begin

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -103,7 +103,12 @@ end
             bridged_mock,
             MOI.ListOfConstraintIndices{MOI.VectorOfVariables,
                                         MOI.Nonnegatives}()))
-        test_delete_bridge(bridged_mock, ci, 3,
+        func = MOI.get(bridged_mock, MOI.ConstraintFunction(), ci)
+        MOI.delete(bridged_mock, func.variables[2])
+        new_func = MOI.VectorOfVariables(func.variables[[1, 3]])
+        @test MOI.get(bridged_mock, MOI.ConstraintFunction(), ci) == new_func
+        @test MOI.get(bridged_mock, MOI.ConstraintSet(), ci) == MOI.Nonnegatives(2)
+        test_delete_bridge(bridged_mock, ci, 2,
                            ((MOI.VectorAffineFunction{Float64},
                              MOI.Nonnegatives, 0),))
     end

--- a/test/Bridges/Constraint/scalarize.jl
+++ b/test/Bridges/Constraint/scalarize.jl
@@ -31,9 +31,15 @@ config = MOIT.TestConfig()
         ((MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}, 0),
          (MOI.SingleVariable, MOI.GreaterThan{Float64}, 0)))
     ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorOfVariables, MOI.Nonnegatives}()))
-    test_delete_bridge(bridged_mock, ci, 3,
+    func = MOI.get(bridged_mock, MOI.ConstraintFunction(), ci)
+    MOI.delete(bridged_mock, func.variables[2])
+    new_func = MOI.VectorOfVariables(func.variables[[1, 3]])
+    @test MOI.get(bridged_mock, MOI.ConstraintFunction(), ci) == new_func
+    @test MOI.get(bridged_mock, MOI.ConstraintSet(), ci) == MOI.Nonnegatives(2)
+    test_delete_bridge(bridged_mock, ci, 2,
         ((MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}, 0),
          (MOI.SingleVariable, MOI.GreaterThan{Float64}, 0)))
+
     # VectorAffineFunction-in-Nonnegatives
     # VectorAffineFunction-in-Zeros
     mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.0, 0.0, 2.0],
@@ -48,6 +54,7 @@ config = MOIT.TestConfig()
     test_delete_bridge(bridged_mock, ci, 3,
         ((MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}, 0),
          (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}, 0)))
+
     # VectorOfVariables-in-Nonnegatives
     # VectorOfVariables-in-Nonpositives
     # VectorOfVariables-in-Zeros
@@ -55,6 +62,7 @@ config = MOIT.TestConfig()
     mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [-4, -3, 16, 0],
         (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})        => [7, 2, -4])
     MOIT.lin2vtest(bridged_mock, config)
+
     # VectorAffineFunction-in-Nonnegatives
     # VectorAffineFunction-in-Nonpositives
     # VectorAffineFunction-in-Zeros

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -143,6 +143,17 @@ MOIU.@model(
     MOIT.nametest(bridged)
 end
 
+@testset "Unit" begin
+    model = LPModel{Float64}()
+    bridged = MOIB.full_bridge_optimizer(model, Float64)
+    MOIT.unittest(bridged, MOIT.TestConfig(solve=false), [
+        # FIXME
+        "update_dimension_nonnegative_variables",
+        # SOC and quadratic constraints not supported
+        "solve_qcp_edge_cases", "delete_soc_variables"
+    ])
+end
+
 # Model similar to SDPA format, it gives a good example because it does not
 # support a lot hence need a lot of bridges
 MOIU.@model(SDPAModel,

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -147,8 +147,6 @@ end
     model = LPModel{Float64}()
     bridged = MOIB.full_bridge_optimizer(model, Float64)
     MOIT.unittest(bridged, MOIT.TestConfig(solve=false), [
-        # FIXME
-        "update_dimension_nonnegative_variables",
         # SOC and quadratic constraints not supported
         "solve_qcp_edge_cases", "delete_soc_variables"
     ])


### PR DESCRIPTION
Fix bug caught by @odow in https://github.com/JuliaOpt/GLPK.jl/pull/120/files#r330827511

This adds the requirements for constraint bridges to implement `MOI.delete(::ModelLike, BridgeType, ::IndexInVector)` for `VectorOfVariables`-in-`S` constraints where `MOI.supports_dimension_update(S)` is `true`.