### PR TITLE
fix incorrect increment in geomean bridge

### DIFF
--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -159,18 +159,17 @@ function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintFunction,
     d = bridge.d
     n = d - 1
     l = ilog2(n)
-    offset = offset_next = 0
-    for i in 1:l
-        offset_next = offset + i
-        for j in 1:(1 << (i-1))
-            if i == l && 2j <= bridge.d
-                func = MOI.get(model, attr, bridge.socrc[offset + j])
-                func_scalars = MOIU.eachscalar(func)
-                f_scalars[2j] = func_scalars[1]
+    num_lvars = 1 << (l - 1)
+    offset = num_lvars - 1
+    for j in 1:num_lvars
+        if 2j <= bridge.d
+            func = MOI.get(model, attr, bridge.socrc[offset + j])
+            func_scalars = MOIU.eachscalar(func)
+            f_scalars[2j] = func_scalars[1]
+            if 2j + 1 <= bridge.d
                 f_scalars[2j + 1] = func_scalars[2]
             end
         end
-        offset = offset_next
     end
     return MOIU.vectorize(f_scalars)
 end

--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -54,7 +54,7 @@ function bridge_constraint(::Type{GeoMeanBridge{T, F, G, H}}, model,
     n = d - 1
     l = ilog2(n)
     N = 1 << l
-    xij = MOI.add_variables(model, N-1)
+    xij = MOI.add_variables(model, N - 1)
     f_scalars = MOIU.eachscalar(f)
 
     xl1 = MOI.SingleVariable(xij[1])
@@ -77,8 +77,9 @@ function bridge_constraint(::Type{GeoMeanBridge{T, F, G, H}}, model,
     socrc = Vector{CI{G, MOI.RotatedSecondOrderCone}}(undef, N - 1)
     offset = offset_next = 0
     for i in 1:l
-        offset_next = offset + i
-        for j in 1:(1 << (i - 1))
+        num_lvars = 1 << (i - 1)
+        offset_next = offset + num_lvars
+        for j in 1:num_lvars
             if i == l
                 a = _getx(2j - 1)
                 b = _getx(2j)

--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -94,6 +94,7 @@ function bridge_constraint(::Type{GeoMeanBridge{T, F, G, H}}, model,
         end
         offset = offset_next
     end
+    @assert offset == length(socrc)
     return GeoMeanBridge{T, F, G, H}(d, xij, tubc, socrc)
 end
 

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1312,7 +1312,7 @@ function _geomean2test(model::MOI.ModelLike, config::TestConfig, vecofvars)
 
     cx = Vector{MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}}}(undef, n)
     for i in 1:n
-        cx[i] = MOI.add_constraint(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x[i])], 0.0), MOI.EqualTo(Float64(i)))
+        cx[i] = MOI.add_constraint(model, MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x[i])], 0.0), MOI.EqualTo(1.0))
     end
 
     @test MOI.get(model, MOI.NumberOfConstraints{vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()) == 1

--- a/test/Bridges/Constraint/geomean.jl
+++ b/test/Bridges/Constraint/geomean.jl
@@ -24,14 +24,57 @@ config = MOIT.TestConfig()
     mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [ones(4); 2; √2; √2])
     MOIT.geomean1vtest(bridged_mock, config)
     MOIT.geomean1ftest(bridged_mock, config)
