### PR TITLE
Add variable indices context to variable bridges

### DIFF
--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -432,7 +432,7 @@ Shortcut for `call_in_context(map, bridge_index, f)` where `bridge_index` is the
 variable bridge that created `ci` (directly or indirectly) or 0 otherwise.
 """
 function call_in_context(map::Map, ci::MOI.ConstraintIndex, f::Function)
-    return call_in_context(map, get(map.constraint_context, ci, 0), f)
+    return call_in_context(map, get(map.constraint_context, ci, Int64(0)), f)
 end
 
 """

--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -20,12 +20,19 @@ mutable struct Map <: AbstractDict{MOI.VariableIndex, AbstractBridge}
     bridges::Vector{Union{Nothing, AbstractBridge}}
     sets::Vector{Union{Nothing, DataType}}
     # If `nothing`, it cannot be computed because some bridges does not support it
-    unbridged_function::Union{Nothing, Dict{MOI.VariableIndex, MOI.AbstractScalarFunction}}
+    unbridged_function::Union{Nothing, Dict{MOI.VariableIndex, Tuple{Int, MOI.AbstractScalarFunction}}}
+    # Bridge that created this bridge, 0 if it is no bridge.
+    parent_index::Vector{Int}
+    # Current bridge, 0 otherwise.
+    current_context::Int
+    # Context of constraint bridged by constraint bridges
+    constraint_context::Dict{MOI.ConstraintIndex, Int}
 end
 function Map()
     return Map(Int[], Int[], Union{Nothing, AbstractBridge}[],
                Union{Nothing, DataType}[],
-               Dict{MOI.VariableIndex, MOI.AbstractScalarFunction}())
+               Dict{MOI.VariableIndex, MOI.AbstractScalarFunction}(),
+               Int[], 0, Dict{MOI.ConstraintIndex, Int}())
 end
 
 # Implementation of `AbstractDict` interface.
@@ -37,10 +44,13 @@ function Base.empty!(map::Map)
     empty!(map.bridges)
     empty!(map.sets)
     if map.unbridged_function === nothing
-        map.unbridged_function = Dict{MOI.VariableIndex, MOI.AbstractScalarFunction}()
+        map.unbridged_function = Dict{MOI.VariableIndex, Tuple{Int, MOI.AbstractScalarFunction}}()
     else
         empty!(map.unbridged_function)
     end
+    empty!(map.parent_index)
+    map.current_context = 0
+    empty!(map.constraint_context)
     return map
 end
 function bridge_index(map::Map, vi::MOI.VariableIndex)
@@ -236,7 +246,7 @@ operations in case variable bridges are not used.
 has_bridges(map::Map) = !isempty(map.info)
 
 """
-    add_key_for_bridge(map::Map, bridge::AbstractBridge,
+    add_key_for_bridge(map::Map, bridge_fun::Function,
                        set::MOI.AbstractScalarSet)
 
 Create a new variable index `vi`, store the mapping `vi => bridge` and
@@ -244,27 +254,32 @@ associate `vi` to `typeof(set)`. It returns a tuple with `vi` and the
 constraint index
 `MOI.ConstraintIndex{MOI.SingleVariable, typeof(set)}(vi.value)`.
 """
