### PR TITLE
Use 0.5 instead of 2.0 for power in PowerCone in `basic_constraint_test`

### DIFF
--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -41,8 +41,8 @@ const BasicConstraintTests = Dict(
     (MOI.VectorOfVariables, MOI.GeometricMeanCone)      => ( dummy_vectorofvariables, 3, MOI.GeometricMeanCone(3) ),
     (MOI.VectorOfVariables, MOI.ExponentialCone)        => ( dummy_vectorofvariables, 3, MOI.ExponentialCone() ),
     (MOI.VectorOfVariables, MOI.DualExponentialCone)    => ( dummy_vectorofvariables, 3, MOI.DualExponentialCone() ),
-    (MOI.VectorOfVariables, MOI.PowerCone{Float64})     => ( dummy_vectorofvariables, 3, MOI.PowerCone(2.0) ),
-    (MOI.VectorOfVariables, MOI.DualPowerCone{Float64}) => ( dummy_vectorofvariables, 3, MOI.DualPowerCone(2.0) ),
+    (MOI.VectorOfVariables, MOI.PowerCone{Float64})     => ( dummy_vectorofvariables, 3, MOI.PowerCone(0.5) ),
+    (MOI.VectorOfVariables, MOI.DualPowerCone{Float64}) => ( dummy_vectorofvariables, 3, MOI.DualPowerCone(0.5) ),
 
     (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle) => ( dummy_vectorofvariables,  7, MOI.PositiveSemidefiniteConeTriangle(3) ),
     (MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeSquare)   => ( dummy_vectorofvariables,  9, MOI.PositiveSemidefiniteConeSquare(3) ),


### PR DESCRIPTION
Mosek does not support 2.0 as power.