### PR TITLE
Add dual_objective_value option to config

### DIFF
--- a/src/Test/UnitTests/solve.jl
+++ b/src/Test/UnitTests/solve.jl
@@ -153,6 +153,10 @@ function solve_result_index(model::MOI.ModelLike, config::TestConfig)
         result_index = result_count + 1
         @test MOI.get(model, MOI.ObjectiveValue(1)) ≈ 1.0 atol=atol rtol=rtol
         @test_throws result_err(MOI.ObjectiveValue(result_index)) MOI.get(model, MOI.ObjectiveValue(result_index))
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue(1)) ≈ 1.0 atol=atol rtol=rtol
+            @test_throws result_err(MOI.DualObjectiveValue(result_index)) MOI.get(model, MOI.DualObjectiveValue(result_index))
+        end
         @test MOI.get(model, MOI.PrimalStatus(1)) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.PrimalStatus(result_index)) == MOI.NO_SOLUTION
         @test MOI.get(model, MOI.VariablePrimal(1), x) ≈ 1.0 atol=atol rtol=rtol
@@ -164,8 +168,6 @@ function solve_result_index(model::MOI.ModelLike, config::TestConfig)
             @test MOI.get(model, MOI.DualStatus(result_index)) == MOI.NO_SOLUTION
             @test MOI.get(model, MOI.ConstraintDual(1), c) ≈ 1.0 atol=atol rtol=rtol
             @test_throws result_err(MOI.ConstraintDual(result_index)) MOI.get(model, MOI.ConstraintDual(result_index), c)
-            @test MOI.get(model, MOI.DualObjectiveValue(1)) ≈ 1.0 atol=atol rtol=rtol
-            @test_throws result_err(MOI.DualObjectiveValue(result_index)) MOI.get(model, MOI.DualObjectiveValue(result_index))
         end
     end
 end

--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -5,6 +5,7 @@ struct TestConfig{T <: Number}
     query::Bool # can get objective function, and constraint functions, and constraint sets
     modify_lhs::Bool # can modify function of a constraint
     duals::Bool # test dual solutions
+    dual_objective_value::Bool # test `DualObjectiveValue`
     infeas_certificates::Bool # check for primal or dual infeasibility certificates when appropriate
     # The expected "optimal" status returned by the solver. Either
     # MOI.OPTIMAL or MOI.LOCALLY_SOLVED.
@@ -13,10 +14,10 @@ struct TestConfig{T <: Number}
     function TestConfig{T}(;
         atol::Float64 = 1e-8, rtol::Float64 = 1e-8, solve::Bool = true,
         query::Bool = true, modify_lhs::Bool = true, duals::Bool = true,
-        infeas_certificates::Bool = true, optimal_status = MOI.OPTIMAL,
-        basis::Bool = false) where {T <: Number}
-        new(atol, rtol, solve, query, modify_lhs, duals, infeas_certificates,
-            optimal_status, basis)
+        dual_objective_value::Bool = duals, infeas_certificates::Bool = true,
+        optimal_status = MOI.OPTIMAL, basis::Bool = false) where {T <: Number}
+        new(atol, rtol, solve, query, modify_lhs, duals, dual_objective_value,
+            infeas_certificates, optimal_status, basis)
     end
     TestConfig(;kwargs...) = TestConfig{Float64}(; kwargs...)
 end

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -58,7 +58,7 @@ function _lin1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -11 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -11 atol=atol rtol=rtol
         end
 
@@ -165,7 +165,7 @@ function _lin2test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -82 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -82 atol=atol rtol=rtol
         end
 
@@ -358,7 +358,7 @@ function _norminf1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.5 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 1.5 atol=atol rtol=rtol
         end
 
@@ -494,7 +494,7 @@ function _normone1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 1 atol=atol rtol=rtol
         end
 
@@ -629,7 +629,7 @@ function _soc1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ √2 atol=atol rtol=rtol
         end
 
@@ -707,7 +707,7 @@ function _soc2test(model::MOI.ModelLike, config::TestConfig, nonneg::Bool)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1/√2 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -1/√2 atol=atol rtol=rtol
         end
 
@@ -829,7 +829,7 @@ function soc4test(model::MOI.ModelLike, config::TestConfig)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -√5 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -√5 atol=atol rtol=rtol
         end
 
@@ -918,7 +918,7 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::TestConfig, abvars::Bool
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ √2 atol=atol rtol=rtol
         end
 
