### PR TITLE
Tests for vector specialized version of MOI.delete

### DIFF
--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -372,17 +372,17 @@ function delete_variables_in_a_batch(model::MOI.ModelLike,
         c3: z >= 1.0
     """)
     x, y, z = MOI.get(model, MOI.ListOfVariableIndices())
-    @test MOI.is_valid(model, x) == true
-    @test MOI.is_valid(model, y) == true
-    @test MOI.is_valid(model, z) == true
+    @test MOI.is_valid(model, x)
+    @test MOI.is_valid(model, y)
+    @test MOI.is_valid(model, z)
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.ObjectiveValue()) == 6.0
     end
     MOI.delete(model, [x, z])
-    @test MOI.is_valid(model, x) == false
-    @test MOI.is_valid(model, y) == true
-    @test MOI.is_valid(model, z) == false
+    @test !MOI.is_valid(model, x)
+    @test MOI.is_valid(model, y)
+    @test !MOI.is_valid(model, z)
     if config.solve
         MOI.optimize!(model)
         @test MOI.get(model, MOI.ObjectiveValue()) == 2.0

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -353,7 +353,6 @@ function delete_variable_with_single_variable_obj(model::MOI.ModelLike,
 end
 modificationtests["delete_variable_with_single_variable_obj"] = delete_variable_with_single_variable_obj
 
-
 """
     delete_variables_in_a_batch(model::MOI.ModelLike, config::TestConfig)
 
@@ -376,14 +375,18 @@ function delete_variables_in_a_batch(model::MOI.ModelLike,
     @test MOI.is_valid(model, x) == true
     @test MOI.is_valid(model, y) == true
     @test MOI.is_valid(model, z) == true
-    MOI.optimize!(model)
-    @test MOI.get(model, MOI.ObjectiveValue()) == 6.0
+    if config.solve
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.ObjectiveValue()) == 6.0
+    end
     MOI.delete(model, [x, z])
     @test MOI.is_valid(model, x) == false
     @test MOI.is_valid(model, y) == true
     @test MOI.is_valid(model, z) == false
-    MOI.optimize!(model)
-    @test MOI.get(model, MOI.ObjectiveValue()) == 2.0
+    if config.solve
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.ObjectiveValue()) == 2.0
+    end
 end
 modificationtests["delete_variables_in_a_batch"] = delete_variables_in_a_batch
 

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -398,6 +398,19 @@ end
     # `UniversalFallback` needed for `MOI.Silent`
     mock   = MOIU.MockOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()))
     config = MOIT.TestConfig()
+    @testset "delete_variables_in_a_batch" begin
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0, 1.0, 1.0]),
+                MOI.FEASIBLE_POINT
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.OPTIMAL, (MOI.FEASIBLE_POINT, [1.0]),
+                MOI.FEASIBLE_POINT
+            )
+        )
+        MOIT.delete_variables_in_a_batch(mock, config)
+    end
     @testset "solve_set_singlevariable_lessthan" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,


### PR DESCRIPTION
Contribution based in a discussion with @odow and @mlubin. I think the tests may cover more cases but will wait suggestions. Looking at the other tests seem like the style of choice is keeping things simple.

The gist of this contribution is that MOI.delete taking a vector may be specialized to be 'smarter' (i.e., not O(n^2) in some situations as it is now) but this 'smarter' code needs extra tests.