### PR TITLE
Callbacks are model attributes

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -622,7 +622,7 @@ end
 """
     abstract type AbstractCallback <: AbstractModelAttribute end
 
-Abstract type for optimizer attribute representing a callback function. The
+Abstract type for a model attribute representing a callback function. The
 value set to subtypes of `AbstractCallback` is a function that may be called
 during [`optimize!`](@ref). As [`optimize!`](@ref) is in progress, the result
 attributes (i.e, the attributes `attr` such that `is_set_by_optimize(attr)`)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -620,7 +620,7 @@ function Base.showerror(io::IO, err::OptimizeInProgress)
 end
 
 """
-    abstract type AbstractCallback <: AbstractOptimizerAttribute end
+    abstract type AbstractCallback <: AbstractModelAttribute end
 
 Abstract type for optimizer attribute representing a callback function. The
 value set to subtypes of `AbstractCallback` is a function that may be called
@@ -638,7 +638,7 @@ commonly called `callback_data`, that can be used for instance in
 [`LazyConstraintCallback`](@ref), [`HeuristicCallback`](@ref) and
 [`UserCutCallback`](@ref).
 """
-abstract type AbstractCallback <: AbstractOptimizerAttribute end
+abstract type AbstractCallback <: AbstractModelAttribute end
 
 """
     LazyConstraintCallback() <: AbstractCallback


### PR DESCRIPTION
As mentioned in the docstrings:
https://github.com/JuliaOpt/MathOptInterface.jl/blob/fa4e026106a8909bd37d6a2e2e3e9fecf4534b5a/src/MathOptInterface.jl#L61-L74
https://github.com/JuliaOpt/MathOptInterface.jl/blob/fa4e026106a8909bd37d6a2e2e3e9fecf4534b5a/src/attributes.jl#L10-L12
The difference between model and optimizer attributes is that model attributes are discarded at `MOI.empty!` and are not copied at `MOI.copy_to`.

This should resolve the issue of callbacks not working in non-direct mode with JuMP. The issue was that GLPK discarded the callback in `MOI.empty!` but then did not receive it again in `MOI.copy_to`.

This does not closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/958 as we should clarify in the docstring of `MOI.copy_to` that optimizer attributes are not copied.