### PR TITLE
No index mapping nor substitution for ModelLike

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -73,7 +73,7 @@ function map_indices(variable_map::AbstractDict{T, T}, x) where {T <: MOI.Index}
     return map_indices(vi -> variable_map[vi], x)
 end
 
-const ObjectWithoutIndex = Union{Nothing, DataType, Number, Enum, AbstractString, MOI.AnyAttribute, MOI.AbstractSet, Function}
+const ObjectWithoutIndex = Union{Nothing, DataType, Number, Enum, AbstractString, MOI.AnyAttribute, MOI.AbstractSet, Function, MOI.ModelLike}
 const ObjectOrTupleWithoutIndex = Union{ObjectWithoutIndex, Tuple{Vararg{ObjectWithoutIndex}}}
 const ObjectOrTupleOrArrayWithoutIndex = Union{ObjectOrTupleWithoutIndex, AbstractArray{<:ObjectOrTupleWithoutIndex}}
 

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -223,6 +223,7 @@ function MOI.set(mock::MockOptimizer, ::MOI.ConstraintBasisStatus,
     mock.con_basis[xor_index(idx)] = value
 end
 
+MOI.get(mock::MockOptimizer, ::MOI.RawSolver) = mock
 function MOI.get(mock::MockOptimizer, attr::MOI.AbstractOptimizerAttribute)
     if MOI.is_set_by_optimize(attr)
         return mock.optimizer_attributes[attr]

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -67,6 +67,10 @@ struct DummyConstraintAttribute <: MOI.AbstractConstraintAttribute end
         @test MOI.get(mock, attr, [index])[1] ≈ 3.0fy + 1.0fz + 3.0
     end
 
+    @testset "RawSolver" begin
+        MOI.get(bridged, MOI.RawSolver()) === mock
+    end
+
     @testset "HeuristicCallback" begin
         attr = MOI.HeuristicCallback()
         f(callback_data) = nothing

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -174,6 +174,10 @@ struct DummyConstraintAttribute <: MOI.AbstractConstraintAttribute end
         @test MOI.get(mock, attr, [optimizer_index])[1] ≈ 3.0fy
     end
 
+    @testset "RawSolver" begin
+        MOI.get(model, MOI.RawSolver()) === mock
+    end
+
     @testset "HeuristicCallback" begin
         attr = MOI.HeuristicCallback()
         f(callback_data) = nothing


### PR DESCRIPTION
Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/926