### PR TITLE
Add support for EqualTo and Zero in Split bridge

### DIFF
--- a/src/Bridges/Constraint/interval.jl
+++ b/src/Bridges/Constraint/interval.jl
@@ -1,40 +1,83 @@
-"""
-    SplitIntervalBridge{T}
+_lower_set(set::MOI.Interval) = MOI.GreaterThan(set.lower)
+_upper_set(set::MOI.Interval) = MOI.LessThan(set.upper)
+_lower_set(set::MOI.EqualTo) = MOI.GreaterThan(set.value)
+_upper_set(set::MOI.EqualTo) = MOI.LessThan(set.value)
+_lower_set(set::MOI.Zeros) = MOI.Nonnegatives(set.dimension)
+_upper_set(set::MOI.Zeros) = MOI.Nonpositives(set.dimension)
 
-The `SplitIntervalBridge` splits a constraint ``l ≤ ⟨a, x⟩ + α ≤ u`` into the constraints ``⟨a, x⟩ + α ≥ l`` and ``⟨a, x⟩ + α ≤ u``.
 """
-struct SplitIntervalBridge{T, F<:MOI.AbstractScalarFunction} <: AbstractBridge
-    lower::CI{F, MOI.GreaterThan{T}}
-    upper::CI{F, MOI.LessThan{T}}
+    SplitIntervalBridge{T, F, S, LS, US}
+
+The `SplitIntervalBridge` splits a `F`-in-`S` constraint into a `F`-in-`LS` and
+a `F`-in-`US` constraint where we have either:
+* `F = MOI.Interval{T}`, `LS = MOI.GreaterThan{T}` and `US = MOI.LessThan{T}`,
+* `F = MOI.EqualTo{T}`, `LS = MOI.GreaterThan{T}` and `US = MOI.LessThan{T}`, or
+* `F = MOI.Zeros`, `LS = MOI.Nonnegatives` and `US = MOI.Nonpositives`.
+
+For instance, if `F` is `MOI.ScalarAffineFunction` and `S` is `MOI.Interval`,
+it transforms the constraint ``l ≤ ⟨a, x⟩ + α ≤ u`` into the constraints
+``⟨a, x⟩ + α ≥ l`` and ``⟨a, x⟩ + α ≤ u``.
+"""
+struct SplitIntervalBridge{T, F<:MOI.AbstractFunction, S<:MOI.AbstractSet,
+                           LS<:MOI.AbstractSet, US<:MOI.AbstractSet} <: AbstractBridge
+    lower::CI{F, LS}
+    upper::CI{F, US}
 end
-function bridge_constraint(::Type{SplitIntervalBridge{T, F}}, model, f::F,
-                           s::MOI.Interval{T}) where {T, F}
-    lower = MOI.add_constraint(model, f, MOI.GreaterThan(s.lower))
-    upper = MOI.add_constraint(model, f, MOI.LessThan(s.upper))
-    return SplitIntervalBridge{T, F}(lower, upper)
+function bridge_constraint(
+    ::Type{SplitIntervalBridge{T, F, S, LS, US}}, model::MOI.ModelLike, f::F,
+    set::S) where {T, F, S, LS, US}
+    lower = MOI.add_constraint(model, f, _lower_set(set))
+    upper = MOI.add_constraint(model, f, _upper_set(set))
+    return SplitIntervalBridge{T, F, S, LS, US}(lower, upper)
 end
 
-MOI.supports_constraint(::Type{SplitIntervalBridge{T}}, ::Type{<:MOI.AbstractScalarFunction}, ::Type{MOI.Interval{T}}) where T = true
+function MOI.supports_constraint(
+    ::Type{SplitIntervalBridge{T}}, ::Type{<:MOI.AbstractScalarFunction},
+    ::Type{<:Union{MOI.Interval{T}, MOI.EqualTo{T}}}) where T
+    return true
+end
+function MOI.supports_constraint(
+    ::Type{SplitIntervalBridge{T}}, ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{MOI.Zeros}) where T
+    return true
+end
 MOIB.added_constrained_variable_types(::Type{<:SplitIntervalBridge}) = Tuple{DataType}[]
-function MOIB.added_constraint_types(::Type{SplitIntervalBridge{T, F}}) where {T, F}
-    return [(F, MOI.GreaterThan{T}), (F, MOI.LessThan{T})]
+function MOIB.added_constraint_types(::Type{SplitIntervalBridge{T, F, S, LS, US}}) where {T, F, S, LS, US}
+    return [(F, LS), (F, US)]
 end
-function concrete_bridge_type(::Type{<:SplitIntervalBridge},
-                              F::Type{<:MOI.AbstractScalarFunction},
-                              ::Type{MOI.Interval{T}}) where T
-    return SplitIntervalBridge{T, F}
+function concrete_bridge_type(
+    ::Type{<:SplitIntervalBridge}, F::Type{<:MOI.AbstractScalarFunction},
+    S::Type{<:Union{MOI.Interval{T}, MOI.EqualTo{T}}}) where T
+    return SplitIntervalBridge{T, F, S, MOI.GreaterThan{T}, MOI.LessThan{T}}
+end
+function concrete_bridge_type(
+    ::Type{<:SplitIntervalBridge{T}}, F::Type{<:MOI.AbstractVectorFunction},
+    ::Type{MOI.Zeros}) where T
+    return SplitIntervalBridge{T, F, MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives}
 end
 
 # Attributes, Bridge acting as a model
-MOI.get(b::SplitIntervalBridge{T, F}, ::MOI.NumberOfConstraints{F, MOI.LessThan{T}}) where {T, F} = 1
-MOI.get(b::SplitIntervalBridge{T, F}, ::MOI.NumberOfConstraints{F, MOI.GreaterThan{T}}) where {T, F} = 1
-MOI.get(b::SplitIntervalBridge{T, F}, ::MOI.ListOfConstraintIndices{F, MOI.GreaterThan{T}}) where {T, F} = [b.lower]
-MOI.get(b::SplitIntervalBridge{T, F}, ::MOI.ListOfConstraintIndices{F, MOI.LessThan{T}}) where {T, F} = [b.upper]
+function MOI.get(::SplitIntervalBridge{T, F, S, LS},
+                 ::MOI.NumberOfConstraints{F, LS}) where {T, F, S, LS}
+    return 1
+end
+function MOI.get(::SplitIntervalBridge{T, F, S, LS, US},
+                 ::MOI.NumberOfConstraints{F, US}) where {T, F, S, LS, US}
+    return 1
+end
+function MOI.get(bridge::SplitIntervalBridge{T, F, S, LS},
+                 ::MOI.ListOfConstraintIndices{F, LS}) where {T, F, S, LS}
+    return [bridge.lower]
+end
+function MOI.get(bridge::SplitIntervalBridge{T, F, S, LS, US},
+                 ::MOI.ListOfConstraintIndices{F, US}) where {T, F, S, LS, US}
+    return [bridge.upper]
+end
 
 # Indices
-function MOI.delete(model::MOI.ModelLike, c::SplitIntervalBridge)
-    MOI.delete(model, c.lower)
-    MOI.delete(model, c.upper)
+function MOI.delete(model::MOI.ModelLike, bridge::SplitIntervalBridge)
+    MOI.delete(model, bridge.lower)
+    MOI.delete(model, bridge.upper)
 end
 
 # Attributes, Bridge acting as a constraint
@@ -50,33 +93,45 @@ function MOI.get(model::MOI.ModelLike, attr::Union{MOI.ConstraintPrimal, MOI.Con
     # lower and upper should give the same value
     return MOI.get(model, attr, bridge.lower)
 end
-function MOI.set(model::MOI.ModelLike, a::MOI.ConstraintPrimalStart,
+function MOI.set(model::MOI.ModelLike, attr::MOI.ConstraintPrimalStart,
                  bridge::SplitIntervalBridge, value)
-    MOI.set(model, a, bridge.lower, value)
-    MOI.set(model, a, bridge.upper, value)
+    MOI.set(model, attr, bridge.lower, value)
+    MOI.set(model, attr, bridge.upper, value)
 end
+# The map is:
+# x ∈ S <=> [1 1]' * x ∈ LS × US
+# So the adjoint map is
+# [1 1] * y ∈ S* <=> y ∈ (LS × US)*
+# where [1 1] * y = y[1] + y[2]
+# so we can just sum the dual values.
 function MOI.get(model::MOI.ModelLike, attr::Union{MOI.ConstraintDual, MOI.ConstraintDualStart},
                  bridge::SplitIntervalBridge)
-    # Should be nonnegative
-    lower_dual = MOI.get(model, attr, bridge.lower)
-    # Should be nonpositive
-    upper_dual = MOI.get(model, attr, bridge.upper)
-    return lower_dual > -upper_dual ? lower_dual : upper_dual
+    return MOI.get(model, attr, bridge.lower) + MOI.get(model, attr, bridge.upper)
 end
-function MOI.set(model::MOI.ModelLike, a::MOI.ConstraintDualStart,
-                 bridge::SplitIntervalBridge, value)
+function _split_dual_start(value)
     if value < 0
-        MOI.set(model, a, bridge.lower, 0.0)
-        MOI.set(model, a, bridge.upper, value)
+        return zero(value), value
     else
-        MOI.set(model, a, bridge.lower, value)
-        MOI.set(model, a, bridge.upper, 0.0)
+        return value, zero(value)
     end
 end
+function _split_dual_start(value::Vector)
+    lower = similar(value)
+    upper = similar(value)
+    for i in eachindex(value)
+        lower[i], upper[i] = _split_dual_start(value[i])
+    end
+end
+function MOI.set(model::MOI.ModelLike, attr::MOI.ConstraintDualStart,
+                 bridge::SplitIntervalBridge{T}, value) where T
+    lower, upper = _split_dual_start(value)
+    MOI.set(model, attr, bridge.lower, lower)
+    MOI.set(model, attr, bridge.upper, upper)
+end
 
-function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintBasisStatus, c::SplitIntervalBridge)
-    lower_stat = MOI.get(model, MOI.ConstraintBasisStatus(), c.lower)
-    upper_stat = MOI.get(model, MOI.ConstraintBasisStatus(), c.upper)
+function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintBasisStatus, bridge::SplitIntervalBridge)
+    lower_stat = MOI.get(model, MOI.ConstraintBasisStatus(), bridge.lower)
+    upper_stat = MOI.get(model, MOI.ConstraintBasisStatus(), bridge.upper)
     if lower_stat == MOI.NONBASIC_AT_LOWER
         @warn("GreaterThan constraints should not have basis status:" *
             " NONBASIC_AT_LOWER, instead use NONBASIC.")
@@ -99,28 +154,37 @@ function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintBasisStatus, c::SplitInte
 end
 
 # Constraints
-function MOI.modify(model::MOI.ModelLike, c::SplitIntervalBridge, change::MOI.AbstractFunctionModification)
-    MOI.modify(model, c.lower, change)
-    MOI.modify(model, c.upper, change)
+function MOI.modify(model::MOI.ModelLike, bridge::SplitIntervalBridge, change::MOI.AbstractFunctionModification)
+    MOI.modify(model, bridge.lower, change)
+    MOI.modify(model, bridge.upper, change)
 end
 
 function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintFunction,
-                  c::SplitIntervalBridge{T, F}, func::F) where {T, F}
-    MOI.set(model, MOI.ConstraintFunction(), c.lower, func)
-    MOI.set(model, MOI.ConstraintFunction(), c.upper, func)
+                  bridge::SplitIntervalBridge{T, F}, func::F) where {T, F}
+    MOI.set(model, MOI.ConstraintFunction(), bridge.lower, func)
+    MOI.set(model, MOI.ConstraintFunction(), bridge.upper, func)
 end
 
-function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintSet, c::SplitIntervalBridge, change::MOI.Interval)
-    MOI.set(model, MOI.ConstraintSet(), c.lower, MOI.GreaterThan(change.lower))
-    MOI.set(model, MOI.ConstraintSet(), c.upper, MOI.LessThan(change.upper))
+function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintSet,
+                 bridge::SplitIntervalBridge{T, F, S}, change::S) where {T, F, S}
+    MOI.set(model, MOI.ConstraintSet(), bridge.lower, _lower_set(change))
+    MOI.set(model, MOI.ConstraintSet(), bridge.upper, _upper_set(change))
 end
 
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintFunction,
-                 b::SplitIntervalBridge)
-    return MOI.get(model, attr, b.lower)
+                 bridge::SplitIntervalBridge)
+    return MOI.get(model, attr, bridge.lower)
 end
 function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintSet,
-                 b::SplitIntervalBridge)
-    return MOI.Interval(MOI.get(model, attr, b.lower).lower,
-                        MOI.get(model, attr, b.upper).upper)
+                 bridge::SplitIntervalBridge{T, F, MOI.Interval{T}}) where {T, F}
+    return MOI.Interval(MOI.get(model, attr, bridge.lower).lower,
+                        MOI.get(model, attr, bridge.upper).upper)
+end
+function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintSet,
+                 bridge::SplitIntervalBridge{T, F, MOI.EqualTo{T}}) where {T, F}
+    return MOI.EqualTo(MOI.get(model, attr, bridge.lower).lower)
+end
+function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintSet,
+                 bridge::SplitIntervalBridge{T, F, MOI.Zeros}) where {T, F}
+    return MOI.Zeros(MOI.get(model, attr, bridge.lower).dimension)
 end

--- a/src/Bridges/graph.jl
+++ b/src/Bridges/graph.jl
@@ -58,7 +58,7 @@ end
 function Base.show(io::IO, graph::Graph)
     print(io, "Bridge graph with ")
     print(io, length(graph.variable_best), " variable nodes, ")
-    print(io, length(graph.constraint_best), " variable nodes and ")
+    print(io, length(graph.constraint_best), " constraint nodes and ")
     print(io, length(graph.objective_best), " objective nodes.")
 end
 function variable_nodes(graph::Graph)

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -143,7 +143,7 @@ bridged_mock = MOIB.Constraint.LessToGreater{Float64}(MOIB.Constraint.SplitInter
 @testset "Unsupported constraint attribute" begin
     attr = MOIT.UnknownConstraintAttribute()
     err = ArgumentError(
-        "Bridge of type `MathOptInterface.Bridges.Constraint.SplitIntervalBridge{Float64,MathOptInterface.SingleVariable}` " *
+        "Bridge of type `$MOI.Bridges.Constraint.SplitIntervalBridge{Float64,$MOI.SingleVariable,$MOI.Interval{Float64},$MOI.GreaterThan{Float64},$MOI.LessThan{Float64}}` " *
         "does not support accessing the attribute `$attr`.")
     x = MOI.add_variable(bridged_mock)
     ci = MOI.add_constraint(bridged_mock, MOI.SingleVariable(x),
@@ -228,9 +228,9 @@ end
 
 @testset "Show" begin
     @test sprint(show, bridged_mock) == raw"""
