### PR TITLE
PrimalStatus/DualStatus should be NO_SOLUTION if `result_index` is out of bounds

### DIFF
--- a/src/Test/UnitTests/solve.jl
+++ b/src/Test/UnitTests/solve.jl
@@ -152,14 +152,14 @@ function solve_result_index(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ObjectiveValue(1)) ≈ 1.0 atol=atol rtol=rtol
         @test_throws result_err(MOI.ObjectiveValue(2)) MOI.get(model, MOI.ObjectiveValue(2))
         @test MOI.get(model, MOI.PrimalStatus(1)) == MOI.FEASIBLE_POINT
-        @test_throws result_err(MOI.PrimalStatus(2)) MOI.get(model, MOI.PrimalStatus(2))
+        @test MOI.get(model, MOI.PrimalStatus(2)) == MOI.NO_SOLUTION
         @test MOI.get(model, MOI.VariablePrimal(1), x) ≈ 1.0 atol=atol rtol=rtol
         @test_throws result_err(MOI.VariablePrimal(2)) MOI.get(model, MOI.VariablePrimal(2), x)
         @test MOI.get(model, MOI.ConstraintPrimal(1), c) ≈ 1.0 atol=atol rtol=rtol
         @test_throws result_err(MOI.ConstraintPrimal(2)) MOI.get(model, MOI.ConstraintPrimal(2), c)
         if config.duals
             @test MOI.get(model, MOI.DualStatus(1)) == MOI.FEASIBLE_POINT
-            @test_throws result_err(MOI.DualStatus(2)) MOI.get(model, MOI.DualStatus(2))
+            @test MOI.get(model, MOI.DualStatus(2)) == MOI.NO_SOLUTION
             @test MOI.get(model, MOI.ConstraintDual(1), c) ≈ 1.0 atol=atol rtol=rtol
             @test_throws result_err(MOI.ConstraintDual(2)) MOI.get(model, MOI.ConstraintDual(2), c)
             @test MOI.get(model, MOI.DualObjectiveValue(1)) ≈ 1.0 atol=atol rtol=rtol

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -312,12 +312,18 @@ function MOI.get(mock::MockOptimizer, attr::MOI.DualObjectiveValue)
     end
 end
 function MOI.get(mock::MockOptimizer, attr::MOI.PrimalStatus)
-    MOI.check_result_index_bounds(mock, attr)
-    return mock.primalstatus
+    if attr.N > mock.result_count
+        return MOI.NO_SOLUTION
+    else
+        return mock.primalstatus
+    end
 end
 function MOI.get(mock::MockOptimizer, attr::MOI.DualStatus)
-    MOI.check_result_index_bounds(mock, attr)
-    return mock.dualstatus
+    if attr.N > mock.result_count
+        return MOI.NO_SOLUTION
+    else
+        return mock.dualstatus
+    end
 end
 MOI.get(mock::MockOptimizer, ::MockModelAttribute) = mock.attribute
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1272,7 +1272,8 @@ The values indicate how to interpret the result vector.
     PrimalStatus()
 
 A model attribute for the `ResultStatusCode` of the primal result `N`.
-If `N` is omitted, it defaults to 1.
+If `N` is omitted, it defaults to 1. If `N` is larger than the value of
+[`ResultCount`](@ref) then `NO_SOLUTION` is returned.
 """
 struct PrimalStatus <: AbstractModelAttribute
     N::Int
@@ -1285,7 +1286,8 @@ _result_index_field(attr::PrimalStatus) = attr.N
     DualStatus()
 
 A model attribute for the `ResultStatusCode` of the dual result `N`.
-If `N` is omitted, it defaults to 1.
+If `N` is omitted, it defaults to 1. If `N` is larger than the value of
+[`ResultCount`](@ref) then `NO_SOLUTION` is returned.
 """
 struct DualStatus <: AbstractModelAttribute
     N::Int


### PR DESCRIPTION
It's difficult to pass both `MOIT.solve_result_index` and `MOIT.default_status_test` without this change.