@@ -1093,7 +1093,7 @@ function rotatedsoc3test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √ub atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ √ub atol=atol rtol=rtol
         end
 
@@ -1181,7 +1181,7 @@ function rotatedsoc4test(model::MOI.ModelLike, config::TestConfig; n=2, ub=3.0)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
         end
 
@@ -1332,7 +1332,7 @@ function _exp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 + 2exp(1/2) atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 + 2exp(1/2) atol=atol rtol=rtol
         end
 
@@ -1402,7 +1402,7 @@ function exp2test(model::MOI.ModelLike, config::TestConfig)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ exp(-0.3) atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ exp(-0.3) atol=atol rtol=rtol
         end
 
@@ -1471,7 +1471,7 @@ function exp3test(model::MOI.ModelLike, config::TestConfig)
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ log(5) atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ log(5) atol=atol rtol=rtol
         end
 
@@ -1552,7 +1552,7 @@ function _dualexp1test(model::MOI.ModelLike, config::TestConfig, vecofvars::Bool
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 + 2exp(1 / 2) atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 + 2exp(1 / 2) atol=atol rtol=rtol
         end
 
@@ -1824,7 +1824,7 @@ function _psd0test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 2 atol=atol rtol=rtol
         end
 
@@ -1972,7 +1972,7 @@ function _psd1test(model::MOI.ModelLike, vecofvars::Bool, psdcone, config::TestC
         end
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ obj atol=atol rtol=rtol
-        if config.duals
+        if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ obj atol=atol rtol=rtol
         end
 

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -76,6 +76,9 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
@@ -83,7 +86,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -1 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
@@ -112,12 +114,14 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 1 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0] atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 1 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 0 atol=atol rtol=rtol
@@ -171,6 +175,9 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus(1)) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 2 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 0, 1] atol=atol rtol=rtol
 
@@ -178,7 +185,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 2 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -2 atol=atol rtol=rtol
 
             @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ 1 atol=atol rtol=rtol
@@ -204,12 +210,14 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [-1, 0, 2] atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 atol=atol rtol=rtol
         end
     end
 
@@ -316,6 +324,9 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 1, 0] atol=atol rtol=rtol
 
@@ -331,7 +342,6 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where T
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus(1)) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 atol=atol rtol=rtol
 
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -T(3//2) atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c2) ≈ T(1//2) atol=atol rtol=rtol
@@ -418,6 +428,9 @@ function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -1 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol=atol rtol=rtol
 
@@ -427,7 +440,6 @@ function linear2test(model::MOI.ModelLike, config::TestConfig{T}) where T
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -1 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
@@ -1220,12 +1232,14 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(10) atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(10) atol=atol rtol=rtol
+        end
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 10 atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(10) atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
         end
 
@@ -1246,10 +1260,12 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(5) atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(5) atol=atol rtol=rtol
+        end
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 5 atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(5) atol=atol rtol=rtol
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
@@ -1275,6 +1291,9 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
+        end
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol=atol rtol=rtol
 
         if config.basis
@@ -1287,7 +1306,6 @@ function linear10test(model::MOI.ModelLike, config::TestConfig{T}) where T
         if config.duals
             @test MOI.get(model, MOI.ResultCount()) >= 1
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ T(2) atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 1 atol=atol rtol=rtol
         end
     end
@@ -1598,6 +1616,9 @@ function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 8 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 8 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 0 atol=atol rtol=rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1/2 atol=atol rtol=rtol
@@ -1611,7 +1632,6 @@ function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where T
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 8 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
@@ -1640,6 +1660,9 @@ function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 6 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 6 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1 atol=atol rtol=rtol
 
@@ -1648,7 +1671,6 @@ function linear14test(model::MOI.ModelLike, config::TestConfig{T}) where T
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 6 atol=atol rtol=rtol
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -1 atol=atol rtol=rtol
 
             # reduced costs
@@ -1699,12 +1721,14 @@ function linear15test(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
 
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0 atol=atol rtol=rtol
+        if config.dual_objective_value
+            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 0 atol=atol rtol=rtol
+        end
 
         @test MOI.get(model, MOI.VariablePrimal(), x[1]) ≈ 0 atol=atol rtol=rtol
 
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-            @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 0 atol=atol rtol=rtol
         end
     end
 end


### PR DESCRIPTION
Some solvers support dual value for the constraints but not for the objective (e.g. Ipopt).