-    MOIB.Constraint.SingleBridgeOptimizer{MOIB.Constraint.LessToGreaterBridge{Float64,F,G} where G<:MOI.AbstractScalarFunction where F<:MOI.AbstractScalarFunction,MOIB.Constraint.SingleBridgeOptimizer{MOIB.Constraint.SplitIntervalBridge{Float64,F} where F<:MOI.AbstractScalarFunction,MOIU.MockOptimizer{NoIntervalModel{Float64}}}}
+    MOIB.Constraint.SingleBridgeOptimizer{MOIB.Constraint.LessToGreaterBridge{Float64,F,G} where G<:MOI.AbstractScalarFunction where F<:MOI.AbstractScalarFunction,MOIB.Constraint.SingleBridgeOptimizer{MOIB.Constraint.SplitIntervalBridge{Float64,F,S,LS,US} where US<:MOI.AbstractSet where LS<:MOI.AbstractSet where S<:MOI.AbstractSet where F<:MOI.AbstractFunction,MOIU.MockOptimizer{NoIntervalModel{Float64}}}}
     with 1 constraint bridge
-    with inner model MOIB.Constraint.SingleBridgeOptimizer{MOIB.Constraint.SplitIntervalBridge{Float64,F} where F<:MOI.AbstractScalarFunction,MOIU.MockOptimizer{NoIntervalModel{Float64}}}
+    with inner model MOIB.Constraint.SingleBridgeOptimizer{MOIB.Constraint.SplitIntervalBridge{Float64,F,S,LS,US} where US<:MOI.AbstractSet where LS<:MOI.AbstractSet where S<:MOI.AbstractSet where F<:MOI.AbstractFunction,MOIU.MockOptimizer{NoIntervalModel{Float64}}}
       with 0 constraint bridges
       with inner model MOIU.MockOptimizer{NoIntervalModel{Float64}}"""
 end

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -330,12 +330,12 @@ end
             @test_throws MOI.UnsupportedConstraint{MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeSquare} MOIB.bridge_type(bridged, MOI.PositiveSemidefiniteConeSquare)
             @test MOIB._dist(bridged.graph, MOIB.node(bridged, MOI.PositiveSemidefiniteConeSquare)) == MOIB.INFINITY
             @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 1 variable nodes, 0 variable nodes and 0 objective nodes.
+Bridge graph with 1 variable nodes, 0 constraint nodes and 0 objective nodes.
  [1] constrained variables in `MOI.PositiveSemidefiniteConeSquare` are not supported
 """
             @test MOI.supports_constraint(bridged, MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeSquare)
             @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 1 variable nodes, 1 variable nodes and 0 objective nodes.
