### PR TITLE
Build bridge graph to improve performance of bridge shortest path

### DIFF
--- a/perf/bellman_ford.jl
+++ b/perf/bellman_ford.jl
@@ -22,24 +22,32 @@ function interval_constraint()
     bridged = MOIB.full_bridge_optimizer(model, Float64)
     F = MOI.ScalarAffineFunction{Float64}
     S = MOI.Interval{Float64}
-    MOIB.update!(bridged, (F, S))
-    @benchmark begin
+    MOIB.bridge_index(bridged, F, S)
+    display(@benchmark begin
         MOIB._reset_dist($bridged)
-        MOIB.update!($bridged, ($F, $S))
-    end
+        MOIB.node($bridged, $F, $S)
+    end)
+    display(@benchmark begin
+        MOIB._reset_dist($bridged)
+        MOIB.bridge_index($bridged, $F, $S)
+    end)
 end
 
-display(interval_constraint())
+interval_constraint()
 
 function quadratic_objective()
     model = SDPAModel{Float64}()
     bridged = MOIB.full_bridge_optimizer(model, Float64)
     F = MOI.ScalarQuadraticFunction{Float64}
-    MOIB.update!(bridged, (F,))
-    @benchmark begin
+    MOIB.bridge_index(bridged, F)
+    display(@benchmark begin
         MOIB._reset_dist($bridged)
-        MOIB.update!($bridged, ($F,))
-    end
+        MOIB.node($bridged, $F)
+    end)
+    display(@benchmark begin
+        MOIB._reset_dist($bridged)
+        MOIB.bridge_index($bridged, $F)
+    end)
 end
 
 display(quadratic_objective())

