### PR TITLE
Testing constant term in indicator constraint

### DIFF
--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -609,8 +609,8 @@ function indicator4_test(model::MOI.ModelLike, config::TestConfig)
     # linear problem with indicator constraint and
     # max  2x1 + 3x2
     # s.t. x1 + x2 <= 10
-    #      z1 ==> x2 + 1 <= 7
-    #      z2 ==> x2 + x1/5 - 1 <= 10
+    #      z1 ==> x2 - 1 <= 7
+    #      z2 ==> x2 + x1/5 + 1 <= 10
     #      z1 + z2 >= 1
 
 
@@ -633,7 +633,7 @@ function indicator4_test(model::MOI.ModelLike, config::TestConfig)
         [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, z1)),
          MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x2)),
         ],
-        [0.0, 1.0]
+        [0.0, -1.0]
     )
     iset1 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(7.0))
     MOI.add_constraint(model, f1, iset1)
@@ -643,7 +643,7 @@ function indicator4_test(model::MOI.ModelLike, config::TestConfig)
          MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(0.2, x1)),
          MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x2)),
         ],
-        [0.0, -1.0],
+        [0.0, 1.0],
     )
     iset2 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(10.0))
 

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -602,6 +602,85 @@ function indicator3_test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
+function indicator4_test(model::MOI.ModelLike, config::TestConfig)
+    atol = config.atol
+    rtol = config.rtol
+    # equivalent to indicator1_test with left-hand-side partially in LHS constant
+    # linear problem with indicator constraint and
+    # max  2x1 + 3x2
+    # s.t. x1 + x2 <= 10
+    #      z1 ==> x2 + 1 <= 7
+    #      z2 ==> x2 + x1/5 - 1 <= 10
+    #      z1 + z2 >= 1
+
+
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.Interval{Float64})
+    @test MOI.supports_constraint(model, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64})
+    @test MOI.supports_constraint(model, MOI.VectorAffineFunction{Float64}, MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE, MOI.LessThan{Float64}})
+    x1 = MOI.add_variable(model)
+    x2 = MOI.add_variable(model)
+    z1 = MOI.add_variable(model)
+    z2 = MOI.add_variable(model)
+    MOI.add_constraint(model, z1, MOI.ZeroOne())
+    MOI.add_constraint(model, z2, MOI.ZeroOne())
+    f1 = MOI.VectorAffineFunction(
+        [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, z1)),
+         MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x2)),
+        ],
+        [0.0, 1.0]
+    )
+    iset1 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(7.0))
+    MOI.add_constraint(model, f1, iset1)
+
+    f2 = MOI.VectorAffineFunction(
+        [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, z2)),
+         MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(0.2, x1)),
+         MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, x2)),
+        ],
+        [0.0, -1.0],
+    )
+    iset2 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(10.0))
+
+    MOI.add_constraint(model, f2, iset2)
+
+    # Additional regular constraint.
+    MOI.add_constraint(model,
+        MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x1), MOI.ScalarAffineTerm(1.0, x2)], 0.0),
+        MOI.LessThan(10.0),
+    )
+
+    # Disjunction z1 ⋁ z2
+    MOI.add_constraint(model,
+        MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, z1), MOI.ScalarAffineTerm(1.0, z2)], 0.0),
+        MOI.GreaterThan(1.0),
+    )
+
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([2.0, 3.0], [x1, x2]), 0.0)
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+
+    if config.solve
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 28.75 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x1) ≈ 1.25 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), x2) ≈ 8.75 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), z1) ≈ 0.0 atol=atol rtol=rtol
+        @test MOI.get(model, MOI.VariablePrimal(), z2) ≈ 1.0 atol=atol rtol=rtol
+    end
+end
+
 const intlineartests = Dict("knapsack" => knapsacktest,
                             "int1"     => int1test,
                             "int2"     => int2test,
@@ -609,6 +688,7 @@ const intlineartests = Dict("knapsack" => knapsacktest,
                             "indicator1"  => indicator1_test,
                             "indicator2"  => indicator2_test,
                             "indicator3"  => indicator3_test,
+                            "indicator4"  => indicator4_test,
                            )
 
 @moitestset intlinear

--- a/test/Test/intlinear.jl
+++ b/test/Test/intlinear.jl
@@ -38,3 +38,7 @@ MOIU.set_mock_optimize!(mock,
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.25, 8.75, 1., 1.])
 )
 MOIT.indicator3_test(mock, config)
+MOIU.set_mock_optimize!(mock,
+    (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.25, 8.75, 0., 1.])
+)
+MOIT.indicator4_test(mock, config)


### PR DESCRIPTION
There was no test such that:
```
y in {0,1}
y -> a^T x + b in Set
```
with `b != 0`, this additional test is equivalent to the first indicator test, with a part of the RHS shifted to the constant term