+Bridge graph with 1 variable nodes, 1 constraint nodes and 0 objective nodes.
  [1] constrained variables in `MOI.PositiveSemidefiniteConeSquare` are not supported
  (1) `MOI.VectorOfVariables`-in-`MOI.PositiveSemidefiniteConeSquare` constraints are bridged (distance 1) by MOIB.Constraint.SquareBridge{$T,MOI.VectorOfVariables,MOI.ScalarAffineFunction{$T},MOI.PositiveSemidefiniteConeTriangle,MOI.PositiveSemidefiniteConeSquare}.
 """
@@ -343,7 +343,7 @@ Bridge graph with 1 variable nodes, 1 variable nodes and 0 objective nodes.
             @test_throws MOI.UnsupportedConstraint{MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeSquare} MOIB.bridge_type(bridged, MOI.PositiveSemidefiniteConeSquare)
             @test MOIB._dist(bridged.graph, MOIB.node(bridged, MOI.PositiveSemidefiniteConeSquare)) == 6
             @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 1 variable nodes, 3 variable nodes and 0 objective nodes.
+Bridge graph with 1 variable nodes, 3 constraint nodes and 0 objective nodes.
  [1] constrained variables in `MOI.PositiveSemidefiniteConeSquare` are supported (distance 6) by adding free variables and then constrain them, see (1).
  (1) `MOI.VectorAffineFunction{$T}`-in-`MOI.PositiveSemidefiniteConeSquare` constraints are bridged (distance 3) by MOIB.Constraint.SquareBridge{$T,MOI.VectorAffineFunction{$T},MOI.ScalarAffineFunction{$T},MOI.PositiveSemidefiniteConeTriangle,MOI.PositiveSemidefiniteConeSquare}.
  (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are bridged (distance 1) by MOIB.Constraint.ScalarizeBridge{$T,MOI.ScalarAffineFunction{$T},MOI.EqualTo{$T}}.
@@ -409,7 +409,7 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 """
         @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 1 variable nodes, 1 variable nodes and 0 objective nodes.
