### PR TITLE
Faster deletion of vector of variables

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -962,6 +962,7 @@ The following utilities are available for functions:
 Utilities.eval_variables
 Utilities.map_indices
 Utilities.substitute_variables
+Utilities.filter_variables
 Utilities.remove_variable
 Utilities.all_coefficients
 Utilities.unsafe_add

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -663,6 +663,11 @@ Return a new function `f` with the variable vi removed.
 function remove_variable(f::MOI.AbstractFunction, vi::MOI.VariableIndex)
     return filter_variables(v -> v != vi, f)
 end
+function remove_variable(f::MOI.AbstractFunction, vis::Vector{MOI.VariableIndex})
+    # Create a `Set` to test membership in `vis` in O(1).
+    set = Set(vis)
+    return filter_variables(vi -> !(vi in set), f)
+end
 
 """
     modify_function(f::AbstractFunction, change::AbstractFunctionModification)

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -618,14 +618,41 @@ function test_models_equal(model1::MOI.ModelLike, model2::MOI.ModelLike, variabl
 end
 
 
-_hasvar(v::VI, vi::Vector{VI}) = v in vi
-_hasvar(v::VI, vi::VI) = v == vi
-_hasvar(t::MOI.ScalarAffineTerm, vi) = _hasvar(t.variable_index, vi)
-_hasvar(t::MOI.ScalarQuadraticTerm, vi) = _hasvar(t.variable_index_1, vi) || _hasvar(t.variable_index_2, vi)
-_hasvar(t::Union{MOI.VectorAffineTerm, MOI.VectorQuadraticTerm}, vi) = _hasvar(t.scalar_term, vi)
+_keep_all(keep::Function, v::MOI.VariableIndex) = keep(v)
+_keep_all(keep::Function, t::MOI.ScalarAffineTerm) = keep(t.variable_index)
+_keep_all(keep::Function, t::MOI.ScalarQuadraticTerm) = keep(t.variable_index_1) && keep(t.variable_index_2)
+_keep_all(keep::Function, t::Union{MOI.VectorAffineTerm, MOI.VectorQuadraticTerm}) = _keep_all(keep, t.scalar_term)
 # Removes terms or variables in `vis_or_terms` that contains the variable of index `vi`
-function _rmvar(vis_or_terms::Vector, vi)
-    return vis_or_terms[.!_hasvar.(vis_or_terms, Ref(vi))]
+function _filter_variables(keep::Function, variables_or_terms::Vector)
+    return filter(el -> _keep_all(keep, el), variables_or_terms)
+end
+
+"""
+    filter_variables(keep::Function, f::AbstractFunction)
+
+Return a new function `f` with the variable `vi` such that `!keep(vi)` removed.
+"""
+function filter_variables end
+function filter_variables(keep::Function, f::MOI.SingleVariable)
+    if !keep(f.variable)
+        error("Cannot remove variable from a `SingleVariable` function of the",
+              " same variable.")
+    end
+    return f
+end
+function filter_variables(keep::Function, f::MOI.VectorOfVariables)
+    return MOI.VectorOfVariables(_filter_variables(keep, f.variables))
+end
+function filter_variables(
+    keep::Function, f::Union{MOI.ScalarAffineFunction, MOI.VectorAffineFunction})
+    return typeof(f)(_filter_variables(keep, f.terms), MOI.constant(f))
+end
+function filter_variables(
+    keep, f::Union{MOI.ScalarQuadraticFunction, MOI.VectorQuadraticFunction})
+    return typeof(f)(
+        _filter_variables(keep, f.affine_terms),
+        _filter_variables(keep, f.quadratic_terms),
+        MOI.constant(f))
 end
 
 """
