### PR TITLE
Fix segfault of #877

### DIFF
--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -102,38 +102,50 @@ function _added_dist(b::LazyBridgeOptimizer, args...)
     return dist
 end
 function added_dist(b::LazyBridgeOptimizer,
-                    BT::Type{<:Union{Variable.AbstractBridge,
-                                     Constraint.AbstractBridge}},
-                    args...)
-    return _added_dist(b, BT, args...)
+                    BT::Type{<:Variable.AbstractBridge},
+                    S::Type{<:MOI.AbstractSet})
+    return _added_dist(b, BT, S)
+end
+function added_dist(b::LazyBridgeOptimizer,
+                    BT::Type{<:Constraint.AbstractBridge},
+                    F::Type{<:MOI.AbstractFunction},
+                    S::Type{<:MOI.AbstractSet})
+    return _added_dist(b, BT, F, S)
 end
 function added_dist(b::LazyBridgeOptimizer,
                     BT::Type{<:Objective.AbstractBridge},
-                    args...)
-    F = set_objective_function_type(BT, args...)
-    return _added_dist(b, BT, args...) + _dist(b, F)
+                    F1::Type{<:MOI.AbstractScalarFunction})
+    F2 = set_objective_function_type(BT, F1)
+    return _added_dist(b, BT, F1) + _dist(b, F2)
 end
 
-function _supports_added_no_update(b::LazyBridgeOptimizer, args...)
+function _supports_added_no_update(b::LazyBridgeOptimizer, args::Vararg{Any, N}) where N
     return all(C -> supports_no_update(b, C[1]), added_constrained_variable_types(args...)) &&
         all(C -> supports_no_update(b, C[1], C[2]), added_constraint_types(args...))
 end
 function supports_added_no_update(
     b::LazyBridgeOptimizer,
-    BT::Type{<:Union{Variable.AbstractBridge,
-                     Constraint.AbstractBridge}},
-    args...
+    BT::Type{<:Variable.AbstractBridge},
+    S::Type{<:MOI.AbstractSet}
 )
-    return _supports_added_no_update(b, BT, args...)
+    return _supports_added_no_update(b, BT, S)
+end
+function supports_added_no_update(
+    b::LazyBridgeOptimizer,
+    BT::Type{<:Constraint.AbstractBridge},
+    F::Type{<:MOI.AbstractFunction},
+    S::Type{<:MOI.AbstractSet}
+)
+    return _supports_added_no_update(b, BT, F, S)
 end
 function supports_added_no_update(
     b::LazyBridgeOptimizer,
     BT::Type{<:Objective.AbstractBridge},
-    args...
+    F1::Type{<:MOI.AbstractScalarFunction}
 )
-    F = set_objective_function_type(BT, args...)
-    return _supports_added_no_update(b, BT, args...) &&
-        supports_no_update(b, F)
+    F2 = set_objective_function_type(BT, F1)
+    return _supports_added_no_update(b, BT, F1) &&
+        supports_no_update(b, F2)
 end
 
 


### PR DESCRIPTION
This fixes the segfault on Julia v1.0 of https://github.com/JuliaOpt/MathOptInterface.jl/pull/877

This also give an impressive performance improvements for the benchmark added in https://github.com/JuliaOpt/MathOptInterface.jl/pull/946. This performance improvement might be explained by https://github.com/JuliaLang/julia/issues/32761
On master:
```
BenchmarkTools.Trial: 
  memory estimate:  269.80 KiB
  allocs estimate:  4658
  --------------
  minimum time:     11.074 ms (0.00% GC)
  median time:      11.251 ms (0.00% GC)
  mean time:        11.761 ms (1.45% GC)
  maximum time:     61.752 ms (79.61% GC)
  --------------
  samples:          425
  evals/sample:     1
BenchmarkTools.Trial: 
  memory estimate:  715.16 KiB
  allocs estimate:  12004
  --------------
  minimum time:     41.166 ms (0.00% GC)
  median time:      45.770 ms (0.00% GC)
  mean time:        50.720 ms (2.82% GC)
  maximum time:     203.532 ms (60.85% GC)
  --------------
  samples:          99
  evals/sample:     1
```
After this PR:
```
BenchmarkTools.Trial: 
  memory estimate:  68.59 KiB
  allocs estimate:  1861
  --------------
  minimum time:     3.819 ms (0.00% GC)
  median time:      5.165 ms (0.00% GC)
  mean time:        5.701 ms (2.53% GC)
  maximum time:     110.109 ms (91.74% GC)
  --------------
  samples:          875
  evals/sample:     1
BenchmarkTools.Trial: 
  memory estimate:  163.96 KiB
  allocs estimate:  4440
  --------------
  minimum time:     23.947 ms (0.00% GC)
  median time:      32.318 ms (0.00% GC)
  mean time:        32.113 ms (0.80% GC)
  maximum time:     83.834 ms (47.83% GC)
  --------------
  samples:          156
  evals/sample:     1
```