+
+    @testset "Test mock model" begin
+        var_names = ["t", "x", "y", "z", "x21", "x11", "x12"]
+        MOI.set(mock, MOI.VariableName(), MOI.get(mock, MOI.ListOfVariableIndices()), var_names)
+        lessthan = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+        @test length(lessthan) == 2
+        # TODO is it OK to assume this order?
+        MOI.set.(mock, MOI.ConstraintName(), lessthan, ["lessthan1", "lessthan2"])
+        rsoc = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}())
+        @test length(rsoc) == 3
+        MOI.set.(mock, MOI.ConstraintName(), rsoc, ["rsoc21", "rsoc11", "rsoc12"])
+
+        # TODO do we need explicit nonnegativity on x11, x12, x21 ?
+        s = """
+        variables: t, x, y, z, x11, x12, x21
+        lessthan1: t + -0.5 * x21 in MathOptInterface.LessThan(0.0)
+        lessthan2: x + y + z in MathOptInterface.LessThan(3.0)
+        rsoc11: [1.0x, y, x11] in MathOptInterface.RotatedSecondOrderCone(3)
+        rsoc12: [z, 0.5 * x21, x12] in MathOptInterface.RotatedSecondOrderCone(3)
+        rsoc21: [1.0x11, x12, x21] in MathOptInterface.RotatedSecondOrderCone(3)
+        maxobjective: t
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(mock, model, var_names, ["lessthan1", "lessthan2", "rsoc11", "rsoc12", "rsoc21"])
+    end
+
+    @testset "Test bridged model" begin
+        var_names = ["t", "x", "y", "z"]
+        MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+        lessthan = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+        @test length(lessthan) == 1
+        MOI.set(bridged_mock, MOI.ConstraintName(), lessthan[1], "lessthan")
+        geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
+        @test length(geomean) == 1
+        MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
+
+        s = """
+        variables: t, x, y, z
+        lessthan: x + y + z in MathOptInterface.LessThan(3.0)
+        geomean: [1.0t, x, y, z] in MathOptInterface.GeometricMeanCone(4)
+        maxobjective: t
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(bridged_mock, model, var_names, ["lessthan", "geomean"])
+    end
+
     # Dual is not yet implemented for GeoMean bridge
     ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
     test_delete_bridge(bridged_mock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
                                             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 1)))
-
-    vals = zeros(15) # TODO how are these used?
-    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, vcat(ones(10), vals))
-    MOIT.geomean2vtest(bridged_mock, config)
-    MOIT.geomean2ftest(bridged_mock, config)
 
 end

--- a/test/Bridges/Constraint/geomean.jl
+++ b/test/Bridges/Constraint/geomean.jl
@@ -27,5 +27,11 @@ config = MOIT.TestConfig()
     # Dual is not yet implemented for GeoMean bridge
     ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
     test_delete_bridge(bridged_mock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
-                                            (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64},      1)))
+                                            (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 1)))
+
+    vals = zeros(15) # TODO how are these used?
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, vcat(ones(10), vals))
+    MOIT.geomean2vtest(bridged_mock, config)
+    MOIT.geomean2ftest(bridged_mock, config)
+
 end

--- a/test/Bridges/Constraint/geomean.jl
+++ b/test/Bridges/Constraint/geomean.jl
@@ -21,60 +21,131 @@ config = MOIT.TestConfig()
                              MOI.VectorQuadraticFunction{Float64}]
                    for S in [MOI.GeometricMeanCone]])
 
-    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [ones(4); 2; √2; √2])
-    MOIT.geomean1vtest(bridged_mock, config)
-    MOIT.geomean1ftest(bridged_mock, config)
+    @testset "geomean1test" begin
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [ones(4); 2; √2; √2])
+        MOIT.geomean1vtest(bridged_mock, config)
+        MOIT.geomean1ftest(bridged_mock, config)
 
-    @testset "Test mock model" begin
-        var_names = ["t", "x", "y", "z", "x21", "x11", "x12"]
-        MOI.set(mock, MOI.VariableName(), MOI.get(mock, MOI.ListOfVariableIndices()), var_names)
-        lessthan = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
-        @test length(lessthan) == 2
-        # TODO is it OK to assume this order?
-        MOI.set.(mock, MOI.ConstraintName(), lessthan, ["lessthan1", "lessthan2"])
-        rsoc = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}())
-        @test length(rsoc) == 3
-        MOI.set.(mock, MOI.ConstraintName(), rsoc, ["rsoc21", "rsoc11", "rsoc12"])
+        @testset "Test mock model" begin
+            var_names = ["t", "x", "y", "z", "x21", "x11", "x12"]
+            MOI.set(mock, MOI.VariableName(), MOI.get(mock, MOI.ListOfVariableIndices()), var_names)
+            lessthan = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+            @test length(lessthan) == 2
+            # TODO is it OK to assume this order?
+            MOI.set.(mock, MOI.ConstraintName(), lessthan, ["lessthan1", "lessthan2"])
+            rsoc = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}())
+            @test length(rsoc) == 3
+            MOI.set.(mock, MOI.ConstraintName(), rsoc, ["rsoc21", "rsoc11", "rsoc12"])
 