--- a/src/Bridges/Constraint/square.jl
+++ b/src/Bridges/Constraint/square.jl
@@ -131,7 +131,7 @@ function concrete_bridge_type(::Type{<:SquareBridge{T}},
     S = MOIU.scalar_type(F)
     G = MOIU.promote_operation(-, T, S, S)
     TT = MOI.triangular_form(ST)
-    SquareBridge{T, F, G, TT, ST}
+    return SquareBridge{T, F, G, TT, ST}
 end
 
 # Attributes, Bridge acting as a model

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -10,8 +10,7 @@ function print_node(io::IO, b::LazyBridgeOptimizer, node::ObjectiveNode)
     F, = b.objective_types[node.index]
     MOIU.print_with_acronym(io, "|$(node.index)| objective function of type `$F` is")
 end
-
-function debug(b::LazyBridgeOptimizer, node::AbstractNode; io::IO = Base.stdout)
+function print_node_info(io::IO, b::LazyBridgeOptimizer, node::AbstractNode)
     print(io, " ")
     print_node(io, b, node)
     d = _dist(b.graph, node)
@@ -29,16 +28,17 @@ function debug(b::LazyBridgeOptimizer, node::AbstractNode; io::IO = Base.stdout)
         end
     end
 end
-function debug(b::LazyBridgeOptimizer; io::IO = Base.stdout)
+print_graph(b::LazyBridgeOptimizer) = print_graph(Base.stdout, b)
+function print_graph(io::IO, b::LazyBridgeOptimizer)
     println(io, b.graph)
     for node in variable_nodes(b.graph)
-        debug(b, node; io = io)
+        print_node_info(io, b, node)
     end
     for node in constraint_nodes(b.graph)
-        debug(b, node; io = io)
+        print_node_info(io, b, node)
     end
     for node in objective_nodes(b.graph)
-        debug(b, node; io = io)
+        print_node_info(io, b, node)
     end
 end
 

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -1,108 +1,136 @@
-function debug_variable(io::IO, variable_to_index, BT, args...)
-    for C in added_constrained_variable_types(BT, args...)
-        i = get(variable_to_index, C, nothing)
-        if i != nothing
-            MOIU.print_with_acronym(io, "  [$i] constrained variables in `$(C[1])` are not supported\n")
-        end
+function print_node(io::IO, b::LazyBridgeOptimizer, node::VariableNode)
+    S, = b.variable_types[node.index]
+    MOIU.print_with_acronym(io, "[$(node.index)] constrained variables in `$S` are")
+end
+function print_node(io::IO, b::LazyBridgeOptimizer, node::ConstraintNode)
+    F, S = b.constraint_types[node.index]
+    MOIU.print_with_acronym(io, "($(node.index)) `$F`-in-`$S` constraints are")
+end
+function print_node(io::IO, b::LazyBridgeOptimizer, node::ObjectiveNode)
+    F, = b.objective_types[node.index]
+    MOIU.print_with_acronym(io, "|$(node.index)| objective function of type `$F` is")
+end
+function print_unsupported(io::IO, b::LazyBridgeOptimizer, node::AbstractNode)
+    if _dist(b.graph, node) != INFINITY
+        return
+    end
+    print(io, "  ")
+    print_node(io, b, node)
+    print(io, " not supported\n")
+end
+function print_unsupported(io::IO, b::LazyBridgeOptimizer, edge::Edge)
+    for node in edge.added_variables
+        print_unsupported(io, b, node)
+    end
+    for node in edge.added_constraints
+        print_unsupported(io, b, node)
     end
 end
-function _print_unsupported_constraint(io::IO, constraint_to_index, C)
-    i = get(constraint_to_index, C, nothing)
-    if i != nothing
-        MOIU.print_with_acronym(io, "  ($i) `$(C[1])`-in-`$(C[2])` constraints are not supported\n")
+function print_unsupported(io::IO, b::LazyBridgeOptimizer, edge::ObjectiveEdge)
+    for node in edge.added_variables
+        print_unsupported(io, b, node)
     end
-end
-function debug_constraint(io::IO, constraint_to_index, BT, args...)
-    for C in added_constraint_types(BT, args...)
-        _print_unsupported_constraint(io, constraint_to_index, C)
+    for node in edge.added_constraints
+        print_unsupported(io, b, node)
     end
+    print_unsupported(io, b, edge.added_objective)
 end
-function debug_objective(io::IO, objective_to_index, BT, args...)
-    F = set_objective_function_type(BT, args...)
-    i = get(objective_to_index, (F,), nothing)
-    if i != nothing
-        MOIU.print_with_acronym(io, "  |$i| objective function of type `$F` is not supported\n")
-    end
-end
-function debug(b::LazyBridgeOptimizer, variable_to_index::OrderedDict,
-               constraint_to_index::OrderedDict, objective_to_index::OrderedDict;
-               io::IO = Base.stdout)
-    for (v, i) in variable_to_index
-        S = v[1]
-        MOIU.print_with_acronym(io, "[$i] constrained variables in `$S` are not supported because")
-        no_bridge = true
-        for BT in b.variable_bridge_types
-            if Variable.supports_constrained_variable(BT, S)
-                if no_bridge
-                    println(io, ":")
-                    no_bridge = false
-                end
-                MOIU.print_with_acronym(io, "  Cannot use `$(Variable.concrete_bridge_type(BT, S))` because:\n")
-                debug_variable(io, variable_to_index, BT, S)
-                debug_constraint(io, constraint_to_index, BT, S)
-            end
-        end
+function print_unsupported(io::IO, b::LazyBridgeOptimizer, edges::Vector, index_to_bridge::Function)
+    no_bridge = true
+    for edge in edges
         if no_bridge
-            println(io, " no added bridge supports bridging it.")
+            println(io, ":")
+            no_bridge = false
         end
-        F = MOIU.variable_function_type(S)
+        MOIU.print_with_acronym(io, "  Cannot use `$(index_to_bridge(edge.bridge_index))` because:\n")
+        print_unsupported(io, b, edge)
+    end
+    if no_bridge
+        println(io, " no added bridge supports bridging it.")
+    end
+end
+function print_unsupported(io::IO, b::LazyBridgeOptimizer, variables, constraints, objectives)
+    for node in variables
+        print_node(io, b, node)
+        print(io, " not supported because")
+        print_unsupported(io, b, b.graph.variable_edges[node.index],
+                          bridge_index -> Variable.concrete_bridge_type(b.variable_bridge_types[bridge_index], b.variable_types[node.index]...))
         println(io, "  Cannot add free variables and then constrain them because:")
-        _print_unsupported_constraint(io, constraint_to_index, (F, S))
+        print_unsupported(io, b, node.constraint_node)
     end
-    for (c, i) in constraint_to_index
-        F, S = c
-        MOIU.print_with_acronym(io, "($i) `$F`-in-`$S` constraints are not supported because")
-        no_bridge = true
-        for BT in b.constraint_bridge_types
-            if MOI.supports_constraint(BT, F, S)
-                if no_bridge
-                    println(io, ":")
-                    no_bridge = false
-                end
-                MOIU.print_with_acronym(io, "  Cannot use `$(Constraint.concrete_bridge_type(BT, F, S))` because:\n")
-                debug_variable(io, variable_to_index, BT, F, S)
-                debug_constraint(io, constraint_to_index, BT, F, S)
-            end
-        end
-        if no_bridge
-            println(io, " no added bridge supports bridging it.")
-        end
+    for node in constraints
+        print_node(io, b, node)
+        print(io, " not supported because")
+        print_unsupported(io, b, b.graph.constraint_edges[node.index],
+                          bridge_index -> Constraint.concrete_bridge_type(b.constraint_bridge_types[bridge_index], b.constraint_types[node.index]...))
     end
-    for (o, i) in objective_to_index
-        F = o[1]
-        MOIU.print_with_acronym(io, "|$i| objective function of type `$F` is not supported because")
-        no_bridge = true
-        for BT in b.objective_bridge_types
-            if Objective.supports_objective_function(BT, F)
-                if no_bridge
-                    println(io, ":")
-                    no_bridge = false
-                end
-                MOIU.print_with_acronym(io, "  Cannot use `$(Objective.concrete_bridge_type(BT, F))` because:\n")
-                debug_variable(io, variable_to_index, BT, F)
-                debug_constraint(io, constraint_to_index, BT, F)
-                debug_objective(io, objective_to_index, BT, F)
-            end
+    for node in objectives
+        print_node(io, b, node)
+        print(io, " not supported because")
+        print_unsupported(io, b, b.graph.objective_edges[node.index],
+                          bridge_index -> Objective.concrete_bridge_type(b.objective_bridge_types[bridge_index], b.objective_types[node.index]...))
+    end
+end
+
+function add_unsupported(graph::Graph, edges::Vector{Edge},
+                         variables, constraints, objectives)
+    for edge in edges
+        for node in edge.added_variables
+            add_unsupported(graph, node, variables, constraints, objectives)
         end
-        if no_bridge
-            println(io, " no added bridge supports bridging it.")
+        for node in edge.added_constraints
+            add_unsupported(graph, node, variables, constraints, objectives)
         end
     end
 end
-function debug(b::LazyBridgeOptimizer, variables::OrderedSet, constraints::OrderedSet, objectives::OrderedSet; kws...)
-    variable_to_index = OrderedDict{Tuple{DataType}, Int}()
-    for (i, key) in enumerate(variables)
-        variable_to_index[key] = i
+function add_unsupported(graph::Graph, edges::Vector{ObjectiveEdge},
+                         variables, constraints, objectives)
+    for edge in edges
+        for node in edge.added_variables
+            add_unsupported(graph, node, variables, constraints, objectives)
+        end
+        for node in edge.added_constraints
+            add_unsupported(graph, node, variables, constraints, objectives)
+        end
+        add_unsupported(graph, edge.added_objective, variables, constraints, objectives)
     end
-    constraint_to_index = OrderedDict{Tuple{DataType, DataType}, Int}()
-    for (i, key) in enumerate(constraints)
-        constraint_to_index[key] = i
+end
+function add_unsupported(graph::Graph, node::VariableNode,
+                         variables, constraints, objectives)
+    if _dist(graph, node) != INFINITY
+        return
     end
-    objective_to_index = OrderedDict{Tuple{DataType}, Int}()
-    for (i, key) in enumerate(objectives)
-        objective_to_index[key] = i
+    push!(variables, node)
+    add_unsupported(graph, graph.variable_edges[node.index], variables, constraints, objectives)
+    add_unsupported(graph, node.constraint_node, variables, constraints, objectives)
+end
+function add_unsupported(graph::Graph, node::ConstraintNode,
+                         variables, constraints, objectives)
+    if _dist(graph, node) != INFINITY
+        return
     end
-    debug(b, variable_to_index, constraint_to_index, objective_to_index; kws...)
+    push!(constraints, node)
+    add_unsupported(graph, graph.constraint_edges[node.index], variables, constraints, objectives)
+end
+function add_unsupported(graph::Graph, node::ObjectiveNode,
+                         variables, constraints, objectives)
+    if _dist(graph, node) != INFINITY
+        return
+    end
+    push!(objectives, node)
+    add_unsupported(graph, graph.objective_edges[node.index], variables, constraints, objectives)
+end
+function _sort(nodes::Set)
+    vector = collect(nodes)
+    sort!(vector, by = node -> node.index)
+    return vector
+end
+function debug_unsupported(io::IO, b::LazyBridgeOptimizer, node::AbstractNode)
+    variables = Set{VariableNode}()
+    constraints = Set{ConstraintNode}()
+    objectives = Set{ObjectiveNode}()
+    add_unsupported(b.graph, node, variables, constraints, objectives)
+    print_unsupported(io, b, _sort(variables), _sort(constraints), _sort(objectives))
 end
 function debug(b::LazyBridgeOptimizer, F::Type{<:MOI.AbstractFunction},
                S::Type{<:MOI.AbstractSet}; io::IO = Base.stdout)
@@ -121,13 +149,11 @@ function debug(b::LazyBridgeOptimizer, F::Type{<:MOI.AbstractFunction},
         if F == MOIU.variable_function_type(S)
             MOIU.print_with_acronym(io, "Constrained variables in `$S`")
             println(io, message)
-            required_tuples = required(b, (S,))
-            fill_required!(required_tuples..., b, F, S)
-            debug(b, required_tuples...; io = io)
+            debug_unsupported(io, b, node(b, S))
         else
             MOIU.print_with_acronym(io, "`$F`-in-`$S` constraints")
             println(io, message)
-            debug(b, required(b, (F, S))...; io = io)
+            debug_unsupported(io, b, node(b, F, S))
         end
     end
 end
@@ -145,6 +171,7 @@ function debug_supports_constraint(
     S::Type{<:MOI.AbstractSet}; kws...)
     debug(b, F, S; kws...)
 end
+
 function debug(b::LazyBridgeOptimizer,
                F::Type{<:MOI.AbstractScalarFunction}; io::IO = Base.stdout)
     MOIU.print_with_acronym(io, "Objective function of type `$F` is")
@@ -154,7 +181,7 @@ function debug(b::LazyBridgeOptimizer,
         MOIU.print_with_acronym(io, " not supported and cannot be bridged" *
             " into a supported objective function by adding only supported" *
             " constrained variables and constraints. See details below:\n")
-        debug(b, required(b, (F,))...; io = io)
+        debug_unsupported(io, b, node(b, F))
     end
 end
 

--- a/src/Bridges/graph.jl
+++ b/src/Bridges/graph.jl
@@ -1,0 +1,231 @@
+const INFINITY = -1
+
+abstract type AbstractNode end
+struct ConstraintNode <: AbstractNode
+    index::Int
+end
+struct VariableNode <: AbstractNode
+    index::Int
+    constraint_node::ConstraintNode
+end
+struct ObjectiveNode <: AbstractNode
+    index::Int
+end
+
+abstract type AbstractEdge end
+struct Edge <: AbstractEdge
+    bridge_index::Int
+    added_variables::Vector{VariableNode}
+    added_constraints::Vector{ConstraintNode}
+end
+struct ObjectiveEdge <: AbstractEdge
+    bridge_index::Int
+    added_variables::Vector{VariableNode}
+    added_constraints::Vector{ConstraintNode}
+    added_objective::ObjectiveNode
+end
+
+mutable struct Graph
+    variable_edges::Vector{Vector{Edge}}
+    # variable node index -> Number of bridges that need to be used
+    variable_dist::Vector{Int}
+    # variable node index -> Index of bridge to be used
+    variable_best::Vector{Int}
+    variable_last_correct::Int
+    constraint_edges::Vector{Vector{Edge}}
+    # constraint node index -> Number of bridges that need to be used
+    constraint_dist::Vector{Int}
+    # constraint node index -> Index of bridge to be used
+    constraint_best::Vector{Int}
+    constraint_last_correct::Int
+    objective_edges::Vector{Vector{ObjectiveEdge}}
+    # objective node index -> Number of bridges that need to be used
+    objective_dist::Vector{Int}
+    # objective node index -> Index of bridge to be used
+    objective_best::Vector{Int}
+    objective_last_correct::Int
+end
+function Graph()
+    return Graph(
+        Vector{Edge}[], Int[], Int[], 0,
+        Vector{Edge}[], Int[], Int[], 0,
+        Vector{ObjectiveEdge}[], Int[], Int[], 0,
+    )
+end
+
+# After `add_bridge(b, BT)`, some constrained variables `(S,)` in
+# `keys(b.variable_best)` or constraints `(F, S)` in `keys(b.constraint_best)`
+# or `(F,)` in `keys(b.objective_best)` may be bridged
+# with less bridges than `b.variable_dist[(S,)]`,
+# `b.constraint_dist[(F, S)]` or `b.objective_dist[(F,)]` using `BT`.
+# We could either recompute the distance from every node or clear the
+# dictionary so that the distance is computed lazily at the next `supports_constraint`
+# call. We prefer clearing the dictionaries so as this is called for each
+# bridge added and recomputing the distance for each bridge would be a wase
+# if several bridges are added consecutively.
+function Base.empty!(graph::Graph)
+    empty!(graph.variable_edges)
+    empty!(graph.variable_dist)
+    empty!(graph.variable_best)
+    graph.variable_last_correct = 0
+    empty!(graph.constraint_edges)
+    empty!(graph.constraint_dist)
+    empty!(graph.constraint_best)
+    graph.constraint_last_correct = 0
+    empty!(graph.objective_edges)
+    empty!(graph.objective_dist)
+    empty!(graph.objective_best)
+    graph.objective_last_correct = 0
+end
+
+function add_edge(graph::Graph, node::VariableNode, edge::Edge)
+    push!(graph.variable_edges[node.index], edge)
+end
+function add_edge(graph::Graph, node::ConstraintNode, edge::Edge)
+    push!(graph.constraint_edges[node.index], edge)
+end
+function add_edge(graph::Graph, node::ObjectiveNode, edge::ObjectiveEdge)
+    push!(graph.objective_edges[node.index], edge)
+end
+function add_variable_node(graph::Graph, constraint_node::ConstraintNode)
+    push!(graph.variable_edges, Edge[])
+    push!(graph.variable_dist, INFINITY)
+    push!(graph.variable_best, 0)
+    return VariableNode(length(graph.variable_best), constraint_node)
+end
+function add_constraint_node(graph::Graph)
+    push!(graph.constraint_edges, Edge[])
+    push!(graph.constraint_dist, INFINITY)
+    push!(graph.constraint_best, 0)
+    return ConstraintNode(length(graph.constraint_best))
+end
+function add_objective_node(graph::Graph)
+    push!(graph.objective_edges, ObjectiveEdge[])
+    push!(graph.objective_dist, INFINITY)
+    push!(graph.objective_best, 0)
+    return ObjectiveNode(length(graph.objective_best))
+end
+
+function bridge_index(graph::Graph, node::VariableNode)
+    bellman_ford!(graph)
+    return graph.variable_best[node.index]
+end
+function bridge_index(graph::Graph, node::ConstraintNode)
+    bellman_ford!(graph)
+    return graph.constraint_best[node.index]
+end
+function bridge_index(graph::Graph, node::ObjectiveNode)
+    bellman_ford!(graph)
+    return graph.objective_best[node.index]
+end
+
+# Update `b.variable_dist`, `b.constraint_dist` `b.variable_best` and
+# `b.constraint_best` for constrained variable types in `variables` and
+# constraint types in `constraints`.
+function updated_dist(graph::Graph, current, edges::Vector{<:AbstractEdge})
+    bridge_index = 0
+    for edge in edges
+        if supports_added_no_update(graph, edge)
+            # `added_dist != INFINITY` because `supports_added_no_update`
+            # returned `true`.
+            dist = 1 + added_dist(graph, edge)
+            if current == INFINITY || dist < current
+                current = dist
+                bridge_index = edge.bridge_index
+            end
+        end
+    end
+    return current, bridge_index
+end
+
+function bellman_ford!(graph::Graph)
+    # Bellman-Ford algorithm
+    changed = true # Has b.constraint_dist changed in the last iteration ?
+    while changed
+        changed = false
+        for i in (graph.variable_last_correct + 1):length(graph.variable_best)
+            dist, best = updated_dist(graph, graph.variable_dist[i],
+                                      graph.variable_edges[i])
+            if !iszero(best)
+                graph.variable_dist[i] = dist
+                graph.variable_best[i] = best
+                changed = true
+            end
+        end
+        for i in (graph.constraint_last_correct + 1):length(graph.constraint_best)
+            dist, best = updated_dist(graph, graph.constraint_dist[i],
+                                      graph.constraint_edges[i])
+            if !iszero(best)
+                graph.constraint_dist[i] = dist
+                graph.constraint_best[i] = best
+                changed = true
+            end
+        end
+        for i in (graph.objective_last_correct + 1):length(graph.objective_best)
+            dist, best = updated_dist(graph, graph.objective_dist[i],
+                                      graph.objective_edges[i])
+            if !iszero(best)
+                graph.objective_dist[i] = dist
+                graph.objective_best[i] = best
+                changed = true
+            end
+        end
+    end
+    graph.variable_last_correct = length(graph.variable_best)
+    graph.constraint_last_correct = length(graph.constraint_best)
+    graph.objective_last_correct = length(graph.objective_best)
+    return
+end
+
+function _dist(graph::Graph, node::VariableNode)
+    dc = _dist(graph, node.constraint_node)
+    if iszero(dc)
+        return dc
+    elseif iszero(node.index)
+        return 0
+    else
+        dv = graph.variable_dist[node.index]
+        if dc == INFINITY
+            return dv
+        elseif dv == INFINITY
+            return dc
+        else
+            return min(dv, dc + 1)
+        end
+    end
+end
+function _dist(graph::Graph, node::ConstraintNode)
+    return iszero(node.index) ? 0 : graph.constraint_dist[node.index]
+end
+function _dist(graph::Graph, node::ObjectiveNode)
+    return iszero(node.index) ? 0 : graph.objective_dist[node.index]
+end
+
+function _sum_dist(graph::Graph, nodes::Vector{<:AbstractNode})
+    return mapreduce(node -> _dist(graph, node), +, nodes, init = 0)
+end
+function added_dist(graph::Graph, edge::Edge)
+    return _sum_dist(graph, edge.added_variables) +
+        _sum_dist(graph, edge.added_constraints)
+end
+function added_dist(graph::Graph, edge::ObjectiveEdge)
+    return _sum_dist(graph, edge.added_variables) +
+        _sum_dist(graph, edge.added_constraints) +
+        _dist(graph, edge.added_objective)
+end
+
+function supports_no_update(graph::Graph, node::AbstractNode)
+    return iszero(node.index) || _dist(graph, node) != INFINITY
+end
+function _supports_all_no_update(graph::Graph, nodes::Vector{<:AbstractNode})
+    return all(node -> supports_no_update(graph, node), nodes)
+end
+function supports_added_no_update(graph::Graph, edge::Edge)
+    return _supports_all_no_update(graph, edge.added_variables) &&
+        _supports_all_no_update(graph, edge.added_constraints)
+end
+function supports_added_no_update(graph::Graph, edge::ObjectiveEdge)
+    return _supports_all_no_update(graph, edge.added_variables) &&
+        _supports_all_no_update(graph, edge.added_constraints) &&
+        supports_no_update(graph, edge.added_objective)
+end

--- a/src/Bridges/graph.jl
+++ b/src/Bridges/graph.jl
@@ -1,4 +1,5 @@
 const INFINITY = -1
+const INVALID_NODE_INDEX = -1
 
 abstract type AbstractNode end
 struct VariableNode <: AbstractNode
@@ -114,7 +115,7 @@ function add_variable_node(graph::Graph)
     push!(graph.variable_edges, Edge[])
     # Use an invalid index so that the code errors instead return something
     # incorrect in case `set_variable_constraint_node` is not called.
-    push!(graph.variable_constraint_node, ConstraintNode(-1))
+    push!(graph.variable_constraint_node, ConstraintNode(INVALID_NODE_INDEX))
     push!(graph.variable_constraint_cost, 0)
     push!(graph.variable_dist, INFINITY)
     push!(graph.variable_best, 0)
@@ -154,7 +155,7 @@ end
 # Update `b.variable_dist`, `b.constraint_dist` `b.variable_best` and
 # `b.constraint_best` for constrained variable types in `variables` and
 # constraint types in `constraints`.
-function updated_dist(graph::Graph, current, edges::Vector{<:AbstractEdge})
+function updated_dist(graph::Graph, current::Int, edges::Vector{<:AbstractEdge})
     bridge_index = 0
     for edge in edges
         if supports_added_no_update(graph, edge)
@@ -215,8 +216,8 @@ function _dist(graph::Graph, node::VariableNode)
     end
     constraint_node = graph.variable_constraint_node[node.index]
     # If free variables are bridged but the functionize bridge was not added,
-    # constraint_node is `ConstraintNode(-1)`.
-    dc = constraint_node.index == -1 ? INFINITY : _dist(graph, constraint_node)
+    # constraint_node is `ConstraintNode(INVALID_NODE_INDEX)`.
+    dc = constraint_node.index == INVALID_NODE_INDEX ? INFINITY : _dist(graph, constraint_node)
     if iszero(dc)
         return dc
     end

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -105,10 +105,10 @@ functionized_type(::Nothing) = nothing
 functionized_type(::Type{<:Constraint.ScalarFunctionizeBridge{T}}) where T = MOI.ScalarAffineFunction{T}
 functionized_type(::Type{<:Constraint.VectorFunctionizeBridge{T}}) where T = MOI.VectorAffineFunction{T}
 function functionized_type(b::LazyBridgeOptimizer, ::Type{MOI.SingleVariable})
-    return functionized_type(__functionize_bridge(b.constraint_bridge_types, Constraint.ScalarFunctionizeBridge))
+    return functionized_type(_first_functionize_bridge(b.constraint_bridge_types, Constraint.ScalarFunctionizeBridge))
 end
 function functionized_type(b::LazyBridgeOptimizer, ::Type{MOI.VectorOfVariables})
-    return functionized_type(__functionize_bridge(b.constraint_bridge_types, Constraint.VectorFunctionizeBridge))
+    return functionized_type(_first_functionize_bridge(b.constraint_bridge_types, Constraint.VectorFunctionizeBridge))
 end
 
 function node(b::LazyBridgeOptimizer, S::Type{<:MOI.AbstractSet})
@@ -340,7 +340,7 @@ end
 _func_name(::Type{Constraint.ScalarFunctionizeBridge}) = "SingleVariable", "constraint"
 _func_name(::Type{Constraint.VectorFunctionizeBridge}) = "VectorOfVariables", "constraint"
 _func_name(::Type{Objective.FunctionizeBridge}) = "SingleVariable", "objective"
-function __functionize_bridge(bridge_types, target_type)
+function _first_functionize_bridge(bridge_types, target_type)
     index = findfirst(bridge_type -> bridge_type <: target_type,
                       bridge_types)
     if index === nothing
@@ -349,7 +349,7 @@ function __functionize_bridge(bridge_types, target_type)
     return bridge_types[index]
 end
 function _functionize_bridge(bridge_types, target_type)
-    bridge_type = __functionize_bridge(bridge_types, target_type)
+    bridge_type = _first_functionize_bridge(bridge_types, target_type)
     if bridge_type === nothing
         func, name = _func_name(target_type)
         error("Need to apply a `$target_type` to a",

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -126,10 +126,16 @@ function node(b::LazyBridgeOptimizer, S::Type{<:MOI.AbstractSet})
     if is_bridged(b, MOI.Reals)
         FF = functionized_type(b, F)
         if FF !== nothing
-            set_variable_constraint_node(b.graph, variable_node, node(b, FF, S))
+            # We assume the distance of the variable node `MOI.Reals` is `1`,
+            # i.e. it is bridged by `Variable.FreeBridge` and then
+            # the distance of `MOI.Nonnegatives` is zero.
+            # We also use the functionize bridge which has cost 1.
+            # And we add `+1` as we treat constrained variables as constraints.
+            set_variable_constraint_node(b.graph, variable_node, node(b, FF, S), 3)
         end
     else
-        set_variable_constraint_node(b.graph, variable_node, node(b, F, S))
+        # We add `+1` as we treat constrained variables as constraints.
+        set_variable_constraint_node(b.graph, variable_node, node(b, F, S), 1)
     end
     for (i, BT) in enumerate(b.variable_bridge_types)
         if Variable.supports_constrained_variable(BT, S)

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -377,12 +377,12 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
   Cannot use `MOIB.Variable.VectorizeBridge{$T,MOI.Nonpositives}` because:
   [2] constrained variables in `MOI.Nonpositives` are not supported
   Cannot add free variables and then constrain them because:
-  (2) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
+  (1) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
 [2] constrained variables in `MOI.Nonpositives` are not supported because no added bridge supports bridging it.
   Cannot add free variables and then constrain them because:
-  (1) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported
-(1) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported because no added bridge supports bridging it.
-(2) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
+  (2) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported
+(1) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
+(2) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported because no added bridge supports bridging it.
 """
         MOIB.add_bridge(bridged, MOIB.Variable.NonposToNonnegBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == "Constrained variables in `MOI.LessThan{$T}` are supported.\n"
@@ -439,32 +439,32 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
         MOIB.add_bridge(bridged, MOIB.Variable.VectorizeBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == """
 `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported and cannot be bridged into supported constrained variables and constraints. See details below:
-[1] constrained variables in `MOI.LessThan{$T}` are not supported because:
+[2] constrained variables in `MOI.LessThan{$T}` are not supported because:
   Cannot use `MOIB.Variable.VectorizeBridge{$T,MOI.Nonpositives}` because:
-  [2] constrained variables in `MOI.Nonpositives` are not supported
+  [3] constrained variables in `MOI.Nonpositives` are not supported
   Cannot add free variables and then constrain them because:
-  (4) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
-[2] constrained variables in `MOI.Nonpositives` are not supported because no added bridge supports bridging it.
+  (5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
+[3] constrained variables in `MOI.Nonpositives` are not supported because no added bridge supports bridging it.
   Cannot add free variables and then constrain them because:
-  (3) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported
-[3] constrained variables in `MOI.Interval{$T}` are not supported because no added bridge supports bridging it.
+  (6) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported
+[4] constrained variables in `MOI.Interval{$T}` are not supported because no added bridge supports bridging it.
   Cannot add free variables and then constrain them because:
-  (5) `MOI.SingleVariable`-in-`MOI.Interval{$T}` constraints are not supported
+  (7) `MOI.SingleVariable`-in-`MOI.Interval{$T}` constraints are not supported
 (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T}}` because:
-  (2) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
+  (4) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.Interval{$T}}` because:
-  [3] constrained variables in `MOI.Interval{$T}` are not supported
-(2) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
+  [4] constrained variables in `MOI.Interval{$T}` are not supported
+(3) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported because no added bridge supports bridging it.
+(4) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.LessThan{$T}}` because:
-  [1] constrained variables in `MOI.LessThan{$T}` are not supported
-(3) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported because no added bridge supports bridging it.
-(4) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
-(5) `MOI.SingleVariable`-in-`MOI.Interval{$T}` constraints are not supported because:
+  [2] constrained variables in `MOI.LessThan{$T}` are not supported
+(5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
+(6) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported because no added bridge supports bridging it.
+(7) `MOI.SingleVariable`-in-`MOI.Interval{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.SingleVariable}` because:
-  (6) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported
-  (4) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
-(6) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported because no added bridge supports bridging it.
+  (3) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported
+  (5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
 """
         MOIB.add_bridge(bridged, MOIB.Variable.NonposToNonnegBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == "`MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are supported.\n"
@@ -537,15 +537,15 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
   (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
 (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported because:
   Cannot use `MOIB.Constraint.VectorSlackBridge{$T,MOI.VectorAffineFunction{$T},MOI.RotatedSecondOrderCone}` because:
-  (3) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported
-(3) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported because no added bridge supports bridging it.
-(4) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
+  (5) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported
+(5) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported because no added bridge supports bridging it.
+(6) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.QuadtoSOCBridge{$T}` because:
   (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
 |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported because:
   Cannot use `MOIB.Objective.SlackBridge{$T,MOI.ScalarQuadraticFunction{$T},MOI.ScalarQuadraticFunction{$T}}` because:
   (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
-  (4) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
+  (6) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
 """
         MOIB.add_bridge(bridged, MOIB.Constraint.ScalarizeBridge{T})
         @test debug_string(MOIB.debug_supports, attr) == "Objective function of type `MOI.ScalarQuadraticFunction{$T}` is supported.\n"
@@ -848,8 +848,7 @@ end
         MOI.RotatedSecondOrderCone) == MOIB.Constraint.RSOCtoPSDBridge{
             Float64, MOI.VectorAffineFunction{Float64}, MOI.VectorOfVariables}
     @test MOIB.bridge(bridged_mock, c) isa MOIB.Constraint.RSOCtoPSDBridge
-    @test bridged_mock.constraint_dist[(MOI.VectorOfVariables,
-                                        MOI.RotatedSecondOrderCone)] == 1
+    @test bridged_mock.graph.constraint_dist[MOI.Bridges.node(bridged_mock, MOI.VectorOfVariables, MOI.RotatedSecondOrderCone).index] == 1
 end
 
 @testset "Supports" begin

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -366,9 +366,7 @@ end
         @test debug_string(MOIB.debug_supports_constraint, F, S) == """
 Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be bridged into supported constrained variables and constraints. See details below:
 [1] constrained variables in `MOI.LessThan{$T}` are not supported because no added bridge supports bridging it.
-  Cannot add free variables and then constrain them because:
-  (1) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
-(1) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 """
         MOIB.add_bridge(bridged, MOIB.Variable.VectorizeBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == """
@@ -376,13 +374,9 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
 [1] constrained variables in `MOI.LessThan{$T}` are not supported because:
   Cannot use `MOIB.Variable.VectorizeBridge{$T,MOI.Nonpositives}` because:
   [2] constrained variables in `MOI.Nonpositives` are not supported
-  Cannot add free variables and then constrain them because:
-  (1) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 [2] constrained variables in `MOI.Nonpositives` are not supported because no added bridge supports bridging it.
-  Cannot add free variables and then constrain them because:
-  (2) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported
-(1) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
-(2) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported because no added bridge supports bridging it.
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 """
         MOIB.add_bridge(bridged, MOIB.Variable.NonposToNonnegBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == "Constrained variables in `MOI.LessThan{$T}` are supported.\n"
@@ -409,32 +403,23 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
         @test debug_string(MOIB.debug_supports_constraint, F, S) == """
 `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported and cannot be bridged into supported constrained variables and constraints. See details below:
 [1] constrained variables in `MOI.GreaterThan{$T}` are not supported because no added bridge supports bridging it.
-  Cannot add free variables and then constrain them because:
-  (3) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 [2] constrained variables in `MOI.LessThan{$T}` are not supported because no added bridge supports bridging it.
-  Cannot add free variables and then constrain them because:
-  (5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 [3] constrained variables in `MOI.Interval{$T}` are not supported because no added bridge supports bridging it.
-  Cannot add free variables and then constrain them because:
-  (6) `MOI.SingleVariable`-in-`MOI.Interval{$T}` constraints are not supported
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T}}` because:
   (2) `MOI.ScalarAffineFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
-  (4) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
+  (3) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.Interval{$T}}` because:
   [3] constrained variables in `MOI.Interval{$T}` are not supported
 (2) `MOI.ScalarAffineFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.GreaterThan{$T}}` because:
   [1] constrained variables in `MOI.GreaterThan{$T}` are not supported
-(3) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported because no added bridge supports bridging it.
-(4) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
+(3) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.LessThan{$T}}` because:
   [2] constrained variables in `MOI.LessThan{$T}` are not supported
-(5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
-(6) `MOI.SingleVariable`-in-`MOI.Interval{$T}` constraints are not supported because:
-  Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.SingleVariable}` because:
-  (3) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported
-  (5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
 """
         MOIB.add_bridge(bridged, MOIB.Variable.VectorizeBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == """
@@ -442,29 +427,19 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
 [2] constrained variables in `MOI.LessThan{$T}` are not supported because:
   Cannot use `MOIB.Variable.VectorizeBridge{$T,MOI.Nonpositives}` because:
   [3] constrained variables in `MOI.Nonpositives` are not supported
-  Cannot add free variables and then constrain them because:
-  (5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 [3] constrained variables in `MOI.Nonpositives` are not supported because no added bridge supports bridging it.
-  Cannot add free variables and then constrain them because:
-  (6) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 [4] constrained variables in `MOI.Interval{$T}` are not supported because no added bridge supports bridging it.
-  Cannot add free variables and then constrain them because:
-  (7) `MOI.SingleVariable`-in-`MOI.Interval{$T}` constraints are not supported
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T}}` because:
-  (4) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
+  (3) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.Interval{$T}}` because:
   [4] constrained variables in `MOI.Interval{$T}` are not supported
-(3) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported because no added bridge supports bridging it.
-(4) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
+(3) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.LessThan{$T}}` because:
   [2] constrained variables in `MOI.LessThan{$T}` are not supported
-(5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
-(6) `MOI.VectorOfVariables`-in-`MOI.Nonpositives` constraints are not supported because no added bridge supports bridging it.
-(7) `MOI.SingleVariable`-in-`MOI.Interval{$T}` constraints are not supported because:
-  Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.SingleVariable}` because:
-  (3) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are not supported
-  (5) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
 """
         MOIB.add_bridge(bridged, MOIB.Variable.NonposToNonnegBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == "`MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are supported.\n"
@@ -509,24 +484,22 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
         @test debug_string(MOIB.debug_supports, attr) == """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
 [1] constrained variables in `MOI.RotatedSecondOrderCone` are not supported because no added bridge supports bridging it.
-  Cannot add free variables and then constrain them because:
-  (3) `MOI.VectorOfVariables`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
+  Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.QuadtoSOCBridge{$T}` because:
   (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
 (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported because:
   Cannot use `MOIB.Constraint.VectorSlackBridge{$T,MOI.VectorAffineFunction{$T},MOI.RotatedSecondOrderCone}` because:
   [1] constrained variables in `MOI.RotatedSecondOrderCone` are not supported
-  (4) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported
-(3) `MOI.VectorOfVariables`-in-`MOI.RotatedSecondOrderCone` constraints are not supported because no added bridge supports bridging it.
-(4) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported because no added bridge supports bridging it.
-(5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
+  (3) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported
+(3) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported because no added bridge supports bridging it.
+(4) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.QuadtoSOCBridge{$T}` because:
   (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
 |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported because:
   Cannot use `MOIB.Objective.SlackBridge{$T,MOI.ScalarQuadraticFunction{$T},MOI.ScalarQuadraticFunction{$T}}` because:
   (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
-  (5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
+  (4) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
 """
         MOIB.add_bridge(bridged, MOIB.Variable.RSOCtoPSDBridge{T})
         MOIB.add_bridge(bridged, MOIB.Constraint.ScalarFunctionizeBridge{T})
@@ -537,15 +510,15 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
   (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
 (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported because:
   Cannot use `MOIB.Constraint.VectorSlackBridge{$T,MOI.VectorAffineFunction{$T},MOI.RotatedSecondOrderCone}` because:
-  (5) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported
-(5) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported because no added bridge supports bridging it.
-(6) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
+  (4) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported
+(4) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported because no added bridge supports bridging it.
+(5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
   Cannot use `MOIB.Constraint.QuadtoSOCBridge{$T}` because:
   (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
 |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported because:
   Cannot use `MOIB.Objective.SlackBridge{$T,MOI.ScalarQuadraticFunction{$T},MOI.ScalarQuadraticFunction{$T}}` because:
   (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
-  (6) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
+  (5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
 """
         MOIB.add_bridge(bridged, MOIB.Constraint.ScalarizeBridge{T})
         @test debug_string(MOIB.debug_supports, attr) == "Objective function of type `MOI.ScalarQuadraticFunction{$T}` is supported.\n"
@@ -569,8 +542,9 @@ end
 @testset "Continuous Conic with SDPAModel{Float64}" begin
     model = SDPAModel{Float64}()
     bridged = MOIB.full_bridge_optimizer(model, Float64)
-    exclude = ["exp", "dualexp", "pow", "dualpow", "logdet", "rootdets"]
-    MOIT.contconictest(bridged, MOIT.TestConfig(solve=false), exclude)
+    MOIT.psds0vtest(bridged, MOIT.TestConfig(solve=false))
+    #exclude = ["exp", "dualexp", "pow", "dualpow", "logdet", "rootdets"]
+    #MOIT.contconictest(bridged, MOIT.TestConfig(solve=false), exclude)
 end
 
 # Model not supporting RotatedSecondOrderCone


### PR DESCRIPTION
Most of the time spent in the bridge shortest path algorithm is due to the type instability of bridge types accessed from the vector of bridges added to the `LazyBridgeOptimizer`.
Indeed, we then need to call `supports_constraint`, `concrete_bridge_type` and `added_...` to the bridge type and the method lookup needs to be done at runtime because the bridge type is not known at compile time.
In this PR, the subpart of the bridge graph is constructed so that the Bellman-Ford algorithm is run on a fully type-stable graph structure.
The graph is built lazily when `node` is called for new types.
Of course, the type instability still affects the `node` functions but once the graph is build, the time to run Bellman-Ford is negligible.
Running the `perf/bellman_ford.jl` benchmark gives which shows that solving the shortest path problem takes a negligible time compared to building the graph:
```
BenchmarkTools.Trial: 
  memory estimate:  10.39 KiB
  allocs estimate:  194
  --------------
  minimum time:     237.782 μs (0.00% GC)
  median time:      313.253 μs (0.00% GC)
  mean time:        386.994 μs (2.17% GC)
  maximum time:     54.999 ms (99.18% GC)
  --------------
  samples:          10000
  evals/sample:     1
BenchmarkTools.Trial: 
  memory estimate:  11.80 KiB
  allocs estimate:  284
  --------------
  minimum time:     239.733 μs (0.00% GC)
  median time:      311.878 μs (0.00% GC)
  mean time:        385.405 μs (2.63% GC)
  maximum time:     72.794 ms (99.43% GC)
  --------------
  samples:          10000
  evals/sample:     1
BenchmarkTools.Trial: 
  memory estimate:  25.72 KiB
  allocs estimate:  479
  --------------
  minimum time:     1.614 ms (0.00% GC)
  median time:      1.789 ms (0.00% GC)
  mean time:        2.268 ms (1.41% GC)
  maximum time:     52.869 ms (95.84% GC)
  --------------
  samples:          2200
  evals/sample:     1
BenchmarkTools.Trial: 
  memory estimate:  29.16 KiB
  allocs estimate:  699
  --------------
  minimum time:     1.617 ms (0.00% GC)
  median time:      1.784 ms (0.00% GC)
  mean time:        2.035 ms (1.34% GC)
  maximum time:     50.862 ms (95.61% GC)
  --------------
  samples:          2453
  evals/sample:     1
```
In comparison, the benchmark result was previously (see https://github.com/JuliaOpt/MathOptInterface.jl/pull/945):
```
BenchmarkTools.Trial: 
  memory estimate:  68.59 KiB
  allocs estimate:  1861
  --------------
  minimum time:     3.819 ms (0.00% GC)
  median time:      5.165 ms (0.00% GC)
  mean time:        5.701 ms (2.53% GC)
  maximum time:     110.109 ms (91.74% GC)
  --------------
  samples:          875
  evals/sample:     1
BenchmarkTools.Trial: 
  memory estimate:  163.96 KiB
  allocs estimate:  4440
  --------------
  minimum time:     23.947 ms (0.00% GC)
  median time:      32.318 ms (0.00% GC)
  mean time:        32.113 ms (0.80% GC)
  maximum time:     83.834 ms (47.83% GC)
  --------------
  samples:          156
  evals/sample:     1
```
This gives almost a 20x speedup !