-function add_key_for_bridge(map::Map, bridge::AbstractBridge,
+function add_key_for_bridge(map::Map, bridge_fun::Function,
                             set::MOI.AbstractScalarSet)
-    index = -(length(map.bridges) + 1)
-    variable = MOI.VariableIndex(index)
+    push!(map.parent_index, map.current_context)
+    bridge_index = length(map.parent_index)
     push!(map.info, 0)
     push!(map.index_in_vector, 0)
-    push!(map.bridges, bridge)
+    push!(map.bridges, nothing)
     push!(map.sets, typeof(set))
+    map.bridges[bridge_index] = call_in_context(map, bridge_index, bridge_fun)
+    index = -bridge_index
+    variable = MOI.VariableIndex(index)
     if map.unbridged_function !== nothing
-        mappings = unbridged_map(bridge, variable)
+        mappings = unbridged_map(map.bridges[bridge_index], variable)
         if mappings === nothing
             map.unbridged_function = nothing
         else
-            push!(map.unbridged_function, mappings...)
+            for mapping in mappings
+                push!(map.unbridged_function, mapping.first => (bridge_index, mapping.second))
+            end
         end
     end
     return variable, MOI.ConstraintIndex{MOI.SingleVariable, typeof(set)}(index)
 end
 
 """
-    add_keys_for_bridge(map::Map, bridge::AbstractBridge,
+    add_keys_for_bridge(map::Map, bridge_fun::Function,
                         set::MOI.AbstractVectorSet)
 
 Create vector of variable indices `variables`, stores the mapping
@@ -272,30 +287,34 @@ Create vector of variable indices `variables`, stores the mapping
 `typeof(set)`. It returns a tuple with `variables` and the constraint index
 `MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(set)}(first(variables).value)`.
 """
-function add_keys_for_bridge(map::Map, bridge::AbstractBridge,
+function add_keys_for_bridge(map::Map, bridge_fun::Function,
                              set::MOI.AbstractVectorSet)
     if iszero(MOI.dimension(set))
         return MOI.VariableIndex[], MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(set)}(0)
     else
-        variables = MOI.VariableIndex[MOI.VariableIndex(-(length(map.bridges) + i))
-                                      for i in 1:MOI.dimension(set)]
+        push!(map.parent_index, map.current_context)
+        bridge_index = length(map.parent_index)
         push!(map.info, -MOI.dimension(set))
         push!(map.index_in_vector, 1)
-        push!(map.bridges, bridge)
+        push!(map.bridges, nothing)
         push!(map.sets, typeof(set))
         for i in 2:MOI.dimension(set)
+            push!(map.parent_index, 0)
             push!(map.info, i)
             push!(map.index_in_vector, i)
             push!(map.bridges, nothing)
             push!(map.sets, nothing)
         end
+        map.bridges[bridge_index] = call_in_context(map, bridge_index, bridge_fun)
+        variables = MOI.VariableIndex[MOI.VariableIndex(-(bridge_index - 1 + i))
+                                      for i in 1:MOI.dimension(set)]
         if map.unbridged_function !== nothing
-            mappings = unbridged_map(bridge, variables)
+            mappings = unbridged_map(map.bridges[bridge_index], variables)
             if mappings === nothing
                 map.unbridged_function = nothing
             else
                 for mapping in mappings
-                    push!(map.unbridged_function, mapping)
+                    push!(map.unbridged_function, mapping.first => (bridge_index, mapping.second))
                 end
             end
         end
@@ -355,7 +374,76 @@ Return the expression of `vi` in terms of bridged variables.
 """
 function unbridged_function(map::Map, vi::MOI.VariableIndex)
     throw_if_cannot_unbridge(map)
-    return get(map.unbridged_function, vi, nothing)
+    context_func = get(map.unbridged_function, vi, nothing)
+    if context_func === nothing
+        return nothing
+    else
+        bridge_index, func = context_func
+        # If the bridge bridging `vi` has index `bridge_index` or directly or
+        # indirectly created this bridge then we don't unbridge the variable.
+        context = map.current_context
+        while !iszero(context)
+            if bridge_index == context
+                return nothing
+            end
+            context = map.parent_index[context]
+        end
+        return func
+    end
+end
+
+"""
+    call_in_context(map::Map, bridge_index::Int, f::Function)
+
+Call function `f` in the context of the variable bridge of index `bridge_index`.
+That is, the variable indices bridged by this bridge or the bridges that
+created it will not be unbridged in [`unbridged_function`](@ref).
+"""
+function call_in_context(map::Map, bridge_index::Int, f::Function)
+    if iszero(bridge_index)
+        return f()
+    end
+    previous_context = map.current_context
+    map.current_context = bridge_index
+    output = nothing
+    try
+        output = f()
+    finally
+        map.current_context = previous_context
+    end
+    return output
+end
+
+"""
+    call_in_context(map::Map, vi::MOI.VariableIndex, f::Function)
+
+Shortcut for `call_in_context(map, bridge_index, () -> f(bridge))` where
+`vi` is bridged by `bridge` with index `bridge_index`.
+"""
+function call_in_context(map::Map, vi::MOI.VariableIndex, f::Function)
+    idx = bridge_index(map, vi)
+    return call_in_context(map, idx, () -> f(map.bridges[idx]))
+end
+
+"""
+    call_in_context(map::Map, ci::MOI.ConstraintIndex, f::Function)
+
+Shortcut for `call_in_context(map, bridge_index, f)` where `bridge_index` is the
+variable bridge that created `ci` (directly or indirectly) or 0 otherwise.
+"""
+function call_in_context(map::Map, ci::MOI.ConstraintIndex, f::Function)
+    return call_in_context(map, map.constraint_context[ci], f)
+end
+
+"""
+    register_context(map::Map, ci::MOI.ConstraintIndex)
+
+Register the current context as the variable bridge that created `ci` (directly
+or indirectly) or 0 otherwise.
+"""
+function register_context(map::Map, ci::MOI.ConstraintIndex)
+    map.constraint_context[ci] = map.current_context
+    return
 end
 
 """
@@ -375,3 +463,5 @@ has_bridges(::EmptyMap) = false
 number_of_variables(::EmptyMap) = 0
 number_with_set(::EmptyMap, ::Type{<:MOI.AbstractSet}) = 0
 constraints_with_set(::EmptyMap, S::Type{<:MOI.AbstractSet}) = MOI.ConstraintIndex{MOIU.variable_function_type(S), S}[]
+register_context(::EmptyMap, ::MOI.ConstraintIndex) = nothing
+call_in_context(::EmptyMap, ::MOI.ConstraintIndex, f::Function) = f()

--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -10,29 +10,29 @@ mutable struct Map <: AbstractDict{MOI.VariableIndex, AbstractBridge}
     #              `add_constrained_variables` with a set of dimension `j`.
     # `i` ->  `j`: `VariableIndex(-i)` was the `j`th  variable of
     #             ` add_constrained_variables`.
-    info::Vector{Int}
+    info::Vector{Int64}
     # `i` ->  `-1`: `VariableIndex(-i)` was deleted.
     # `i` ->  `0`: `VariableIndex(-i)` was added with `add_constrained_variable`.
     # `i` ->  `j`: `VariableIndex(-i)` is the `j`th  variable of a constrained
     #               vector of variables, taking deletion into account.
-    index_in_vector::Vector{Int}
+    index_in_vector::Vector{Int64}
     # `i` -> `bridge`: `VariableIndex(-i)` was bridged by `bridge`.
     bridges::Vector{Union{Nothing, AbstractBridge}}
     sets::Vector{Union{Nothing, DataType}}
     # If `nothing`, it cannot be computed because some bridges does not support it
-    unbridged_function::Union{Nothing, Dict{MOI.VariableIndex, Tuple{Int, MOI.AbstractScalarFunction}}}
+    unbridged_function::Union{Nothing, Dict{MOI.VariableIndex, Tuple{Int64, MOI.AbstractScalarFunction}}}
     # Bridge that created this bridge, 0 if it is no bridge.
-    parent_index::Vector{Int}
+    parent_index::Vector{Int64}
     # Current bridge, 0 otherwise.
-    current_context::Int
+    current_context::Int64
     # Context of constraint bridged by constraint bridges
-    constraint_context::Dict{MOI.ConstraintIndex, Int}
+    constraint_context::Dict{MOI.ConstraintIndex, Int64}
 end
 function Map()
-    return Map(Int[], Int[], Union{Nothing, AbstractBridge}[],
+    return Map(Int64[], Int64[], Union{Nothing, AbstractBridge}[],
                Union{Nothing, DataType}[],
                Dict{MOI.VariableIndex, MOI.AbstractScalarFunction}(),
-               Int[], 0, Dict{MOI.ConstraintIndex, Int}())
+               Int64[], 0, Dict{MOI.ConstraintIndex, Int64}())
 end
 
 # Implementation of `AbstractDict` interface.
@@ -44,7 +44,7 @@ function Base.empty!(map::Map)
     empty!(map.bridges)
     empty!(map.sets)
     if map.unbridged_function === nothing
-        map.unbridged_function = Dict{MOI.VariableIndex, Tuple{Int, MOI.AbstractScalarFunction}}()
+        map.unbridged_function = Dict{MOI.VariableIndex, Tuple{Int64, MOI.AbstractScalarFunction}}()
     else
         empty!(map.unbridged_function)
     end
@@ -257,7 +257,7 @@ constraint index
 function add_key_for_bridge(map::Map, bridge_fun::Function,
                             set::MOI.AbstractScalarSet)
     push!(map.parent_index, map.current_context)
-    bridge_index = length(map.parent_index)
+    bridge_index = Int64(length(map.parent_index))
     push!(map.info, 0)
     push!(map.index_in_vector, 0)
     push!(map.bridges, nothing)
@@ -293,7 +293,7 @@ function add_keys_for_bridge(map::Map, bridge_fun::Function,
         return MOI.VariableIndex[], MOI.ConstraintIndex{MOI.VectorOfVariables, typeof(set)}(0)
     else
         push!(map.parent_index, map.current_context)
-        bridge_index = length(map.parent_index)
+        bridge_index = Int64(length(map.parent_index))
         push!(map.info, -MOI.dimension(set))
         push!(map.index_in_vector, 1)
         push!(map.bridges, nothing)
@@ -393,13 +393,13 @@ function unbridged_function(map::Map, vi::MOI.VariableIndex)
 end
 
 """
-    call_in_context(map::Map, bridge_index::Int, f::Function)
+    call_in_context(map::Map, bridge_index::Int64, f::Function)
 
 Call function `f` in the context of the variable bridge of index `bridge_index`.
 That is, the variable indices bridged by this bridge or the bridges that
 created it will not be unbridged in [`unbridged_function`](@ref).
 """
-function call_in_context(map::Map, bridge_index::Int, f::Function)
+function call_in_context(map::Map, bridge_index::Int64, f::Function)
     if iszero(bridge_index)
         return f()
     end

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -178,6 +178,32 @@ Return the `Objective.AbstractBridge` used to bridge the objective function
 function bridge(b::AbstractBridgeOptimizer, attr::MOI.ObjectiveFunction)
     return Objective.bridges(b)[attr]
 end
+
+"""
+    call_in_context(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex, f::Function)
+
+Call `f(bridge)` where `vi` is bridged by `bridge` in its context, see
+[`Variable.call_in_context`](@ref).
+"""
+function call_in_context(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex, f::Function)
+    return Variable.call_in_context(Variable.bridges(b), vi, f)
+end
+
+"""
+    call_in_context(b::AbstractBridgeOptimizer, ci::MOI.ConstraintIndex, f::Function)
+
+Call `f(bridge)` where `ci` is bridged by `bridge` in its context, see
+[`Variable.call_in_context`](@ref).
+"""
+function call_in_context(b::AbstractBridgeOptimizer, ci::MOI.ConstraintIndex, f::Function)
+    if is_variable_bridged(b, ci)
+        return call_in_context(b, MOI.VariableIndex(ci.value), f)
+    else
+        return Variable.call_in_context(Variable.bridges(b), ci,
+                                        () -> f(Constraint.bridges(b)[ci]))
+    end
+end
+
 function _functionize_bridge(b::AbstractBridgeOptimizer, bridge_type)
     func, name = _func_name(bridge_type)
     error("Need to apply a `$bridge_type` to a `$func` $name because the",
@@ -265,7 +291,7 @@ function _delete_variables_in_vector_of_variables_constraint(
             i = findfirst(isequal(vi), variables)
             if i !== nothing
                 if MOI.supports_dimension_update(S)
-                    MOI.delete(b, bridge(b, ci), Constraint.IndexInVector(i))
+                    call_in_context(b, ci, bridge -> MOI.delete(b, bridge, Constraint.IndexInVector(i)))
                 else
                     MOIU.throw_delete_variable_in_vov(vi)
                 end
@@ -295,7 +321,7 @@ function MOI.delete(b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
             MOI.throw_if_not_valid(b, vi)
         end
         if all(vi -> is_bridged(b, vi), vis) && Variable.has_keys(Variable.bridges(b), vis)
-            MOI.delete(b, bridge(b, first(vis)))
+            call_in_context(b, first(vis), bridge -> MOI.delete(b, bridge))
             b.name_to_var = nothing
             for vi in vis
                 delete!(b.var_to_name, vi)
@@ -321,12 +347,14 @@ function MOI.delete(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex)
         MOI.throw_if_not_valid(b, vi)
         if Variable.length_of_vector_of_variables(Variable.bridges(b), vi) > 1
             if MOI.supports_dimension_update(Variable.constrained_set(Variable.bridges(b), vi))
-                MOI.delete(b, bridge(b, vi), _index(b, vi)...)
+                call_in_context(
+                    b, vi,
+                    bridge -> MOI.delete(b, bridge, _index(b, vi)...))
             else
                 MOIU.throw_delete_variable_in_vov(vi)
             end
         else
-            MOI.delete(b, bridge(b, vi))
+            call_in_context(b, vi, bridge -> MOI.delete(b, bridge))
             ci = Variable.constraint(Variable.bridges(b), vi)
             b.name_to_con = nothing
             delete!(b.con_to_name, ci)
@@ -349,7 +377,7 @@ function MOI.delete(b::AbstractBridgeOptimizer, ci::MOI.ConstraintIndex)
         else
             delete!(Constraint.bridges(b), ci)
         end
-        MOI.delete(b, br)
+        Variable.call_in_context(Variable.bridges(b), ci, () -> MOI.delete(b, br))
         b.name_to_con = nothing
         delete!(b.con_to_name, ci)
     else
@@ -703,7 +731,9 @@ function MOI.get(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractVariableAttribute,
                  index::MOI.VariableIndex)
     if is_bridged(b, index)
-        value = MOI.get(b, attr, bridge(b, index), _index(b, index)...)
+        value = call_in_context(
+            b, index,
+            bridge -> MOI.get(b, attr, bridge, _index(b, index)...))
     else
         value = MOI.get(b.model, attr, index)
     end
@@ -728,7 +758,7 @@ function MOI.set(b::AbstractBridgeOptimizer,
                  index::MOI.Index, value)
     value = bridged_function(b, value)
     if is_bridged(b, index)
-        return MOI.set(b, attr, bridge(b, index), value, _index(b, index)...)
+        return call_in_context(b, index, bridge -> MOI.set(b, attr, bridge, value, _index(b, index)...))
     else
         return MOI.set(b.model, attr, index, value)
     end
@@ -759,11 +789,11 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintFunction,
                  ci::MOI.ConstraintIndex)
     if is_bridged(b, ci)
         MOI.throw_if_not_valid(b, ci)
-        br = bridge(b, ci)
-        if br isa Variable.AbstractBridge
+        if is_variable_bridged(b, ci)
             return Variable.function_for(Variable.bridges(b), ci)
+        else
+            func = call_in_context(b, ci, br -> MOI.get(b, attr, br))
         end
-        func = MOI.get(b, attr, br)
     else
         func = MOI.get(b.model, attr, ci)
     end
@@ -778,7 +808,7 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintSet,
                  ci::MOI.ConstraintIndex{MOI.SingleVariable})
     return if is_bridged(b, ci)
         MOI.throw_if_not_valid(b, ci)
-        MOI.get(b, attr, bridge(b, ci))
+        call_in_context(b, ci, bridge -> MOI.get(b, attr, bridge))
     else
         MOI.get(b.model, attr, ci)
     end
@@ -796,7 +826,7 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintSet,
                  ci::MOI.ConstraintIndex{<:MOI.AbstractScalarFunction})
     if is_bridged(b, ci)
         MOI.throw_if_not_valid(b, ci)
-        set = MOI.get(b, attr, bridge(b, ci))
+        set = call_in_context(b, ci, bridge -> MOI.get(b, attr, bridge))
     else
         set = MOI.get(b.model, attr, ci)
     end
@@ -804,7 +834,7 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ConstraintSet,
         # The function constant of the bridged function was moved to the set,
         # we need to remove it.
         if is_bridged(b, ci)
-            func = MOI.get(b, MOI.ConstraintFunction(), bridge(b, ci))
+            func = call_in_context(b, ci, bridge -> MOI.get(b, MOI.ConstraintFunction(), bridge))
         else
             func = MOI.get(b.model, MOI.ConstraintFunction(), ci)
         end
@@ -817,7 +847,7 @@ function MOI.get(b::AbstractBridgeOptimizer,
                  attr::MOI.AbstractConstraintAttribute, ci::MOI.ConstraintIndex)
     if is_bridged(b, ci)
         MOI.throw_if_not_valid(b, ci)
-        func = MOI.get(b, attr, bridge(b, ci))
+        func = call_in_context(b, ci, bridge -> MOI.get(b, attr, bridge))
     else
         func = MOI.get(b.model, attr, ci)
     end
@@ -838,7 +868,7 @@ function _set_substituted(
     ci::MOI.ConstraintIndex, value)
     if is_bridged(b, ci)
         MOI.throw_if_not_valid(b, ci)
-        MOI.set(b, attr, bridge(b, ci), value)
+        call_in_context(b, ci, bridge -> MOI.set(b, attr, bridge, value))
     else
         MOI.set(b.model, attr, ci, value)
     end
@@ -958,6 +988,12 @@ function MOI.supports_constraint(b::AbstractBridgeOptimizer,
         return MOI.supports_constraint(b.model, F, S)
     end
 end
+function add_bridged_constraint(b, BridgeType, f, s)
+    bridge = Constraint.bridge_constraint(BridgeType, b, f, s)
+    ci = Constraint.add_key_for_bridge(Constraint.bridges(b), bridge, f, s)
+    Variable.register_context(Variable.bridges(b), ci)
+    return ci
+end
 function MOI.add_constraint(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
                             s::MOI.AbstractSet)
     if Variable.has_bridges(Variable.bridges(b))
@@ -970,8 +1006,7 @@ function MOI.add_constraint(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
                 end
                 BridgeType = Constraint.concrete_bridge_type(
                     constraint_scalar_functionize_bridge(b), typeof(f), typeof(s))
-                bridge = Constraint.bridge_constraint(BridgeType, b, f, s)
-                return Constraint.add_key_for_bridge(Constraint.bridges(b), bridge, f, s)
+                return add_bridged_constraint(b, BridgeType, f, s)
             end
         elseif f isa MOI.VectorOfVariables
             if any(vi -> is_bridged(b, vi), f.variables)
@@ -990,8 +1025,7 @@ function MOI.add_constraint(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
                 end
                 BridgeType = Constraint.concrete_bridge_type(
                     constraint_vector_functionize_bridge(b), typeof(f), typeof(s))
-                bridge = Constraint.bridge_constraint(BridgeType, b, f, s)
-                return Constraint.add_key_for_bridge(Constraint.bridges(b), bridge, f, s)
+                return add_bridged_constraint(b, BridgeType, f, s)
             end
         else
             f, s = bridged_constraint_function(b, f, s)
@@ -1004,8 +1038,7 @@ function MOI.add_constraint(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
         BridgeType = Constraint.concrete_bridge_type(b, typeof(f), typeof(s))
         # `add_constraint` might throw an `UnsupportedConstraint` but no
         # modification has been done in the previous line
-        bridge = Constraint.bridge_constraint(BridgeType, b, f, s)
-        return Constraint.add_key_for_bridge(Constraint.bridges(b), bridge, f, s)
+        return add_bridged_constraint(b, BridgeType, f, s)
     else
         return MOI.add_constraint(b.model, f, s)
     end
@@ -1078,7 +1111,7 @@ function MOI.modify(b::AbstractBridgeOptimizer, ci::MOI.ConstraintIndex,
         modify_bridged_change(b, ci, change)
     else
         if is_bridged(b, ci)
-            MOI.modify(b, bridge(b, ci), change)
+            call_in_context(b, ci, bridge -> MOI.modify(b, bridge, change))
         else
             MOI.modify(b.model, ci, change)
         end
@@ -1110,8 +1143,9 @@ function MOI.add_constrained_variables(b::AbstractBridgeOptimizer,
         is_bridged(b, MOI.VectorOfVariables, typeof(set))
         if set isa MOI.Reals || supports_bridging_constrained_variable(b, typeof(set))
             BridgeType = Variable.concrete_bridge_type(b, typeof(set))
-            bridge = Variable.bridge_constrained_variable(BridgeType, b, set)
-            return Variable.add_keys_for_bridge(Variable.bridges(b), bridge, set)
+            return Variable.add_keys_for_bridge(Variable.bridges(b),
+                () -> Variable.bridge_constrained_variable(BridgeType, b, set),
+                set)
         else
             variables = MOI.add_variables(b, MOI.dimension(set))
             constraint = MOI.add_constraint(b, MOI.VectorOfVariables(variables), set)
@@ -1127,8 +1161,9 @@ function MOI.add_constrained_variable(b::AbstractBridgeOptimizer,
         is_bridged(b, MOI.SingleVariable, typeof(set))
         if supports_bridging_constrained_variable(b, typeof(set))
             BridgeType = Variable.concrete_bridge_type(b, typeof(set))
-            bridge = Variable.bridge_constrained_variable(BridgeType, b, set)
-            return Variable.add_key_for_bridge(Variable.bridges(b), bridge, set)
+            return Variable.add_key_for_bridge(Variable.bridges(b),
+                () -> Variable.bridge_constrained_variable(BridgeType, b, set),
+                set)
         else
             variable = MOI.add_variable(b)
             constraint = MOI.add_constraint(b, MOI.SingleVariable(variable), set)

--- a/test/Bridges/Variable/map.jl
+++ b/test/Bridges/Variable/map.jl
@@ -19,7 +19,7 @@ b1 = VariableDummyBridge(1)
 set1 = MOI.EqualTo(0.0)
 F1 = MOI.SingleVariable
 S1 = typeof(set1)
-v1, c1 = MOIB.Variable.add_key_for_bridge(map, b1, set1)
+v1, c1 = MOIB.Variable.add_key_for_bridge(map, () -> b1, set1)
 cannot_unbridge_err = ErrorException(
     "Cannot unbridge function because some variables are bridged by variable" *
     " bridges that do not support reverse mapping, e.g., `ZerosBridge`."
@@ -49,7 +49,7 @@ b2 = VariableDummyBridge(2)
 set2 = MOI.Zeros(4)
 F2 = MOI.VectorOfVariables
 S2 = typeof(set2)
-v2, c2 = MOIB.Variable.add_keys_for_bridge(map, b2, set2)
+v2, c2 = MOIB.Variable.add_keys_for_bridge(map, () -> b2, set2)
 @testset "Vector set" begin
     @test v2[1].value == c2.value == -2
     @test MOIB.Variable.has_keys(map, v2)
@@ -80,7 +80,7 @@ end
 
 b3 = VariableDummyBridge(3)
 set3 = MOI.Zeros(0)
-v3, c3 = MOIB.Variable.add_keys_for_bridge(map, b3, set3)
+v3, c3 = MOIB.Variable.add_keys_for_bridge(map, () -> b3, set3)
 @testset "Vector set of length 0" begin
     @test isempty(v3)
     @test c3.value == 0


### PR DESCRIPTION
As the variable bridges substitute user (bridged) variables into
solver variables, the solver and the bridges that are created by this bridge are
using the solver variables while the user and other bridges are using
the user variables.

Before this commit, the solver variables where substituted for the user
variables even when the call was coming from a bridge that was created
(directly or indirectly) by the bridge that created these variables.
This causes issues if the call was for getting a function which should
then be converted into a VectorOfVariables as even if it is a
VectorOfVariables in terms of the solver variables, it may not be a
VectorOfVariables in terms of the user variables.