-        # TODO do we need explicit nonnegativity on x11, x12, x21 ?
-        s = """
-        variables: t, x, y, z, x11, x12, x21
-        lessthan1: t + -0.5 * x21 in MathOptInterface.LessThan(0.0)
-        lessthan2: x + y + z in MathOptInterface.LessThan(3.0)
-        rsoc11: [1.0x, y, x11] in MathOptInterface.RotatedSecondOrderCone(3)
-        rsoc12: [z, 0.5 * x21, x12] in MathOptInterface.RotatedSecondOrderCone(3)
-        rsoc21: [1.0x11, x12, x21] in MathOptInterface.RotatedSecondOrderCone(3)
-        maxobjective: t
-        """
-        model = MOIU.Model{Float64}()
-        MOIU.loadfromstring!(model, s)
-        MOIU.test_models_equal(mock, model, var_names, ["lessthan1", "lessthan2", "rsoc11", "rsoc12", "rsoc21"])
+            # TODO do we need explicit nonnegativity on x11, x12, x21 ?
+            s = """
+            variables: t, x, y, z, x11, x12, x21
+            lessthan1: t + -0.5 * x21 in MathOptInterface.LessThan(0.0)
+            lessthan2: x + y + z in MathOptInterface.LessThan(3.0)
+            rsoc11: [1.0x, y, x11] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc12: [z, 0.5 * x21, x12] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc21: [1.0x11, x12, x21] in MathOptInterface.RotatedSecondOrderCone(3)
+            maxobjective: t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(mock, model, var_names, ["lessthan1", "lessthan2", "rsoc11", "rsoc12", "rsoc21"])
+        end
+
+        @testset "Test bridged model" begin
+            var_names = ["t", "x", "y", "z"]
+            MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+            lessthan = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+            @test length(lessthan) == 1
+            MOI.set(bridged_mock, MOI.ConstraintName(), lessthan[1], "lessthan")
+            geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
+            @test length(geomean) == 1
+            MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
+
+            s = """
+            variables: t, x, y, z
+            lessthan: x + y + z in MathOptInterface.LessThan(3.0)
+            geomean: [1.0t, x, y, z] in MathOptInterface.GeometricMeanCone(4)
+            maxobjective: t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(bridged_mock, model, var_names, ["lessthan", "geomean"])
+        end
+
+        # Dual is not yet implemented for GeoMean bridge
+        ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
+        test_delete_bridge(bridged_mock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
+                                                (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 1)))
     end
 
-    @testset "Test bridged model" begin
-        var_names = ["t", "x", "y", "z"]
-        MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
-        lessthan = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
-        @test length(lessthan) == 1
-        MOI.set(bridged_mock, MOI.ConstraintName(), lessthan[1], "lessthan")
-        geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
-        @test length(geomean) == 1
-        MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
+    @testset "geomean2test" begin
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [ones(10); zeros(15)])
+        MOIT.geomean2vtest(bridged_mock, config)
+        MOIT.geomean2ftest(bridged_mock, config)
 
