### PR TITLE
fix tiny typo in geomean bridge docs

### DIFF
--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -32,7 +32,7 @@ Now, this is equivalent to
 \\begin{align*}
   t & \\le x_{21}/\\sqrt{4},\\\\
   x_{21}^2 & \\le 2x_{11} x_{12},\\\\
-  x_{11}^2 & \\le 2x_1 x_2, & x_{21}^2 & \\le 2x_3(x_{21}/\\sqrt{4}).
+  x_{11}^2 & \\le 2x_1 x_2, & x_{12}^2 & \\le 2x_3(x_{21}/\\sqrt{4}).
 \\end{align*}
 ```
 


### PR DESCRIPTION
I am guessing one of the `x_{21}`s in the final constraint in the description of the geomean bridge supposed to be `x_{12}`?