+Bridge graph with 1 variable nodes, 1 constraint nodes and 0 objective nodes.
  [1] constrained variables in `MOI.LessThan{$T}` are not supported
  (1) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
 """
@@ -426,7 +426,7 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
         MOIB.add_bridge(bridged, MOIB.Variable.NonposToNonnegBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == "Constrained variables in `MOI.LessThan{$T}` are supported.\n"
         @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 2 variable nodes, 0 variable nodes and 0 objective nodes.
+Bridge graph with 2 variable nodes, 0 constraint nodes and 0 objective nodes.
  [1] constrained variables in `MOI.LessThan{$T}` are bridged (distance 2) by MOIB.Variable.VectorizeBridge{$T,MOI.Nonpositives}.
  [2] constrained variables in `MOI.Nonpositives` are bridged (distance 1) by MOIB.Variable.NonposToNonnegBridge{$T}.
 """
@@ -444,7 +444,7 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
 (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
 """
         @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 1 variable nodes, 2 variable nodes and 0 objective nodes.
+Bridge graph with 1 variable nodes, 2 constraint nodes and 0 objective nodes.
  [1] constrained variables in `MOI.LessThan{$T}` are not supported
  (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
  (2) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are not supported
@@ -464,7 +464,7 @@ Constrained variables in `MOI.LessThan{$T}` are not supported and cannot be brid
         MOIB.add_bridge(bridged, MOIB.Variable.NonposToNonnegBridge{T})
         @test debug_string(MOIB.debug_supports_constraint, F, S) == "Constrained variables in `MOI.LessThan{$T}` are supported.\n"
         @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 2 variable nodes, 1 variable nodes and 0 objective nodes.
+Bridge graph with 2 variable nodes, 1 constraint nodes and 0 objective nodes.
  [1] constrained variables in `MOI.LessThan{$T}` are bridged (distance 2) by MOIB.Variable.VectorizeBridge{$T,MOI.Nonpositives}.
  [2] constrained variables in `MOI.Nonpositives` are bridged (distance 1) by MOIB.Variable.NonposToNonnegBridge{$T}.
  (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
@@ -482,7 +482,7 @@ Bridge graph with 2 variable nodes, 1 variable nodes and 0 objective nodes.
         @test debug_string(MOIB.debug_supports_constraint, F, S) == """
 `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported and cannot be bridged into supported constrained variables and constraints. See details below:
 (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported because:
-  Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T}}` because:
+  Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T},MOI.Interval{$T},MOI.GreaterThan{$T},MOI.LessThan{$T}}` because:
   (2) `MOI.ScalarAffineFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
   (3) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
 (2) `MOI.ScalarAffineFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because no added bridge supports bridging it.
@@ -498,7 +498,7 @@ Bridge graph with 2 variable nodes, 1 variable nodes and 0 objective nodes.
 [3] constrained variables in `MOI.Interval{$T}` are not supported because no added bridge supports bridging it.
   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported because:
-  Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T}}` because:
+  Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T},MOI.Interval{$T},MOI.GreaterThan{$T},MOI.LessThan{$T}}` because:
   (2) `MOI.ScalarAffineFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
   (3) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.Interval{$T}}` because:
@@ -522,7 +522,7 @@ Bridge graph with 2 variable nodes, 1 variable nodes and 0 objective nodes.
 [4] constrained variables in `MOI.Interval{$T}` are not supported because no added bridge supports bridging it.
   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
 (1) `MOI.ScalarAffineFunction{$T}`-in-`MOI.Interval{$T}` constraints are not supported because:
-  Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T}}` because:
+  Cannot use `MOIB.Constraint.SplitIntervalBridge{$T,MOI.ScalarAffineFunction{$T},MOI.Interval{$T},MOI.GreaterThan{$T},MOI.LessThan{$T}}` because:
   (3) `MOI.ScalarAffineFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
   Cannot use `MOIB.Constraint.ScalarSlackBridge{$T,MOI.ScalarAffineFunction{$T},MOI.Interval{$T}}` because:
   [4] constrained variables in `MOI.Interval{$T}` are not supported
@@ -612,7 +612,7 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
         MOIB.add_bridge(bridged, MOIB.Constraint.ScalarizeBridge{T})
         @test debug_string(MOIB.debug_supports, attr) == "Objective function of type `MOI.ScalarQuadraticFunction{$T}` is supported.\n"
         @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 1 variable nodes, 5 variable nodes and 2 objective nodes.
+Bridge graph with 1 variable nodes, 5 constraint nodes and 2 objective nodes.
  [1] constrained variables in `MOI.RotatedSecondOrderCone` are bridged (distance 2) by MOIB.Variable.RSOCtoPSDBridge{$T}.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are bridged (distance 5) by MOIB.Constraint.QuadtoSOCBridge{$T}.
  (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are bridged (distance 4) by MOIB.Constraint.VectorSlackBridge{$T,MOI.VectorAffineFunction{$T},MOI.RotatedSecondOrderCone}.
@@ -712,7 +712,7 @@ end
     @test !MOIB.is_variable_bridged(bridged, cy)
     @test MOIB.bridge(bridged, cy) isa MOIB.Constraint.RSOCBridge{T}
     @test sprint(MOIB.print_graph, bridged) == """
-Bridge graph with 4 variable nodes, 8 variable nodes and 0 objective nodes.
+Bridge graph with 4 variable nodes, 9 constraint nodes and 0 objective nodes.
  [1] constrained variables in `MOI.SecondOrderCone` are supported (distance 2) by adding free variables and then constrain them, see (1).
  [2] constrained variables in `MOI.RotatedSecondOrderCone` are supported (distance 2) by adding free variables and then constrain them, see (3).
  [3] constrained variables in `MOI.PositiveSemidefiniteConeTriangle` are not supported
@@ -725,6 +725,7 @@ Bridge graph with 4 variable nodes, 8 variable nodes and 0 objective nodes.
  (6) `MOI.VectorOfVariables`-in-`MOI.Nonnegatives` constraints are bridged (distance 1) by MOIB.Constraint.NonnegToNonposBridge{$T,MOI.VectorAffineFunction{$T},MOI.VectorOfVariables}.
  (7) `MOI.SingleVariable`-in-`MOI.GreaterThan{$T}` constraints are bridged (distance 1) by MOIB.Constraint.GreaterToLessBridge{$T,MOI.ScalarAffineFunction{$T},MOI.SingleVariable}.
  (8) `MOI.SingleVariable`-in-`MOI.EqualTo{$T}` constraints are bridged (distance 1) by MOIB.Constraint.VectorizeBridge{$T,MOI.VectorAffineFunction{$T},MOI.Zeros,MOI.SingleVariable}.
+ (9) `MOI.SingleVariable`-in-`MOI.LessThan{$T}` constraints are bridged (distance 1) by MOIB.Constraint.LessToGreaterBridge{$T,MOI.ScalarAffineFunction{$T},MOI.SingleVariable}.
 """
 end
 


### PR DESCRIPTION
This would allow solvers in geometric conic form to support ScalarAffineFunction-in-EqualTo and VectorAffineFunction-in-Zeros constraints.