### PR TITLE
Add complementarity constraints

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -273,6 +273,7 @@ SettingSingleVariableFunctionNotAllowed
 List of recognized functions.
 ```@docs
 AbstractFunction
+AbstractVectorFunction
 SingleVariable
 VectorOfVariables
 ScalarAffineTerm

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -349,6 +349,7 @@ DualPowerCone
 SOS1
 SOS2
 IndicatorSet
+Complements
 ```
 
 ### Matrix sets

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -64,7 +64,7 @@ const BasicConstraintTests = Dict(
     (MOI.VectorAffineFunction{Float64}, MOI.Zeros)        => ( dummy_vector_affine, 2, MOI.Zeros(2) ),
     (MOI.VectorAffineFunction{Float64}, MOI.Nonpositives) => ( dummy_vector_affine, 2, MOI.Nonpositives(2) ),
     (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives) => ( dummy_vector_affine, 2, MOI.Nonnegatives(2) ),
-
+    (MOI.VectorAffineFunction{Float64}, MOI.Complements) => (dummy_vector_affine, 2, MOI.Complements(1)),
     (MOI.VectorAffineFunction{Float64}, MOI.NormInfinityCone)       => ( dummy_vector_affine, 3, MOI.NormInfinityCone(3) ),
     (MOI.VectorAffineFunction{Float64}, MOI.NormOneCone)            => ( dummy_vector_affine, 3, MOI.NormOneCone(3) ),
     (MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone)        => ( dummy_vector_affine, 3, MOI.SecondOrderCone(3) ),

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -473,7 +473,8 @@ function test_qp_complementarity_constraint(
         @test isapprox(
             x_val,
             [1.0, 0.0, 3.5, 0.0, 0.0, 0.0, 3.0, 6.0],
-            atol = config.atol, rtol = config.rtol
+            atol = config.atol,
+            rtol = config.rtol
         )
         @test isapprox(
             MOI.get(model, MOI.ObjectiveValue()),

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -361,7 +361,7 @@ function test_linear_mixed_complementarity(model::MOI.ModelLike, config::TestCon
             iszero(M[i, j]) && continue
             push!(
                 terms,
-                MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(M[i, j], x[j]))
+                MOI.VectorAffineTerm(i, MOI.ScalarAffineTerm(M[i, j], x[j]))
             )
         end
     end
@@ -421,38 +421,39 @@ function test_qp_mixed_complementarity(model::MOI.ModelLike, config::TestConfig)
     obj = MOI.ScalarQuadraticFunction(
         [MOI.ScalarAffineTerm(-10.0, x[1]), MOI.ScalarAffineTerm(4.0, x[2])],
         [MOI.ScalarQuadraticTerm(2.0, x[1], x[1]), MOI.ScalarQuadraticTerm(8.0, x[2], x[2])],
-        26.0)
+        26.0
+    )
 
     MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(), obj)
 
-    cf1 = MOI.ScalarAffineFunction([
-                                    MOI.ScalarAffineTerm(-1.5, x[1]),
-                                    MOI.ScalarAffineTerm(2.0, x[2]),
-                                    MOI.ScalarAffineTerm(1.0, x[3]),
-                                    MOI.ScalarAffineTerm(0.5, x[4]),
-                                    MOI.ScalarAffineTerm(1.0, x[5])
-                                   ], 0.0)
-    cf2 = MOI.ScalarAffineFunction([
-                                    MOI.ScalarAffineTerm(3.0, x[1]),
-                                    MOI.ScalarAffineTerm(-1.0, x[2]),
-                                    MOI.ScalarAffineTerm(-1.0, x[6]),
-                                   ], 0.0)
-    cf3 = MOI.ScalarAffineFunction([
-                                    MOI.ScalarAffineTerm(-1.0, x[1]),
-                                    MOI.ScalarAffineTerm(0.5, x[2]),
-                                    MOI.ScalarAffineTerm(-1.0, x[7]),
-                                   ], 0.0)
-    cf4 = MOI.ScalarAffineFunction([
-                                    MOI.ScalarAffineTerm(-1.0, x[1]),
-                                    MOI.ScalarAffineTerm(-1.0, x[2]),
-                                    MOI.ScalarAffineTerm(-1.0, x[8]),
-                                   ], 0.0)
-
-    MOI.add_constraint(model, cf1, MOI.EqualTo(2.0))
-    MOI.add_constraint(model, cf2, MOI.EqualTo(3.0))
-    MOI.add_constraint(model, cf3, MOI.EqualTo(-4.0))
-    MOI.add_constraint(model, cf4, MOI.EqualTo(-7.0))
-
+    MOI.add_constraint(
+        model, 
+        MOI.ScalarAffineFunction(
+            MOI.ScalarAffineTerm.([-1.5, 2.0, 1.0, 0.5, 1.0], x[1:5]), 0.0
+        ),
+        MOI.EqualTo(2.0)
+   )
+    MOI.add_constraint(
+        model, 
+        MOI.ScalarAffineFunction(
+            MOI.ScalarAffineTerm.([3.0, -1.0, -1.0], x[[1, 2, 6]]), 0.0
+        ),
+        MOI.EqualTo(3.0)
+   )
+    MOI.add_constraint(
+        model, 
+        MOI.ScalarAffineFunction(
+            MOI.ScalarAffineTerm.([-1.0, 0.5, -1.0], x[[1, 2, 7]]), 0.0
+        ),
+        MOI.EqualTo(-4.0)
+   )
+    MOI.add_constraint(
+        model, 
+        MOI.ScalarAffineFunction(
+           MOI.ScalarAffineTerm.(-1.0, x[[1, 2, 8]]), 0.0
+        ),
+        MOI.EqualTo(-7.0)
+   )
     MOI.add_constraint(
         model,
         MOI.VectorOfVariables([x[3], x[4], x[5], x[6], x[7], x[8]]),

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -372,7 +372,7 @@ function test_linear_mixed_complementarity(model::MOI.ModelLike, config::TestCon
     )
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
     MOI.optimize!(model)
-    @test MOI.get(model, MOI.TerminationStatus()) == MOI.LOCALLY_SOLVED
+    @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
     x_val = MOI.get.(model, MOI.VariablePrimal(), x)
     @test isapprox(
         x_val, [2.8, 0.0, 0.8, 1.2], atol = config.atol, rtol = config.rtol

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -338,7 +338,13 @@ const nlptests = Dict("hs071" => hs071_test,
 
 @moitestset nlp
 
-function test_linear_mcp(model::MOI.ModelLike, config::TestConfig)
+"""
+    test_linear_mixed_complementarity(model::MOI.ModelLike, config::TestConfig)
+
+Test the solution of the linear mixed-complementarity problem:
+`F(x) complements x`, where `F(x) = M * x .+ q` and `0 <= x <= 10`.
+"""
+function test_linear_mixed_complementarity(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     x = MOI.add_variables(model, 4)
     MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.Interval(0.0, 10.0))
@@ -374,7 +380,7 @@ function test_linear_mcp(model::MOI.ModelLike, config::TestConfig)
 end
 
 const complementaritytests = Dict(
-    "linear_mcp" => test_linear_mcp,
+    "linear_mixed_complementarity" => test_linear_mixed_complementarity,
 )
 
 @moitestset complementarity

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -1027,7 +1027,7 @@ const LessThanIndicatorSetZero{T} = MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO, MOI.L
        (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval,
         MOI.Semicontinuous, MOI.Semiinteger),
        (MOI.Reals, MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives,
-        MOI.NormInfinityCone, MOI.NormOneCone,
+        MOI.Complements, MOI.NormInfinityCone, MOI.NormOneCone,
         MOI.SecondOrderCone, MOI.RotatedSecondOrderCone,
         MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone,
         MOI.PositiveSemidefiniteConeTriangle, MOI.PositiveSemidefiniteConeSquare,

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -682,22 +682,38 @@ defines a complementarity constraint between the scalar function `F[i]` and the
 variable in `F[i + dimension]`. Thus, `F[i + dimension]` must be interpretable
 as a single variable `x_i` (e.g., `1.0 * x + 0.0`).
 
-If the variable `x_i` is constrained in `Interval(lb, ub)`, then mathematically,
-the mixed complementarity problem is to find a solution such that at least one
-of the following holds:
+If the variable `x_i` is constrained in `Interval(lb_i, ub_i)`, then
+mathematically, the mixed complementarity problem is to find a solution such
+that at least one of the following holds:
 
-  1.  F_i(x) = 0, lb <= x_i <= ub_i
-  2.  F_i(x) > 0, lb == x_i
-  3.  F_i(x) < 0,       x_i == ub_i
+  1.  F_i(x) = 0, lb_i <= x_i <= ub_i
+  2.  F_i(x) > 0, lb_i == x_i
+  3.  F_i(x) < 0,         x_i == ub_i
 
 Classically, the bounding set for `x_i` is `Interval(0, Inf)`, which recovers:
 0 <= F_i(x) ⟂ x >= 0, where the `⟂` operator implies F_i(x) * x = 0.
 
 ### Examples
 
-    [x, y] -in- Complements(1)
-    [x, y, u, w] -in- Complements(2)
+The problem:
+
+    x -in- Interval(-1, 1)
     [2 * x - 3, x] -in- Complements(1)
+
+defines the mixed complementarity problem where at least one of the following
+holds:
+
+  1. `2 * x - 3 = 0` if `-1 <= x <= 1`
+  2. `2 * x - 3 > 0` if `x == -1`
+  3. `2 * x - 3 < 0` if `x == 1`
+
+The problem:
+
+    [x_3, x_4] -in- Nonnegatives(2)
+    [x_1, x_2, x_3, x_4] -in- Complements(2)
+
+defines the complementarity problem where `0 <= x_1 ⟂ x_3 >= 0` and
+`0 <= x_2 ⟂ x_4 >= 0`.
 """
 struct Complements <: AbstractVectorSet
     dimension::Int

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -677,12 +677,12 @@ The set corresponding to a mixed complementarity constraint.
 Complementarity constraints should be specified with an
 [`AbstractVectorFunction`](@ref)-in-`Complements(dimension)` constraint.
 
-If `F` function, then the dimension of `F` must be `2 * dimension`. This defines
-a complementarity constraint between `F[i]` and `F[i + dimension]`. Thus,
-`F[i + dimension]` must be interpretable as a single variable (e.g., `1.0 * x +
-0.0`).
+The dimension of the vector-valued function `F` must be `2 * dimension`. This
+defines a complementarity constraint between the scalar function `F[i]` and the
+variable in `F[i + dimension]`. Thus, `F[i + dimension]` must be interpretable
+as a single variable `x_i` (e.g., `1.0 * x + 0.0`).
 
-If a variable `x_i` is constrained in `Interval(lb, ub)`, then mathematically,
+If the variable `x_i` is constrained in `Interval(lb, ub)`, then mathematically,
 the mixed complementarity problem is to find a solution such that at least one
 of the following holds:
 

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -686,9 +686,9 @@ If the variable `x_i` is constrained in `Interval(lb_i, ub_i)`, then
 mathematically, the mixed complementarity problem is to find a solution such
 that at least one of the following holds:
 
-  1. `F_i(x) = 0` if `lb_i <= x_i <= ub_i`
-  2. `F_i(x) > 0` if `lb_i == x_i`
-  3. `F_i(x) < 0` if `x_i == ub_i`
+  1. `F_i(x) == 0` if `lb_i < x_i < ub_i`
+  2. `F_i(x) >= 0` if `lb_i == x_i`
+  3. `F_i(x) <= 0` if `x_i == ub_i`
 
 Classically, the bounding set for `x_i` is `Interval(0, Inf)`, which recovers:
 `0 <= F_i(x) ⟂ x_i >= 0`, where the `⟂` operator implies `F_i(x) * x_i = 0`.
@@ -703,9 +703,9 @@ The problem:
 defines the mixed complementarity problem where at least one of the following
 holds:
 
-  1. `2 * x - 3 = 0` if `-1 <= x <= 1`
-  2. `2 * x - 3 > 0` if `x == -1`
-  3. `2 * x - 3 < 0` if `x == 1`
+  1. `2 * x - 3 == 0` if `-1 < x < 1`
+  2. `2 * x - 3 >= 0` if `x == -1`
+  3. `2 * x - 3 <= 0` if `x == 1`
 
 The problem:
 

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -697,15 +697,22 @@ Classically, the bounding set for `x_i` is `Interval(0, Inf)`, which recovers:
 The problem:
 
     x -in- Interval(-1, 1)
-    [2 * x - 3, x] -in- Complements(1)
+    [-4 * x - 3, x] -in- Complements(1)
 
 defines the mixed complementarity problem where the following holds:
 
-  1. `2 * x - 3 == 0` if `-1 < x < 1`
-  2. `2 * x - 3 >= 0` if `x == -1`
-  3. `2 * x - 3 <= 0` if `x == 1`
+  1. `-4 * x - 3 == 0` if `-1 < x < 1`
+  2. `-4 * x - 3 >= 0` if `x == -1`
+  3. `-4 * x - 3 <= 0` if `x == 1`
 
-The problem:
+There are three solutions:
+
+  1. `x = -3/4` with `F(x) = 0`
+  2. `x = -1` with `F(x) = 1`
+  3. `x = 1` with `F(x) = -7`
+
+The function `F` can also be defined in terms of single variables. For example,
+the problem:
 
     [x_3, x_4] -in- Nonnegatives(2)
     [x_1, x_2, x_3, x_4] -in- Complements(2)

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -682,9 +682,8 @@ defines a complementarity constraint between the scalar function `F[i]` and the
 variable in `F[i + dimension]`. Thus, `F[i + dimension]` must be interpretable
 as a single variable `x_i` (e.g., `1.0 * x + 0.0`).
 
-If the variable `x_i` is constrained in `Interval(lb_i, ub_i)`, then
-mathematically, the mixed complementarity problem is to find a solution such
-that at least one of the following holds:
+The mixed complementarity problem consists of finding `x_i` in the interval
+`[lb, ub]` (i.e., in the set `Interval(lb, ub)`), such that the following holds:
 
   1. `F_i(x) == 0` if `lb_i < x_i < ub_i`
   2. `F_i(x) >= 0` if `lb_i == x_i`
@@ -700,8 +699,7 @@ The problem:
     x -in- Interval(-1, 1)
     [2 * x - 3, x] -in- Complements(1)
 
-defines the mixed complementarity problem where at least one of the following
-holds:
+defines the mixed complementarity problem where the following holds:
 
   1. `2 * x - 3 == 0` if `-1 < x < 1`
   2. `2 * x - 3 >= 0` if `x == -1`

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -686,12 +686,12 @@ If the variable `x_i` is constrained in `Interval(lb_i, ub_i)`, then
 mathematically, the mixed complementarity problem is to find a solution such
 that at least one of the following holds:
 
-  1.  F_i(x) = 0, lb_i <= x_i <= ub_i
-  2.  F_i(x) > 0, lb_i == x_i
-  3.  F_i(x) < 0,         x_i == ub_i
+  1. `F_i(x) = 0` if `lb_i <= x_i <= ub_i`
+  2. `F_i(x) > 0` if `lb_i == x_i`
+  3. `F_i(x) < 0` if `x_i == ub_i`
 
 Classically, the bounding set for `x_i` is `Interval(0, Inf)`, which recovers:
-0 <= F_i(x) ⟂ x >= 0, where the `⟂` operator implies F_i(x) * x = 0.
+`0 <= F_i(x) ⟂ x_i >= 0`, where the `⟂` operator implies `F_i(x) * x_i = 0`.
 
 ### Examples
 

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -669,18 +669,53 @@ end
 
 Base.:(==)(set1::IndicatorSet{A, S}, set2::IndicatorSet{A, S}) where {A, S} = set1.set == set2.set
 
+"""
+    Complements(dimension::Int)
+
+The set corresponding to a mixed complementarity constraint.
+
+Complementarity constraints should be specified with an
+[`AbstractVectorFunction`](@ref)-in-`Complements(dimension)` constraint.
+
+If `F` function, then the dimension of `F` must be `2 * dimension`. This defines
+a complementarity constraint between `F[i]` and `F[i + dimension]`. Thus,
+`F[i + dimension]` must be interpretable as a single variable (e.g., `1.0 * x +
+0.0`).
+
+If a variable `x_i` is constrained in `Interval(lb, ub)`, then mathematically,
+the mixed complementarity problem is to find a solution such that at least one
+of the following holds:
+
+  1.  F_i(x) = 0, lb <= x_i <= ub_i
+  2.  F_i(x) > 0, lb == x_i
+  3.  F_i(x) < 0,       x_i == ub_i
+
+Classically, the bounding set for `x_i` is `Interval(0, Inf)`, which recovers:
+0 <= F_i(x) ⟂ x >= 0, where the `⟂` operator implies F_i(x) * x = 0.
+
+### Examples
+
+    [x, y] -in- Complements(1)
+    [x, y, u, w] -in- Complements(2)
+    [2 * x - 3, x] -in- Complements(1)
+"""
+struct Complements <: AbstractVectorSet
+    dimension::Int
+end
+
 # isbits types, nothing to copy
-function Base.copy(set::Union{Reals, Zeros, Nonnegatives, Nonpositives,
-                              GreaterThan, LessThan, EqualTo, Interval,
-                              NormInfinityCone, NormOneCone,
-                              SecondOrderCone, RotatedSecondOrderCone,
-                              GeometricMeanCone, ExponentialCone,
-                              DualExponentialCone, PowerCone, DualPowerCone,
-                              PositiveSemidefiniteConeTriangle,
-                              PositiveSemidefiniteConeSquare,
-                              LogDetConeTriangle, LogDetConeSquare,
-                              RootDetConeTriangle, RootDetConeSquare,
-                              Integer, ZeroOne, Semicontinuous, Semiinteger})
+function Base.copy(
+    set::Union{
+        Reals, Zeros, Nonnegatives, Nonpositives, GreaterThan, LessThan,
+        EqualTo, Interval, NormInfinityCone, NormOneCone, SecondOrderCone,
+        RotatedSecondOrderCone, GeometricMeanCone, ExponentialCone,
+        DualExponentialCone, PowerCone, DualPowerCone,
+        PositiveSemidefiniteConeTriangle, PositiveSemidefiniteConeSquare,
+        LogDetConeTriangle, LogDetConeSquare, RootDetConeTriangle,
+        RootDetConeSquare, Complements, Integer, ZeroOne, Semicontinuous,
+        Semiinteger
+    }
+)
     return set
 end
 Base.copy(set::S) where {S <: Union{SOS1, SOS2}} = S(copy(set.weights))

--- a/test/Test/Test.jl
+++ b/test/Test/Test.jl
@@ -1,23 +1,8 @@
 using Test
 
-@testset "Config" begin
-    include("config.jl")
-end
-@testset "Unit" begin
-    include("unit.jl")
-end
-@testset "Continuous Linear" begin
-    include("contlinear.jl")
-end
-@testset "Continuous Conic" begin
-    include("contconic.jl")
-end
-@testset "Continuous Quadratic" begin
-    include("contquadratic.jl")
-end
-@testset "Integer Linear" begin
-    include("intlinear.jl")
-end
-@testset "Integer Conic" begin
-    include("intconic.jl")
+@testset "$(file)" for file in readdir(@__DIR__)
+    if file == "Test.jl"
+        continue
+    end
+    include(file)
 end

--- a/test/Test/nlp.jl
+++ b/test/Test/nlp.jl
@@ -3,25 +3,30 @@ using Test
 import MathOptInterface
 const MOI = MathOptInterface
 
-@testset "complementarity" begin
+@testset "mixed_complementarity" begin
     mock = MOI.Utilities.MockOptimizer(
         MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     )
     config = MOI.Test.TestConfig(optimal_status = MOI.LOCALLY_SOLVED)
-
     MOI.Utilities.set_mock_optimize!(
         mock,
         (mock) -> MOI.Utilities.mock_optimize!(
             mock, config.optimal_status, [2.8, 0.0, 0.8, 1.2]
         )
     )
-    MOI.Test.test_linear_mixed_complementarity(mock, config)
+    MOI.Test.mixed_complementaritytest(mock, config)
+end
 
+@testset "math_program_complementarity_constraints" begin
+    mock = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    )
+    config = MOI.Test.TestConfig(optimal_status = MOI.LOCALLY_SOLVED)
     MOI.Utilities.set_mock_optimize!(
         mock,
         (mock) -> MOI.Utilities.mock_optimize!(
             mock, config.optimal_status, [1.0, 0.0, 3.5, 0.0, 0.0, 0.0, 3.0, 6.0]
         )
     )
-    MOI.Test.test_qp_mixed_complementarity(mock, config)
+    MOI.Test.math_program_complementarity_constraintstest(mock, config)
 end

--- a/test/Test/nlp.jl
+++ b/test/Test/nlp.jl
@@ -1,0 +1,19 @@
+using Test
+
+import MathOptInterface
+const MOI = MathOptInterface
+
+@testset "complementarity" begin
+    mock = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    )
+    config = MOI.Test.TestConfig()
+
+    MOI.Utilities.set_mock_optimize!(
+        mock,
+        (mock) -> MOI.Utilities.mock_optimize!(
+            mock, MOI.LOCALLY_SOLVED, [2.8, 0.0, 0.8, 1.2]
+        )
+    )
+    MOI.Test.test_linear_mcp(mock, config)
+end

--- a/test/Test/nlp.jl
+++ b/test/Test/nlp.jl
@@ -16,4 +16,12 @@ const MOI = MathOptInterface
         )
     )
     MOI.Test.test_linear_mixed_complementarity(mock, config)
+
+    MOI.Utilities.set_mock_optimize!(
+        mock,
+        (mock) -> MOI.Utilities.mock_optimize!(
+            mock, config.optimal_status, [1.0, 0.0, 3.5, 0.0, 0.0, 0.0, 3.0, 6.0]
+        )
+    )
+    MOI.Test.test_qp_mixed_complementarity(mock, config)
 end

--- a/test/Test/nlp.jl
+++ b/test/Test/nlp.jl
@@ -7,13 +7,13 @@ const MOI = MathOptInterface
     mock = MOI.Utilities.MockOptimizer(
         MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     )
-    config = MOI.Test.TestConfig()
+    config = MOI.Test.TestConfig(optimal_status = MOI.LOCALLY_SOLVED)
 
     MOI.Utilities.set_mock_optimize!(
         mock,
         (mock) -> MOI.Utilities.mock_optimize!(
-            mock, MOI.LOCALLY_SOLVED, [2.8, 0.0, 0.8, 1.2]
+            mock, config.optimal_status, [2.8, 0.0, 0.8, 1.2]
         )
     )
-    MOI.Test.test_linear_mcp(mock, config)
+    MOI.Test.test_linear_mixed_complementarity(mock, config)
 end


### PR DESCRIPTION
This PR adds the set `Complements(dimension)` which defines a mixed complementarity constraint.

The main targets are 
 - [KNITRO.jl](https://github.com/JuliaOpt/KNITRO.jl), which will implement `VectorOfVariables-in-Complements` (cc @frapac)
 - [PATH.jl](https://github.com/odow/PATH.jl), which will implement `VectorQuadraticFunction-in-Complements` and `VectorAffineFunction-in-Complements`, implementing both allows us to short-circuit the Jacobian evaluation the affine case. `VectorOfVariables-in-Complements` will be handled by bridges.

Closes #771 

I've left more obscure complementarity constraints, like conic constrained `x` compared to `lb <= x <= ub`, un-mentioned. @frapac does KNITRO just look at the bounds? Or does it do something different?

cc @xhub