@@ -633,23 +660,8 @@ end
 
 Return a new function `f` with the variable vi removed.
 """
-function remove_variable end
-function remove_variable(f::MOI.SingleVariable, vi::MOI.VariableIndex)
-    if f.variable == vi
-        error("Cannot remove variable from a `SingleVariable` function of the",
-              " same variable.")
-    end
-    return f
-end
-function remove_variable(f::VVF, vi)
-    VVF(_rmvar(f.variables, vi))
-end
-function remove_variable(f::Union{SAF, VAF}, vi)
-    typeof(f)(_rmvar(f.terms, vi), MOI.constant(f))
-end
-function remove_variable(f::Union{SQF, VQF}, vi)
-    terms = _rmvar.((f.affine_terms, f.quadratic_terms), Ref(vi))
-    typeof(f)(terms..., MOI.constant(f))
+function remove_variable(f::MOI.AbstractFunction, vi::MOI.VariableIndex)
+    return filter_variables(v -> v != vi, f)
 end
 
 """
@@ -671,7 +683,7 @@ function modify_function(f::VQF, change::MOI.VectorConstantChange)
 end
 function _modifycoefficient(terms::Vector{<:MOI.ScalarAffineTerm}, variable::VI, new_coefficient)
     terms = copy(terms)
-    i = something(findfirst(t -> _hasvar(t, variable), terms), 0)
+    i = something(findfirst(t -> t.variable_index == variable, terms), 0)
     if iszero(i)
         # The variable was not already in the function
         if !iszero(new_coefficient)
@@ -701,7 +713,7 @@ function _modifycoefficients(n, terms::Vector{<:MOI.VectorAffineTerm}, variable:
     rowmap = Dict(c[1]=>i for (i,c) in enumerate(new_coefficients))
     del = Int[]
     for i in 1:length(terms)
-        if _hasvar(terms[i], variable)
+        if terms[i].scalar_term.variable_index == variable
             row = terms[i].output_index
             j = Base.get(rowmap, row, 0)
             if !iszero(j) # If it is zero, it means that the row should not be changed

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -222,6 +222,11 @@ function MOI.delete(model::AbstractModel, vi::MOI.VariableIndex)
     model.objective = remove_variable(model.objective, vi)
 end
 function MOI.delete(model::AbstractModel, vis::Vector{MOI.VariableIndex})
+    if isempty(vis)
+        # In `keep`, we assume that `model.variable_indices !== nothing` so
+        # at least one variable need to be deleted.
+        return
+    end
     # Delete `VectorOfVariables(vis)` constraints as otherwise, it will error
     # when removing variables one by one.
     vov_to_remove = broadcastvcat(constrs -> _vector_of_variables_with(constrs, vis), model)

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -200,10 +200,15 @@ end
     @test 1 == @inferred MOI.get(model, MOI.NumberOfConstraints{MOI.VectorAffineFunction{Int},MOI.SecondOrderCone}())
     @test MOI.get(model, MOI.ConstraintFunction(), c6).constants == f6.constants
 
+    fx = MOI.SingleVariable(x)
+    fy = MOI.SingleVariable(y)
+    obj = 1fx + 2fy
+    MOI.set(model, MOI.ObjectiveFunction{typeof(obj)}(), obj)
     message = string("Cannot delete variable as it is constrained with other",
                      " variables in a `MOI.VectorOfVariables`.")
     err = MOI.DeleteNotAllowed(y, message)
     @test_throws err MOI.delete(model, y)
+    @test MOI.get(model, MOI.ObjectiveFunction{typeof(obj)}()) ≈ 1fx + 2fy
 
     @test MOI.is_valid(model, c8)
     MOI.delete(model, c8)
@@ -211,6 +216,7 @@ end
     @test 0 == @inferred MOI.get(model, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}())
 
     MOI.delete(model, y)
+    @test MOI.get(model, MOI.ObjectiveFunction{typeof(obj)}()) ≈ 1fx
 
     f = MOI.get(model, MOI.ConstraintFunction(), c2)
     @test f.affine_terms == MOI.VectorAffineTerm.([1, 2], MOI.ScalarAffineTerm.([3, 1], [x, x]))


### PR DESCRIPTION
When several variables are deleted, instead of doing one pass through each function for each variables, we do only one pass for all variables and use the set of variable indices to determine in O(1) whether a variable should be removed or not.
If N is the number of variables deleted and M is the number of terms in all the functions of the model, the complexity before the PR is O(N * M) and it is O(M) after the PR.