### PR TITLE
Fix add_constraints with non-bridged variable constraint on bridged variable

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1050,11 +1050,11 @@ function MOI.add_constraints(b::AbstractBridgeOptimizer, f::Vector{F},
         return MOI.add_constraint.(b, f, s)
     else
         if Variable.has_bridges(Variable.bridges(b))
-            if S == MOI.SingleVariable
+            if F == MOI.SingleVariable
                 if any(func -> is_bridged(b, func.variable), f)
                     return MOI.add_constraint.(b, f, s)
                 end
-            elseif S == MOI.VectorOfVariables
+            elseif F == MOI.VectorOfVariables
                 if any(func -> any(vi -> is_bridged(b, vi), func.variables), f)
                     return MOI.add_constraint.(b, f, s)
                 end

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -80,8 +80,8 @@ MOI.supports(::StandardLPModel, ::MOI.ObjectiveFunction{MOI.SingleVariable}) = f
             @test_throws err MOI.add_constraints(bridged, [fx], [set])
         end
         @testset "with `Constraint.ScalarFunctionizeBridge`" begin
-            for (i, data) in enumerate([_bridged(), _bridged()])
-                model, bridged, fx = data
+            for i in 1:2
+                model, bridged, fx = _bridged()
                 MOIB.add_bridge(bridged, MOIB.Constraint.ScalarFunctionizeBridge{T})
                 if i == 1
                     cx = MOI.add_constraint(bridged, fx, set)
@@ -128,8 +128,8 @@ end
             @test_throws err MOI.add_constraints(bridged, [fx], [set])
         end
         @testset "with `Constraint.ScalarFunctionizeBridge`" begin
-            for (i, data) in enumerate([_bridged(), _bridged()])
-                model, bridged, fx = data
+            for i in 1:2
+                model, bridged, fx = _bridged()
                 MOIB.add_bridge(bridged, MOIB.Constraint.VectorFunctionizeBridge{T})
                 if i == 1
                     cx = MOI.add_constraint(bridged, fx, set)


### PR DESCRIPTION
All the tests with `add_constraints` we had were run on model that needed the constraint to be bridged which allowed this bug to slip through.