### PR TITLE
don't recommend passing optimizer attributes to constructors

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -1100,8 +1100,7 @@ appropriate constraint bridges for unsupported constraints.
 
 ### Solver-specific attributes
 
-Solver-specific attributes should either be passed to the optimizer on creation,
-e.g., `MyPackage.Optimizer(PrintLevel = 0)`, or through a sub-type of
+Solver-specific attributes should be specified by creating an
 [`AbstractOptimizerAttribute`](@ref). For example, inside `MyPackage`, we could
 add the following:
 ```julia


### PR DESCRIPTION
See the removal of `with_optimizer` in JuMP: https://github.com/JuliaOpt/JuMP.jl/pull/2090.