-        s = """
-        variables: t, x, y, z
-        lessthan: x + y + z in MathOptInterface.LessThan(3.0)
-        geomean: [1.0t, x, y, z] in MathOptInterface.GeometricMeanCone(4)
-        maxobjective: t
-        """
-        model = MOIU.Model{Float64}()
-        MOIU.loadfromstring!(model, s)
-        MOIU.test_models_equal(bridged_mock, model, var_names, ["lessthan", "geomean"])
+        @testset "Test mock model" begin
+            x_names = ["x$(i)" for i in 1:9]
+            l1_names = ["x1$(i)" for i in 1:8]
+            l2_names = ["x2$(i)" for i in 1:4]
+            l3_names = ["x3$(i)" for i in 1:2]
+            var_names = vcat("t", x_names, "x41", l3_names, l2_names, l1_names)
+            MOI.set(mock, MOI.VariableName(), MOI.get(mock, MOI.ListOfVariableIndices()), var_names)
+            lessthan = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+            @test length(lessthan) == 1
+            MOI.set(mock, MOI.ConstraintName(), lessthan[1], "lessthan")
+            rsoc = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone}())
+            @test length(rsoc) == 15
+            rsoc_names = vcat("rsoc41", ["rsoc3$(i)" for i in 1:2], ["rsoc2$(i)" for i in 1:4], ["rsoc1$(i)" for i in 1:8])
+            MOI.set.(mock, MOI.ConstraintName(), rsoc, rsoc_names)
+
+            varnames_str = vcat("t", [", " * v for v in var_names[2:end]])
+            s = """
+            variables: $(varnames_str...)
+            lessthan: t + -0.25 * x41 in MathOptInterface.LessThan(0.0)
+            rsoc41: [1.0x31, x32, x41] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc31: [1.0x21, x22, x31] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc32: [1.0x23, x24, x32] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc21: [1.0x11, x12, x21] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc22: [1.0x13, x14, x22] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc23: [1.0x15, x16, x23] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc24: [1.0x17, x18, x24] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc11: [1.0x1, x2, x11] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc12: [1.0x3, x4, x12] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc13: [1.0x5, x6, x13] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc14: [1.0x7, x8, x14] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc15: [1.0x9, 0.25 * x41, x15] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc16: [0.25 * x41, 0.25 * x41, x16] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc17: [0.25 * x41, 0.25 * x41, x17] in MathOptInterface.RotatedSecondOrderCone(3)
+            rsoc18: [0.25 * x41, 0.25 * x41, x18] in MathOptInterface.RotatedSecondOrderCone(3)
+            maxobjective: t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(mock, model, var_names, vcat("lessthan", rsoc_names))
+        end
+
+        @testset "Test bridged model" begin
+            var_names = vcat("t", ["x$(i)" for i in 1:9])
+            MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+            geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
+            @test length(geomean) == 1
+            MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
+
+            s = """
+            variables: t, x1, x2, x3, x4, x5, x6, x7, x8, x9
+            geomean: [1.0t, x1, x2, x3, x4, x5, x6, x7, x8, x9] in MathOptInterface.GeometricMeanCone(10)
+            maxobjective: t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(bridged_mock, model, var_names, ["geomean"])
+        end
+
+        # Dual is not yet implemented for GeoMean bridge
+        ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
+        test_delete_bridge(bridged_mock, ci, 10, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
+                                                (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 0)))
     end
-
-    # Dual is not yet implemented for GeoMean bridge
-    ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
-    test_delete_bridge(bridged_mock, ci, 4, ((MOI.VectorAffineFunction{Float64}, MOI.RotatedSecondOrderCone, 0),
-                                            (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 1)))
 
 end

--- a/test/Test/contconic.jl
+++ b/test/Test/contconic.jl
@@ -101,7 +101,13 @@ end
 end
 @testset "GeoMean" begin
     mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, ones(4))
-    MOIT.geomeantest(mock, config)
+    MOIT.geomean1vtest(mock, config)
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, ones(4))
+    MOIT.geomean1ftest(mock, config)
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, ones(10))
+    MOIT.geomean2vtest(mock, config)
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, ones(10))
+    MOIT.geomean2ftest(mock, config)
 end
 @testset "Exponential" begin
     mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1., 2., 2exp(1/2)],


### PR DESCRIPTION
On MOI master I get:
```julia
using JuMP
using MosekTools

n = 9
v = collect(1:n)

model = Model(with_optimizer(Mosek.Optimizer))
@variable(model, t)
@objective(model, Max, t)
@constraint(model, vcat(t, v) in MOI.GeometricMeanCone(n + 1))
optimize!(model)
objective_value(model)
prod(v)^(1 / n)

julia> objective_value(model)
2.6771584679712452

julia> prod(v)^(1 / n)
4.147166274396913
```

A test problem needs more than eight variables in the geomean to trigger this. 