### PR TITLE
Add support for starting values for functionize bridges

### DIFF
--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -25,6 +25,63 @@ function MOI.Bridges.Constraint.bridge_constraint(BridgeType, b, f, s)
 end
 
 # Constraint bridges
+# Function conversion bridges
+
+"""
+    abstract type AbstractFunctionConversionBridge <: AbstractBridge end
+
+Bridge a constraint `F`-in-`S` into a constraint `G`-in-`S` where `F` and `G`
+are equivalent representations of the same function. By convention, the
+transformed function is stored in the `constraint` field.
+"""
+abstract type AbstractFunctionConversionBridge <: AbstractBridge end
+
+function MOI.get(model::MOI.ModelLike, attr::MOI.AbstractConstraintAttribute,
+                 bridge::AbstractFunctionConversionBridge)
+    if invariant_under_function_conversion(attr)
+        return MOI.get(model, attr, bridge.constraint)
+    else
+        throw(ArgumentError("Bridge of type `$(typeof(bridge))` does not support accessing the attribute `$attr` because `MOIB.Constraint.invariant_under_function_conversion($attr)` returns `false`."))
+    end
+end
+
+function MOI.set(model::MOI.ModelLike, attr::MOI.AbstractConstraintAttribute,
+                 bridge::AbstractFunctionConversionBridge, value)
+    if invariant_under_function_conversion(attr)
+        return MOI.set(model, attr, bridge.constraint, value)
+    else
+        throw(ArgumentError("Bridge of type `$(typeof(bridge))` does not support setting the attribute `$attr` because `MOIB.Constraint.invariant_under_function_conversion($attr)` returns `false`."))
+    end
+end
+
+"""
+    invariant_under_function_conversion(attr::MOI.AbstractConstraintAttribute)
+
+Returns whether the value of the attribute does not change if the constraint
+`F`-in-`S` is transformed into a constraint `G`-in-`S` where `F` and `G` are
+equivalent representations of the same function. If it returns true, then
+subtypes of [`Constraint.AbstractFunctionConversionBridge`](@ref) such as
+[`Constraint.ScalarFunctionizeBridge`](@ref) and
+[`Constraint.VectorFunctionizeBridge`](@ref) will automatically support
+[`MOI.get`](@ref) and [`MOI.set`](@ref) for `attr`.
+"""
+invariant_under_function_conversion(::MOI.AbstractConstraintAttribute) = false
+
+function invariant_under_function_conversion(::Union{
+       MOI.ConstraintSet,
+       MOI.ConstraintBasisStatus,
+       MOI.ConstraintPrimal,
+       MOI.ConstraintPrimalStart,
+       MOI.ConstraintDual,
+       MOI.ConstraintDualStart})
+    return true
+end
+
+include("functionize.jl")
+const ScalarFunctionize{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{ScalarFunctionizeBridge{T}, OT}
+const VectorFunctionize{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{VectorFunctionizeBridge{T}, OT}
+# TODO add affine -> quadratic conversion bridge
+
 include("flip_sign.jl")
 const GreaterToLess{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{GreaterToLessBridge{T}, OT}
 const LessToGreater{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{LessToGreaterBridge{T}, OT}
@@ -37,9 +94,6 @@ const Scalarize{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{ScalarizeBridge{T}
 include("slack.jl")
 const ScalarSlack{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{ScalarSlackBridge{T}, OT}
 const VectorSlack{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{VectorSlackBridge{T}, OT}
-include("functionize.jl")
-const ScalarFunctionize{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{ScalarFunctionizeBridge{T}, OT}
-const VectorFunctionize{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{VectorFunctionizeBridge{T}, OT}
 include("interval.jl")
 const SplitInterval{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{SplitIntervalBridge{T}, OT}
 include("rsoc.jl")

--- a/src/Bridges/Constraint/functionize.jl
+++ b/src/Bridges/Constraint/functionize.jl
@@ -6,7 +6,7 @@
 The `ScalarFunctionizeBridge` converts a constraint `SingleVariable`-in-`S`
 into the constraint `ScalarAffineFunction{T}`-in-`S`.
 """
-struct ScalarFunctionizeBridge{T, S} <: AbstractBridge
+struct ScalarFunctionizeBridge{T, S} <: AbstractFunctionConversionBridge
     constraint::CI{MOI.ScalarAffineFunction{T}, S}
 end
 function bridge_constraint(::Type{ScalarFunctionizeBridge{T, S}}, model,
@@ -39,37 +39,15 @@ function MOI.delete(model::MOI.ModelLike, c::ScalarFunctionizeBridge)
     return
 end
 
-# Attributes, Bridge acting as a constraint
-function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal, c::ScalarFunctionizeBridge)
-    return MOI.get(model, attr, c.constraint)
-end
-function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintDual, c::ScalarFunctionizeBridge)
-    return MOI.get(model, a, c.constraint)
-end
-function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintBasisStatus,
-                 bridge::ScalarFunctionizeBridge)
-    return MOI.get(model, attr, bridge.constraint)
-end
-
-
 # Constraints
 function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintFunction,
                  c::ScalarFunctionizeBridge{T}, f::MOI.SingleVariable) where {T}
     MOI.set(model, MOI.ConstraintFunction(), c.constraint, MOI.ScalarAffineFunction{T}(f))
 end
-function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintSet,
-                 c::ScalarFunctionizeBridge{T, S}, change::S) where {T, S}
-    MOI.set(model, MOI.ConstraintSet(), c.constraint, change)
-end
-
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintFunction,
                  b::ScalarFunctionizeBridge)
     f = MOIU.canonical(MOI.get(model, attr, b.constraint))
     return convert(MOI.SingleVariable, f)
-end
-function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintSet,
-                 b::ScalarFunctionizeBridge)
-    return MOI.get(model, attr, b.constraint)
 end
 
 # vector version
@@ -80,7 +58,7 @@ end
 The `VectorFunctionizeBridge` converts a constraint `VectorOfVariables`-in-`S`
 into the constraint `VectorAffineFunction{T}`-in-`S`.
 """
-mutable struct VectorFunctionizeBridge{T, S} <: AbstractBridge
+mutable struct VectorFunctionizeBridge{T, S} <: AbstractFunctionConversionBridge
     constraint::CI{MOI.VectorAffineFunction{T}, S}
 end
 function bridge_constraint(::Type{VectorFunctionizeBridge{T, S}}, model,
@@ -124,16 +102,6 @@ function MOI.delete(model::MOI.ModelLike, bridge::VectorFunctionizeBridge,
     bridge.constraint = MOI.add_constraint(model, new_func, new_set)
 end
 
-# Attributes, Bridge acting as a constraint
-function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal,
-                 bridge::VectorFunctionizeBridge)
-    return MOI.get(model, attr, bridge.constraint)
-end
-function MOI.get(model::MOI.ModelLike, a::MOI.ConstraintDual,
-                 bridge::VectorFunctionizeBridge)
-    return MOI.get(model, a, bridge.constraint)
-end
-
 # Constraints
 function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintFunction,
                  bridge::VectorFunctionizeBridge{T},
@@ -141,17 +109,8 @@ function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintFunction,
     MOI.set(model, MOI.ConstraintFunction(), bridge.constraint,
             MOI.VectorAffineFunction{T}(func))
 end
-function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintSet,
-                 bridge::VectorFunctionizeBridge{T, S}, change::S) where {T, S}
-    MOI.set(model, MOI.ConstraintSet(), bridge.constraint, change)
-end
-
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintFunction,
                  b::VectorFunctionizeBridge)
     f = MOI.get(model, attr, b.constraint)
     return MOIU.convert_approx(MOI.VectorOfVariables, f)
-end
-function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintSet,
-                 b::VectorFunctionizeBridge)
-    return MOI.get(model, attr, b.constraint)
 end

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -63,6 +63,12 @@ config_with_basis = MOIT.TestConfig(basis = true)
             end
         end
 
+        attr = MOIT.UnknownConstraintAttribute()
+        err = ArgumentError("Bridge of type `MathOptInterface.Bridges.Constraint.ScalarFunctionizeBridge{Float64,MathOptInterface.GreaterThan{Float64}}` does not support setting the attribute `$attr` because `MOIB.Constraint.invariant_under_function_conversion($attr)` returns `false`.")
+        @test_throws err MOI.set(bridged_mock, attr, ci, 1.0)
+        err = ArgumentError("Bridge of type `MathOptInterface.Bridges.Constraint.ScalarFunctionizeBridge{Float64,MathOptInterface.GreaterThan{Float64}}` does not support accessing the attribute `$attr` because `MOIB.Constraint.invariant_under_function_conversion($attr)` returns `false`.")
+        @test_throws err MOI.get(bridged_mock, attr, ci)
+
         @testset "delete" begin
             for (i, ci) in enumerate(cis)
                 test_delete_bridge(bridged_mock, ci, 2,

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -8,7 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
+mock = MOIU.MockOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()))
 config = MOIT.TestConfig()
 config_with_basis = MOIT.TestConfig(basis = true)
 
@@ -52,14 +52,24 @@ config_with_basis = MOIT.TestConfig(basis = true)
                  (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.BASIC, MOI.NONBASIC]]))
         MOIT.linear2test(bridged_mock, config_with_basis)
 
-        for (i, ci) in enumerate(MOI.get(
-            bridged_mock,
-            MOI.ListOfConstraintIndices{MOI.SingleVariable,
-                                        MOI.GreaterThan{Float64}}()))
-            test_delete_bridge(bridged_mock, ci, 2,
-                               ((MOI.ScalarAffineFunction{Float64},
-                                 MOI.GreaterThan{Float64}, 0),),
-                               num_bridged = 3 - i)
+        cis = MOI.get(bridged_mock,
+                      MOI.ListOfConstraintIndices{MOI.SingleVariable,
+                                                  MOI.GreaterThan{Float64}}())
+
+        @testset "$attr" for attr in [MOI.ConstraintPrimalStart(), MOI.ConstraintDualStart()]
+            for ci in cis
+                MOI.set(bridged_mock, attr, ci, 2.0)
+                @test MOI.get(bridged_mock, attr, ci) == 2.0
+            end
+        end
+
+        @testset "delete" begin
+            for (i, ci) in enumerate(cis)
+                test_delete_bridge(bridged_mock, ci, 2,
+                                   ((MOI.ScalarAffineFunction{Float64},
+                                     MOI.GreaterThan{Float64}, 0),),
+                                   num_bridged = 3 - i)
+            end
         end
     end
 end
@@ -108,6 +118,12 @@ end
         new_func = MOI.VectorOfVariables(func.variables[[1, 3]])
         @test MOI.get(bridged_mock, MOI.ConstraintFunction(), ci) == new_func
         @test MOI.get(bridged_mock, MOI.ConstraintSet(), ci) == MOI.Nonnegatives(2)
+
+        @testset "$attr" for attr in [MOI.ConstraintPrimalStart(), MOI.ConstraintDualStart()]
+            MOI.set(bridged_mock, attr, ci, [1.0, 2.0])
+            @test MOI.get(bridged_mock, attr, ci) == [1.0, 2.0]
+        end
+
         test_delete_bridge(bridged_mock, ci, 2,
                            ((MOI.VectorAffineFunction{Float64},
                              MOI.Nonnegatives, 0),))


### PR DESCRIPTION
Also allows custom attributes to be supported by such bridges via the new `invariant_under_function_conversion` function.

See https://github.com/JuliaOpt/MathOptInterface.jl/issues/684