### PR TITLE
DNMY: add bridge for geomean to relative entropy

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ MathOptInterface (MOI) release notes
 v0.9.10 (January 31, 2020)
 ---------------------
 
+- Added `GeoMeantoRelEntrBridge` to bridge a geomean constraint to a relative entropy constraint.
 - Added `OptimizerWithAttributes` grouping an optimizer constructor and a list
   of optimizer attributes (#1008).
 - Added `RelativeEntropyCone` with corresponding bridge into exponential cone
@@ -14,7 +15,7 @@ v0.9.10 (January 31, 2020)
 - Added `dual_set_type` (#1002).
 - Added tests for vector specialized version of `delete` (#989, #1011).
 - Added PSD3 test (#1007).
-- Clarifed dual solution of `Tests.pow1v` and `Tests.pow1f` (#1013).
+- Clarified dual solution of `Tests.pow1v` and `Tests.pow1f` (#1013).
 - Added support for `EqualTo` and `Zero` in
   `Bridges.Constraint.SplitIntervalBridge` (#1005).
 - Fixed `Utilities.vectorize` for empty vector (#1003).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,14 @@
 MathOptInterface (MOI) release notes
 ====================================
 
-v0.9.10 (January 31, 2020)
+v0.9.11 (February 9, 2020)
 ---------------------
 
 - Added `GeoMeantoRelEntrBridge` to bridge a geomean constraint to a relative entropy constraint.
+
+v0.9.10 (January 31, 2020)
+---------------------
+
 - Added `OptimizerWithAttributes` grouping an optimizer constructor and a list
   of optimizer attributes (#1008).
 - Added `RelativeEntropyCone` with corresponding bridge into exponential cone

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -758,6 +758,7 @@ Bridges.Constraint.SOCRBridge
 Bridges.Constraint.QuadtoSOCBridge
 Bridges.Constraint.NormInfinityBridge
 Bridges.Constraint.NormOneBridge
+Bridges.Constraint.GeoMeantoRelEntrBridge
 Bridges.Constraint.GeoMeanBridge
 Bridges.Constraint.RelativeEntropyBridge
 Bridges.Constraint.NormSpectralBridge

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -44,6 +44,8 @@ const QuadtoSOC{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{QuadtoSOCBridge{T}
 include("norm_to_lp.jl")
 const NormInfinity{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{NormInfinityBridge{T}, OT}
 const NormOne{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{NormOneBridge{T}, OT}
+include("geomean_to_relentr.jl")
+const GeoMeantoRelEntr{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{GeoMeantoRelEntrBridge{T}, OT}
 include("geomean.jl")
 const GeoMean{T, OT<:MOI.ModelLike} = SingleBridgeOptimizer{GeoMeanBridge{T}, OT}
 include("relentr_to_exp.jl")
@@ -84,6 +86,7 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOIB.add_bridge(bridged_model, QuadtoSOCBridge{T})
     MOIB.add_bridge(bridged_model, NormInfinityBridge{T})
     MOIB.add_bridge(bridged_model, NormOneBridge{T})
+    MOIB.add_bridge(bridged_model, GeoMeantoRelEntrBridge{T})
     MOIB.add_bridge(bridged_model, GeoMeanBridge{T})
     MOIB.add_bridge(bridged_model, RelativeEntropyBridge{T})
     MOIB.add_bridge(bridged_model, NormSpectralBridge{T})

--- a/src/Bridges/Constraint/geomean_to_relentr.jl
+++ b/src/Bridges/Constraint/geomean_to_relentr.jl
@@ -73,7 +73,7 @@ function MOI.set(model::MOI.ModelLike, attr::MOI.ConstraintPrimalStart, bridge::
     return
 end
 # Given a is dual on y >= 0 and (b, c, d) is dual on RelativeEntropyCone constraint,
-# dual on (u, w) in GeometricMeanCone is (-a, c)
+# dual on (u, w) in GeometricMeanCone is (-a, c).
 function MOI.get(model::MOI.ModelLike, attr::Union{MOI.ConstraintDual, MOI.ConstraintDualStart}, bridge::GeoMeantoRelEntrBridge)
     u_dual = -MOI.get(model, attr, bridge.nn_index)[1]
     relentr_dual = MOI.get(model, attr, bridge.relentr_index)

--- a/src/Bridges/Constraint/geomean_to_relentr.jl
+++ b/src/Bridges/Constraint/geomean_to_relentr.jl
@@ -1,0 +1,92 @@
+"""
+    GeoMeantoRelEntrBridge{T}
+
+The `geometric mean cone` is representable with a relative entropy constraint and a nonnegative auxiliary variable,
+since ``u \\le \\prod_{i=1}^n w_i^{1/n}`` if and only if there exists a ``y \\ge 0`` such that
+``0 \\ge \\sum_{i=1}^n (u + y) \\log (\\frac{u + y}{w_i})``, or equivalently
+``(0, w, (u + y) e) \\in RelativeEntropyCone(1 + 2n)``, where ``e`` is a vector of ones.
+"""
+struct GeoMeantoRelEntrBridge{T, F, G, H} <: AbstractBridge
+    y::MOI.VariableIndex
+    ge_index::CI{F, MOI.GreaterThan{T}} # for y >= 0
+    relentr_index::CI{G, MOI.RelativeEntropyCone}
+end
+function bridge_constraint(::Type{GeoMeantoRelEntrBridge{T, F, G, H}}, model::MOI.ModelLike, f::H, s::MOI.GeometricMeanCone) where {T, F, G, H}
+    f_scalars = MOIU.eachscalar(f)
+    y = MOI.add_variable(model)
+    ge_index = MOI.add_constraint(model, y, MOI.GreaterThan(zero(T)))
+    relentr_func = MOIU.operate(vcat, T, zero(MOI.ScalarAffineFunction{Float64}), f_scalars[2:end], fill(MOIU.operate(+, T, f_scalars[1], MOI.SingleVariable(y)), MOI.dimension(s) - 1)...)
+    relentr_index = MOI.add_constraint(model, relentr_func, MOI.RelativeEntropyCone(MOI.output_dimension(relentr_func)))
+    return GeoMeantoRelEntrBridge{T, F, G, H}(y, ge_index, relentr_index)
+end
+
+MOI.supports_constraint(::Type{GeoMeantoRelEntrBridge{T}}, ::Type{<:MOI.AbstractVectorFunction}, ::Type{MOI.GeometricMeanCone}) where T = true
+MOIB.added_constrained_variable_types(::Type{<:GeoMeantoRelEntrBridge}) = Tuple{DataType}[]
+MOIB.added_constraint_types(::Type{GeoMeantoRelEntrBridge{T, F, G, H}}) where {T, F, G, H} = [(F, MOI.GreaterThan{T}), (G, MOI.RelativeEntropyCone)]
+function concrete_bridge_type(::Type{<:GeoMeantoRelEntrBridge{T}}, H::Type{<:MOI.AbstractVectorFunction}, ::Type{MOI.GeometricMeanCone}) where T
+    F = MOI.SingleVariable
+    S = MOIU.scalar_type(H)
+    G = MOIU.promote_operation(vcat, T, T, S, MOIU.promote_operation(+, T, S, MOI.SingleVariable))
+    return GeoMeantoRelEntrBridge{T, F, G, H}
+end
+
+# Attributes, Bridge acting as a model
+MOI.get(bridge::GeoMeantoRelEntrBridge, ::MOI.NumberOfVariables) = 1
+MOI.get(bridge::GeoMeantoRelEntrBridge, ::MOI.ListOfVariableIndices) = [bridge.y]
+MOI.get(bridge::GeoMeantoRelEntrBridge{T, F}, ::MOI.NumberOfConstraints{F, MOI.GreaterThan{T}}) where {T, F} = 1
+MOI.get(bridge::GeoMeantoRelEntrBridge{T, F, G}, ::MOI.NumberOfConstraints{G, MOI.RelativeEntropyCone}) where {T, F, G} = 1
+MOI.get(bridge::GeoMeantoRelEntrBridge{T, F}, ::MOI.ListOfConstraintIndices{F, MOI.GreaterThan{T}}) where {T, F} = [bridge.ge_index]
+MOI.get(bridge::GeoMeantoRelEntrBridge{T, F, G}, ::MOI.ListOfConstraintIndices{G, MOI.RelativeEntropyCone}) where {T, F, G} = [bridge.relentr_index]
+
+# References
+function MOI.delete(model::MOI.ModelLike, bridge::GeoMeantoRelEntrBridge)
+    MOI.delete(model, bridge.relentr_index)
+    MOI.delete(model, bridge.ge_index)
+    MOI.delete(model, bridge.y)
+end
+
+# Attributes, Bridge acting as a constraint
+function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintFunction, bridge::GeoMeantoRelEntrBridge{T, F, G, H}) where {T, F, G, H}
+    relentr_func = MOIU.eachscalar(MOI.get(model, MOI.ConstraintFunction(), bridge.relentr_index))
+    d = div(length(relentr_func) - 1, 2)
+    u_func = MOIU.remove_variable(MOIU.operate(-, T, relentr_func[end], MOI.SingleVariable(bridge.y)), bridge.y)
+    w_func = relentr_func[2:(1 + d)]
+    return MOIU.convert_approx(H, MOIU.operate(vcat, T, u_func, w_func))
+end
+MOI.get(model::MOI.ModelLike, ::MOI.ConstraintSet, bridge::GeoMeantoRelEntrBridge) = MOI.GeometricMeanCone(1 + div(MOI.dimension(MOI.get(model, MOI.ConstraintSet(), bridge.relentr_index)) - 1, 2))
+MOI.supports(::MOI.ModelLike, ::Union{MOI.ConstraintPrimalStart, MOI.ConstraintDualStart}, ::Type{<:GeoMeantoRelEntrBridge}) = true
+function MOI.get(model::MOI.ModelLike, attr::Union{MOI.ConstraintPrimal, MOI.ConstraintPrimalStart}, bridge::GeoMeantoRelEntrBridge)
+    relentr_primal = MOI.get(model, attr, bridge.relentr_index)
+    d = div(length(relentr_primal) - 1, 2)
+    y_val = MOI.get(model, attr, bridge.ge_index)
+    u_val = sum(relentr_primal[(2 + d):end]) / d - y_val
+    return vcat(u_val, relentr_primal[2:(1 + d)])
+end
+function MOI.set(model::MOI.ModelLike, attr::MOI.ConstraintPrimalStart, bridge::GeoMeantoRelEntrBridge, value)
+    u_val = value[1]
+    u_pos = -min(zero(u_val), u_val)
+    d = length(value) - 1
+    MOI.set(model, MOI.VariablePrimalStart(), bridge.y, u_pos)
+    MOI.set(model, attr, bridge.ge_index, u_pos)
+    MOI.set(model, attr, bridge.relentr_index, vcat(0, value[2:end], fill(u_pos + u_val, d)))
+    return
+end
+# Given a is dual on y >= 0 and (b, c, d) is dual on RelativeEntropyCone constraint,
+# dual on (u, w) in GeometricMeanCone is (-a, c)
+function MOI.get(model::MOI.ModelLike, attr::Union{MOI.ConstraintDual, MOI.ConstraintDualStart}, bridge::GeoMeantoRelEntrBridge)
+    u_dual = -MOI.get(model, attr, bridge.ge_index)[1]
+    relentr_dual = MOI.get(model, attr, bridge.relentr_index)
+    d = div(length(relentr_dual) - 1, 2)
+    w_dual = relentr_dual[2:(d + 1)]
+    return vcat(u_dual, w_dual)
+end
+# Given constraint dual start of (u, w), constraint dual on RelativeEntropyCone
+# constraint is (1/d, -u/d * e, -w) and dual on y >= 0 constraint is -u.
+function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintDualStart, bridge::GeoMeantoRelEntrBridge, value)
+    d = length(value) - 1
+    u = value[1]
+    MOI.set(model, MOI.ConstraintDualStart(), bridge.ge_index, -u)
+    relentr_dual = vcat(one(u) / d, fill(-u / d, d), -value[2:end])
+    MOI.set(model, MOI.ConstraintDualStart(), bridge.relentr_index, relentr_dual)
+    return
+end

--- a/src/Bridges/Constraint/geomean_to_relentr.jl
+++ b/src/Bridges/Constraint/geomean_to_relentr.jl
@@ -8,23 +8,23 @@ since ``u \\le \\prod_{i=1}^n w_i^{1/n}`` if and only if there exists a ``y \\ge
 """
 struct GeoMeantoRelEntrBridge{T, F, G, H} <: AbstractBridge
     y::MOI.VariableIndex
-    ge_index::CI{F, MOI.GreaterThan{T}} # for y >= 0
+    nn_index::CI{F, MOI.Nonnegatives} # for y >= 0
     relentr_index::CI{G, MOI.RelativeEntropyCone}
 end
 function bridge_constraint(::Type{GeoMeantoRelEntrBridge{T, F, G, H}}, model::MOI.ModelLike, f::H, s::MOI.GeometricMeanCone) where {T, F, G, H}
     f_scalars = MOIU.eachscalar(f)
-    y = MOI.add_variable(model)
-    ge_index = MOI.add_constraint(model, y, MOI.GreaterThan(zero(T)))
-    relentr_func = MOIU.operate(vcat, T, zero(MOI.ScalarAffineFunction{Float64}), f_scalars[2:end], fill(MOIU.operate(+, T, f_scalars[1], MOI.SingleVariable(y)), MOI.dimension(s) - 1)...)
+    (y, nn_index) = MOI.add_constrained_variables(model, MOI.Nonnegatives(1))
+    w_func = MOIU.vectorize(fill(MOIU.operate(+, T, f_scalars[1], MOI.SingleVariable(y[1])), MOI.dimension(s) - 1))
+    relentr_func = MOIU.operate(vcat, T, zero(MOI.ScalarAffineFunction{Float64}), f_scalars[2:end], w_func)
     relentr_index = MOI.add_constraint(model, relentr_func, MOI.RelativeEntropyCone(MOI.output_dimension(relentr_func)))
-    return GeoMeantoRelEntrBridge{T, F, G, H}(y, ge_index, relentr_index)
+    return GeoMeantoRelEntrBridge{T, F, G, H}(y[1], nn_index, relentr_index)
 end
 
-MOI.supports_constraint(::Type{GeoMeantoRelEntrBridge{T}}, ::Type{<:MOI.AbstractVectorFunction}, ::Type{MOI.GeometricMeanCone}) where T = true
-MOIB.added_constrained_variable_types(::Type{<:GeoMeantoRelEntrBridge}) = Tuple{DataType}[]
-MOIB.added_constraint_types(::Type{GeoMeantoRelEntrBridge{T, F, G, H}}) where {T, F, G, H} = [(F, MOI.GreaterThan{T}), (G, MOI.RelativeEntropyCone)]
+MOI.supports_constraint(::Type{<:GeoMeantoRelEntrBridge{T}}, ::Type{<:MOI.AbstractVectorFunction}, ::Type{MOI.GeometricMeanCone}) where T = true
+MOIB.added_constrained_variable_types(::Type{<:GeoMeantoRelEntrBridge}) = [(MOI.Nonnegatives,)]
+MOIB.added_constraint_types(::Type{<:GeoMeantoRelEntrBridge{T, F, G}}) where {T, F, G} = [(G, MOI.RelativeEntropyCone)]
 function concrete_bridge_type(::Type{<:GeoMeantoRelEntrBridge{T}}, H::Type{<:MOI.AbstractVectorFunction}, ::Type{MOI.GeometricMeanCone}) where T
-    F = MOI.SingleVariable
+    F = MOI.VectorOfVariables
     S = MOIU.scalar_type(H)
     G = MOIU.promote_operation(vcat, T, T, S, MOIU.promote_operation(+, T, S, MOI.SingleVariable))
     return GeoMeantoRelEntrBridge{T, F, G, H}
@@ -33,15 +33,15 @@ end
 # Attributes, Bridge acting as a model
 MOI.get(bridge::GeoMeantoRelEntrBridge, ::MOI.NumberOfVariables) = 1
 MOI.get(bridge::GeoMeantoRelEntrBridge, ::MOI.ListOfVariableIndices) = [bridge.y]
-MOI.get(bridge::GeoMeantoRelEntrBridge{T, F}, ::MOI.NumberOfConstraints{F, MOI.GreaterThan{T}}) where {T, F} = 1
+MOI.get(bridge::GeoMeantoRelEntrBridge{T, F}, ::MOI.NumberOfConstraints{F, MOI.Nonnegatives}) where {T, F} = 1
 MOI.get(bridge::GeoMeantoRelEntrBridge{T, F, G}, ::MOI.NumberOfConstraints{G, MOI.RelativeEntropyCone}) where {T, F, G} = 1
-MOI.get(bridge::GeoMeantoRelEntrBridge{T, F}, ::MOI.ListOfConstraintIndices{F, MOI.GreaterThan{T}}) where {T, F} = [bridge.ge_index]
+MOI.get(bridge::GeoMeantoRelEntrBridge{T, F}, ::MOI.ListOfConstraintIndices{F, MOI.Nonnegatives}) where {T, F} = [bridge.nn_index]
 MOI.get(bridge::GeoMeantoRelEntrBridge{T, F, G}, ::MOI.ListOfConstraintIndices{G, MOI.RelativeEntropyCone}) where {T, F, G} = [bridge.relentr_index]
 
 # References
 function MOI.delete(model::MOI.ModelLike, bridge::GeoMeantoRelEntrBridge)
     MOI.delete(model, bridge.relentr_index)
-    MOI.delete(model, bridge.ge_index)
+    MOI.delete(model, bridge.nn_index)
     MOI.delete(model, bridge.y)
 end
 
@@ -54,11 +54,12 @@ function MOI.get(model::MOI.ModelLike, ::MOI.ConstraintFunction, bridge::GeoMean
     return MOIU.convert_approx(H, MOIU.operate(vcat, T, u_func, w_func))
 end
 MOI.get(model::MOI.ModelLike, ::MOI.ConstraintSet, bridge::GeoMeantoRelEntrBridge) = MOI.GeometricMeanCone(1 + div(MOI.dimension(MOI.get(model, MOI.ConstraintSet(), bridge.relentr_index)) - 1, 2))
-MOI.supports(::MOI.ModelLike, ::Union{MOI.ConstraintPrimalStart, MOI.ConstraintDualStart}, ::Type{<:GeoMeantoRelEntrBridge}) = true
+MOI.supports(::MOI.ModelLike, ::Union{MOI.ConstraintPrimalStart, MOI.ConstraintDualStart},
+    ::Type{<:GeoMeantoRelEntrBridge}) = true
 function MOI.get(model::MOI.ModelLike, attr::Union{MOI.ConstraintPrimal, MOI.ConstraintPrimalStart}, bridge::GeoMeantoRelEntrBridge)
     relentr_primal = MOI.get(model, attr, bridge.relentr_index)
     d = div(length(relentr_primal) - 1, 2)
-    y_val = MOI.get(model, attr, bridge.ge_index)
+    y_val = MOI.get(model, attr, bridge.nn_index)[1]
     u_val = sum(relentr_primal[(2 + d):end]) / d - y_val
     return vcat(u_val, relentr_primal[2:(1 + d)])
 end
@@ -67,26 +68,27 @@ function MOI.set(model::MOI.ModelLike, attr::MOI.ConstraintPrimalStart, bridge::
     u_pos = -min(zero(u_val), u_val)
     d = length(value) - 1
     MOI.set(model, MOI.VariablePrimalStart(), bridge.y, u_pos)
-    MOI.set(model, attr, bridge.ge_index, u_pos)
+    MOI.set(model, attr, bridge.nn_index, [u_pos])
     MOI.set(model, attr, bridge.relentr_index, vcat(0, value[2:end], fill(u_pos + u_val, d)))
     return
 end
 # Given a is dual on y >= 0 and (b, c, d) is dual on RelativeEntropyCone constraint,
 # dual on (u, w) in GeometricMeanCone is (-a, c)
 function MOI.get(model::MOI.ModelLike, attr::Union{MOI.ConstraintDual, MOI.ConstraintDualStart}, bridge::GeoMeantoRelEntrBridge)
-    u_dual = -MOI.get(model, attr, bridge.ge_index)[1]
+    u_dual = -MOI.get(model, attr, bridge.nn_index)[1]
     relentr_dual = MOI.get(model, attr, bridge.relentr_index)
     d = div(length(relentr_dual) - 1, 2)
     w_dual = relentr_dual[2:(d + 1)]
     return vcat(u_dual, w_dual)
 end
 # Given constraint dual start of (u, w), constraint dual on RelativeEntropyCone
-# constraint is (1/d, -u/d * e, -w) and dual on y >= 0 constraint is -u.
+# constraint is (1/d, w, u/d * e) and dual on y >= 0 constraint is -u.
+# TODO try to fix using https://github.com/JuliaOpt/MathOptInterface.jl/pull/1017#discussion_r376708499
 function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintDualStart, bridge::GeoMeantoRelEntrBridge, value)
     d = length(value) - 1
     u = value[1]
-    MOI.set(model, MOI.ConstraintDualStart(), bridge.ge_index, -u)
-    relentr_dual = vcat(one(u) / d, fill(-u / d, d), -value[2:end])
+    MOI.set(model, MOI.ConstraintDualStart(), bridge.nn_index, [-u])
+    relentr_dual = vcat(one(u) / d, value[2:end], fill(u / d, d))
     MOI.set(model, MOI.ConstraintDualStart(), bridge.relentr_index, relentr_dual)
     return
 end

--- a/src/Bridges/Constraint/geomean_to_relentr.jl
+++ b/src/Bridges/Constraint/geomean_to_relentr.jl
@@ -83,7 +83,7 @@ function MOI.get(model::MOI.ModelLike, attr::Union{MOI.ConstraintDual, MOI.Const
 end
 # Given constraint dual start of (u, w), constraint dual on RelativeEntropyCone
 # constraint is (1/d, w, u/d * e) and dual on y >= 0 constraint is -u.
-# TODO try to fix using https://github.com/JuliaOpt/MathOptInterface.jl/pull/1017#discussion_r376708499
+# TODO incorrect. fix, see discussion at https://github.com/JuliaOpt/MathOptInterface.jl/pull/1017#discussion_r376708499
 function MOI.set(model::MOI.ModelLike, ::MOI.ConstraintDualStart, bridge::GeoMeantoRelEntrBridge, value)
     d = length(value) - 1
     u = value[1]

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1270,6 +1270,11 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
         @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ ones(n+1) atol=atol rtol=rtol
 
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ n atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ vcat(-1.0, fill(inv(n), n)) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ inv(n) atol=atol rtol=rtol
+        end
     end
 end
 

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1343,7 +1343,7 @@ function _geomean2test(model::MOI.ModelLike, config::TestConfig, vecofvars)
 
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ vcat(-1, fill(inv(9), 9)) atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ fill(inv(9), 9) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ fill(-inv(9), 9) atol=atol rtol=rtol
         end
     end
 end
@@ -1408,7 +1408,7 @@ function _geomean3test(model::MOI.ModelLike, config::TestConfig, vecofvars)
 
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ [-2.0, 2.0] atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ 2.0 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ -2.0 atol=atol rtol=rtol
         end
     end
 end

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1273,7 +1273,7 @@ function _geomean1test(model::MOI.ModelLike, config::TestConfig, vecofvars, n=3)
 
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ vcat(-1.0, fill(inv(n), n)) atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ inv(n) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), c) ≈ -inv(n) atol=atol rtol=rtol
         end
     end
 end
@@ -1289,7 +1289,7 @@ function _geomean2test(model::MOI.ModelLike, config::TestConfig, vecofvars)
     # max t
     # st  (t,x_1,x_2,...,x_9) ∈ GeometricMeanCone(10)
     #     x_1 == x_2, ..., x_9 == 1
-    # the optimal solution is 1
+    # the optimal solution is 1 with optimal value 1
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1340,6 +1340,11 @@ function _geomean2test(model::MOI.ModelLike, config::TestConfig, vecofvars)
 
         @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ ones(n + 1) atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ ones(n) atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ vcat(-1, fill(inv(9), 9)) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ fill(inv(9), 9) atol=atol rtol=rtol
+        end
     end
 end
 
@@ -1354,7 +1359,7 @@ function _geomean3test(model::MOI.ModelLike, config::TestConfig, vecofvars)
     # max 2t
     # st  (t,x) ∈ GeometricMeanCone(2)
     #     x <= 2
-    # the optimal solution is 4
+    # the optimal solution is (t, x) = (2, 2) with objective value 4
 
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
@@ -1400,6 +1405,11 @@ function _geomean3test(model::MOI.ModelLike, config::TestConfig, vecofvars)
 
         @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ [2.0; 2.0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ 2.0 atol=atol rtol=rtol
+
+        if config.duals
+            @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ [-2.0, 2.0] atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ 2.0 atol=atol rtol=rtol
+        end
     end
 end
 

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1342,8 +1342,8 @@ function _geomean2test(model::MOI.ModelLike, config::TestConfig, vecofvars)
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ ones(n) atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ vcat(-1, fill(inv(9), 9)) atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ fill(-inv(9), 9) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ vcat(-1, fill(inv(n), n)) atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ fill(-inv(n), n) atol=atol rtol=rtol
         end
     end
 end

--- a/test/Bridges/Constraint/geomean.jl
+++ b/test/Bridges/Constraint/geomean.jl
@@ -8,7 +8,7 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
+mock = MOIU.MockOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()))
 config = MOIT.TestConfig()
 
 @testset "GeoMean" begin

--- a/test/Bridges/Constraint/geomean.jl
+++ b/test/Bridges/Constraint/geomean.jl
@@ -8,8 +8,8 @@ const MOIB = MathOptInterface.Bridges
 
 include("../utilities.jl")
 
-mock = MOIU.MockOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()))
-config = MOIT.TestConfig()
+mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
+config = MOIT.TestConfig(duals = false)
 
 @testset "GeoMean" begin
     bridged_mock = MOIB.Constraint.GeoMean{Float64}(mock)

--- a/test/Bridges/Constraint/geomean_to_relentr.jl
+++ b/test/Bridges/Constraint/geomean_to_relentr.jl
@@ -22,7 +22,7 @@ config = MOIT.TestConfig()
     var_primal = [1, 1, 1, 1, 0]
     relentr_dual = [1, 1, 1, 1, -1, -1, -1] / 3
     mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, var_primal,
-        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [inv(3)],
+        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-inv(3)],
         (MOI.VectorOfVariables, MOI.Nonnegatives) => [[1.0]],
         (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone) => [relentr_dual])
 

--- a/test/Bridges/Constraint/geomean_to_relentr.jl
+++ b/test/Bridges/Constraint/geomean_to_relentr.jl
@@ -26,7 +26,6 @@ config = MOIT.TestConfig()
         (MOI.VectorOfVariables, MOI.Nonnegatives) => [[1.0]],
         (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone) => [relentr_dual])
 
-    # MOIT.geomean1vtest(bridged_mock, config)
     MOIT.geomean1ftest(bridged_mock, config)
 
     var_names = ["t", "x", "y", "z"]

--- a/test/Bridges/Constraint/geomean_to_relentr.jl
+++ b/test/Bridges/Constraint/geomean_to_relentr.jl
@@ -1,0 +1,100 @@
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+const MOIT = MathOptInterface.Test
+const MOIU = MathOptInterface.Utilities
+const MOIB = MathOptInterface.Bridges
+
+include("../utilities.jl")
+
+mock = MOIU.MockOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()))
+config = MOIT.TestConfig()
+
+@testset "GeoMeantoRelEntr" begin
+    bridged_mock = MOIB.Constraint.GeoMeantoRelEntr{Float64}(mock)
+
+    MOIT.basic_constraint_tests(bridged_mock, config,
+        include = [(F, MOI.GeometricMeanCone) for F in [
+            MOI.VectorOfVariables, MOI.VectorAffineFunction{Float64}, MOI.VectorQuadraticFunction{Float64}
+        ]])
+
+    var_primal = [1, 1, 1, 1, 0]
+    relentr_dual = [1, 1, 1, 1, -1, -1, -1] / 3
+    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, var_primal,
+        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [inv(3)],
+        (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [1.0],
+        (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone) => [relentr_dual])
+
+    # MOIT.geomean1vtest(bridged_mock, config)
+    MOIT.geomean1ftest(bridged_mock, config)
+
+    var_names = ["t", "x", "y", "z"]
+    MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+
+    greater = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.SingleVariable, MOI.GreaterThan{Float64}}())
+    relentr = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone}())
+    aux = MOI.get(mock, MOI.ListOfVariableIndices())[end]
+
+    @testset "Test mock model" begin
+        MOI.set(mock, MOI.VariableName(), aux, "aux")
+        @test length(greater) == 1
+        MOI.set(mock, MOI.ConstraintName(), greater[1], "greater")
+        @test length(relentr) == 1
+        MOI.set(mock, MOI.ConstraintName(), relentr[1], "relentr")
+        less = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+        @test length(less) == 1
+        MOI.set(mock, MOI.ConstraintName(), less[1], "less")
+
+        s = """
+        variables: t, x, y, z, aux
+        less: x + y + z in MathOptInterface.LessThan(3.0)
+        greater: aux >= 0.0
+        relentr: [0.0, x, y, z, t + aux, t + aux, t + aux] in MathOptInterface.RelativeEntropyCone(7)
+        maxobjective: t
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(mock, model, vcat(var_names, "aux"), ["less", "greater", "relentr"])
+    end
+
+    @testset "Test bridged model" begin
+        geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
+        @test length(geomean) == 1
+        MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
+        less = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+        @test length(less) == 1
+        MOI.set(bridged_mock, MOI.ConstraintName(), less[1], "less")
+
+        s = """
+        variables: t, x, y, z
+        less: x + y + z in MathOptInterface.LessThan(3.0)
+        geomean: [1.0t, x, y, z] in MathOptInterface.GeometricMeanCone(4)
+        maxobjective: t
+        """
+        model = MOIU.Model{Float64}()
+        MOIU.loadfromstring!(model, s)
+        MOIU.test_models_equal(bridged_mock, model, var_names, ["less", "geomean"])
+    end
+
+    ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
+
+    @testset "$attr" for attr in [MOI.ConstraintPrimalStart(), MOI.ConstraintDualStart()]
+        @test MOI.supports(bridged_mock, attr, typeof(ci))
+        value = (attr isa MOI.ConstraintPrimalStart) ? ones(4) : vcat(-1, fill(inv(3), 3))
+        MOI.set(bridged_mock, attr, ci, value)
+        @test MOI.get(bridged_mock, attr, ci) ≈ value
+        if attr isa MOI.ConstraintPrimalStart
+            @test MOI.get(mock, MOI.VariablePrimalStart(), aux) == 0
+            @test MOI.get(mock, attr, greater[1]) == 0
+            @test MOI.get(mock, attr, relentr[1]) == [0, 1, 1, 1, 1, 1, 1]
+        else
+            @test MOI.get(mock, attr, greater[1]) == 1
+            @test MOI.get(mock, attr, relentr[1]) == relentr_dual
+        end
+    end
+
+    test_delete_bridge(bridged_mock, ci, 4, (
+        (MOI.SingleVariable, MOI.GreaterThan{Float64}, 0),
+        (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone, 0)))
+end

--- a/test/Bridges/Constraint/geomean_to_relentr.jl
+++ b/test/Bridges/Constraint/geomean_to_relentr.jl
@@ -19,82 +19,264 @@ config = MOIT.TestConfig()
             MOI.VectorOfVariables, MOI.VectorAffineFunction{Float64}, MOI.VectorQuadraticFunction{Float64}
         ]])
 
-    var_primal = [1, 1, 1, 1, 0]
-    relentr_dual = [1, 1, 1, 1, -1, -1, -1] / 3
-    mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, var_primal,
-        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-inv(3)],
-        (MOI.VectorOfVariables, MOI.Nonnegatives) => [[1.0]],
-        (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone) => [relentr_dual])
+    @testset "geomean1test" begin
+        var_primal = [1, 1, 1, 1, 0]
+        relentr_dual = [1, 1, 1, 1, -1, -1, -1] / 3
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, var_primal,
+            (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-inv(3)],
+            (MOI.VectorOfVariables, MOI.Nonnegatives) => [[1]],
+            (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone) => [relentr_dual])
 
-    MOIT.geomean1ftest(bridged_mock, config)
+        MOIT.geomean1ftest(bridged_mock, config)
 
-    var_names = ["t", "x", "y", "z"]
-    MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+        var_names = ["t", "x", "y", "z"]
+        MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
 
-    nonneg = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorOfVariables, MOI.Nonnegatives}())
-    relentr = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone}())
-    aux = MOI.get(mock, MOI.ListOfVariableIndices())[end]
+        nonneg = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorOfVariables, MOI.Nonnegatives}())
+        relentr = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone}())
+        aux = MOI.get(mock, MOI.ListOfVariableIndices())[end]
 
-    @testset "Test mock model" begin
-        MOI.set(mock, MOI.VariableName(), aux, "aux")
-        @test length(nonneg) == 1
-        MOI.set(mock, MOI.ConstraintName(), nonneg[1], "nonneg")
-        @test length(relentr) == 1
-        MOI.set(mock, MOI.ConstraintName(), relentr[1], "relentr")
-        less = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
-        @test length(less) == 1
-        MOI.set(mock, MOI.ConstraintName(), less[1], "less")
+        @testset "Test mock model" begin
+            MOI.set(mock, MOI.VariableName(), aux, "aux")
+            @test length(nonneg) == 1
+            MOI.set(mock, MOI.ConstraintName(), nonneg[1], "nonneg")
+            @test length(relentr) == 1
+            MOI.set(mock, MOI.ConstraintName(), relentr[1], "relentr")
+            less = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+            @test length(less) == 1
+            MOI.set(mock, MOI.ConstraintName(), less[1], "less")
 
-        s = """
-        variables: t, x, y, z, aux
-        less: x + y + z in MathOptInterface.LessThan(3.0)
-        nonneg: [aux] in MathOptInterface.Nonnegatives(1)
-        relentr: [0.0, x, y, z, t + aux, t + aux, t + aux] in MathOptInterface.RelativeEntropyCone(7)
-        maxobjective: t
-        """
-        model = MOIU.Model{Float64}()
-        MOIU.loadfromstring!(model, s)
-        MOIU.test_models_equal(mock, model, vcat(var_names, "aux"), ["less", "nonneg", "relentr"])
-    end
-
-    @testset "Test bridged model" begin
-        geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
-        @test length(geomean) == 1
-        MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
-        less = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
-        @test length(less) == 1
-        MOI.set(bridged_mock, MOI.ConstraintName(), less[1], "less")
-
-        s = """
-        variables: t, x, y, z
-        less: x + y + z in MathOptInterface.LessThan(3.0)
-        geomean: [1.0t, x, y, z] in MathOptInterface.GeometricMeanCone(4)
-        maxobjective: t
-        """
-        model = MOIU.Model{Float64}()
-        MOIU.loadfromstring!(model, s)
-        MOIU.test_models_equal(bridged_mock, model, var_names, ["less", "geomean"])
-    end
-
-    ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
-
-    @testset "$attr" for attr in [MOI.ConstraintPrimalStart(), MOI.ConstraintDualStart()]
-        @test MOI.supports(bridged_mock, attr, typeof(ci))
-        value = (attr isa MOI.ConstraintPrimalStart) ? ones(4) : vcat(-1, fill(inv(3), 3))
-        MOI.set(bridged_mock, attr, ci, value)
-        @test MOI.get(bridged_mock, attr, ci) ≈ value
-        if attr isa MOI.ConstraintPrimalStart
-            @test MOI.get(mock, MOI.VariablePrimalStart(), aux) == 0
-            @test MOI.get(mock, attr, nonneg[1]) == [0]
-            @test MOI.get(mock, attr, relentr[1]) == [0, 1, 1, 1, 1, 1, 1]
-        else
-            @test MOI.get(mock, attr, nonneg[1]) == [1]
-            @test MOI.get(mock, attr, relentr[1]) == relentr_dual
+            s = """
+            variables: t, x, y, z, aux
+            less: x + y + z in MathOptInterface.LessThan(3.0)
+            nonneg: [aux] in MathOptInterface.Nonnegatives(1)
+            relentr: [0.0, x, y, z, t + aux, t + aux, t + aux] in MathOptInterface.RelativeEntropyCone(7)
+            maxobjective: t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(mock, model, vcat(var_names, "aux"), ["less", "nonneg", "relentr"])
         end
+
+        @testset "Test bridged model" begin
+            geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
+            @test length(geomean) == 1
+            MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
+            less = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+            @test length(less) == 1
+            MOI.set(bridged_mock, MOI.ConstraintName(), less[1], "less")
+
+            s = """
+            variables: t, x, y, z
+            less: x + y + z in MathOptInterface.LessThan(3.0)
+            geomean: [1.0t, x, y, z] in MathOptInterface.GeometricMeanCone(4)
+            maxobjective: t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(bridged_mock, model, var_names, ["less", "geomean"])
+        end
+
+        ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
+
+        @testset "$attr" for attr in [MOI.ConstraintPrimalStart(), MOI.ConstraintDualStart()]
+            @test MOI.supports(bridged_mock, attr, typeof(ci))
+            value = (attr isa MOI.ConstraintPrimalStart) ? ones(4) : vcat(-1, fill(inv(3), 3))
+            MOI.set(bridged_mock, attr, ci, value)
+            @test MOI.get(bridged_mock, attr, ci) ≈ value
+            if attr isa MOI.ConstraintPrimalStart
+                @test MOI.get(mock, MOI.VariablePrimalStart(), aux) == 0
+                @test MOI.get(mock, attr, nonneg[1]) == [0]
+                @test MOI.get(mock, attr, relentr[1]) == [0, 1, 1, 1, 1, 1, 1]
+            else
+                @test MOI.get(mock, attr, nonneg[1]) == [1]
+                @test MOI.get(mock, attr, relentr[1]) == relentr_dual
+            end
+        end
+
+        test_delete_bridge(bridged_mock, ci, 4, (
+            (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 1),
+            (MOI.VectorOfVariables, MOI.Nonnegatives, 0),
+            (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone, 0)))
     end
 
-    test_delete_bridge(bridged_mock, ci, 4, (
-        (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 1),
-        (MOI.VectorOfVariables, MOI.Nonnegatives, 0),
-        (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone, 0)))
+    @testset "geomean2test" begin
+        var_primal = vcat(ones(10), 0)
+        relentr_dual = vcat(fill(inv(9), 10), fill(-inv(9), 9))
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, var_primal,
+            (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}) => fill(-inv(9), 9),
+            (MOI.VectorOfVariables, MOI.Nonnegatives) => [[1]],
+            (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone) => [relentr_dual])
+
+        MOIT.geomean2ftest(bridged_mock, config)
+
+        var_names = vcat("t", ["x$(i)" for i in 1:9])
+        MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+
+        nonneg = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorOfVariables, MOI.Nonnegatives}())
+        relentr = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone}())
+        aux = MOI.get(mock, MOI.ListOfVariableIndices())[end]
+
+        @testset "Test mock model" begin
+            MOI.set(mock, MOI.VariableName(), aux, "aux")
+            @test length(nonneg) == 1
+            MOI.set(mock, MOI.ConstraintName(), nonneg[1], "nonneg")
+            @test length(relentr) == 1
+            MOI.set(mock, MOI.ConstraintName(), relentr[1], "relentr")
+            equalto = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}())
+            @test length(equalto) == 9
+            equalto_names = ["equalto$(i)" for i in 1:9]
+            MOI.set.(bridged_mock, MOI.ConstraintName(), equalto, equalto_names)
+
+            s = """
+            variables: t, x1, x2, x3, x4, x5, x6, x7, x8, x9, aux
+            equalto1: 1.0x1 in MathOptInterface.EqualTo(1.0)
+            equalto2: 1.0x2 in MathOptInterface.EqualTo(1.0)
+            equalto3: 1.0x3 in MathOptInterface.EqualTo(1.0)
+            equalto4: 1.0x4 in MathOptInterface.EqualTo(1.0)
+            equalto5: 1.0x5 in MathOptInterface.EqualTo(1.0)
+            equalto6: 1.0x6 in MathOptInterface.EqualTo(1.0)
+            equalto7: 1.0x7 in MathOptInterface.EqualTo(1.0)
+            equalto8: 1.0x8 in MathOptInterface.EqualTo(1.0)
+            equalto9: 1.0x9 in MathOptInterface.EqualTo(1.0)
+            nonneg: [aux] in MathOptInterface.Nonnegatives(1)
+            relentr: [0.0, x1, x2, x3, x4, x5, x6, x7, x8, x9, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux] in MathOptInterface.RelativeEntropyCone(19)
+            maxobjective: t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(mock, model, vcat(var_names, "aux"), vcat(equalto_names, "nonneg", "relentr"))
+        end
+
+        @testset "Test bridged model" begin
+            geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
+            @test length(geomean) == 1
+            MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
+            equalto = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}}())
+            @test length(equalto) == 9
+            equalto_names = ["equalto$(i)" for i in 1:9]
+            MOI.set.(bridged_mock, MOI.ConstraintName(), equalto, equalto_names)
+
+            s = """
+            variables: t, x1, x2, x3, x4, x5, x6, x7, x8, x9
+            equalto1: 1.0x1 in MathOptInterface.EqualTo(1.0)
+            equalto2: 1.0x2 in MathOptInterface.EqualTo(1.0)
+            equalto3: 1.0x3 in MathOptInterface.EqualTo(1.0)
+            equalto4: 1.0x4 in MathOptInterface.EqualTo(1.0)
+            equalto5: 1.0x5 in MathOptInterface.EqualTo(1.0)
+            equalto6: 1.0x6 in MathOptInterface.EqualTo(1.0)
+            equalto7: 1.0x7 in MathOptInterface.EqualTo(1.0)
+            equalto8: 1.0x8 in MathOptInterface.EqualTo(1.0)
+            equalto9: 1.0x9 in MathOptInterface.EqualTo(1.0)
+            geomean: [1.0t, x1, x2, x3, x4, x5, x6, x7, x8, x9] in MathOptInterface.GeometricMeanCone(10)
+            maxobjective: t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(bridged_mock, model, var_names, vcat(equalto_names, "geomean"))
+        end
+
+        ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
+
+        @testset "$attr" for attr in [MOI.ConstraintPrimalStart(), MOI.ConstraintDualStart()]
+            @test MOI.supports(bridged_mock, attr, typeof(ci))
+            value = (attr isa MOI.ConstraintPrimalStart) ? ones(10) : vcat(-1, fill(inv(9), 9))
+            MOI.set(bridged_mock, attr, ci, value)
+            @test MOI.get(bridged_mock, attr, ci) ≈ value
+            if attr isa MOI.ConstraintPrimalStart
+                @test MOI.get(mock, MOI.VariablePrimalStart(), aux) == 0
+                @test MOI.get(mock, attr, nonneg[1]) == [0]
+                @test MOI.get(mock, attr, relentr[1]) == vcat(0, ones(18))
+            else
+                @test MOI.get(mock, attr, nonneg[1]) == [1]
+                @test MOI.get(mock, attr, relentr[1]) == relentr_dual
+            end
+        end
+
+        test_delete_bridge(bridged_mock, ci, 10, (
+            (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}, 9),
+            (MOI.VectorOfVariables, MOI.Nonnegatives, 0),
+            (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone, 0)))
+    end
+
+    @testset "geomean3test" begin
+        var_primal = [2, 2, 0]
+        relentr_dual = [2, 2, -2]
+        mock.optimize! = (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, var_primal,
+            (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-2],
+            (MOI.VectorOfVariables, MOI.Nonnegatives) => [[2]],
+            (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone) => [relentr_dual])
+
+        MOIT.geomean3ftest(bridged_mock, config)
+
+        var_names = ["t", "x"]
+        MOI.set(bridged_mock, MOI.VariableName(), MOI.get(bridged_mock, MOI.ListOfVariableIndices()), var_names)
+
+        nonneg = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorOfVariables, MOI.Nonnegatives}())
+        relentr = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone}())
+        aux = MOI.get(mock, MOI.ListOfVariableIndices())[end]
+
+        @testset "Test mock model" begin
+            MOI.set(mock, MOI.VariableName(), aux, "aux")
+            @test length(nonneg) == 1
+            MOI.set(mock, MOI.ConstraintName(), nonneg[1], "nonneg")
+            @test length(relentr) == 1
+            MOI.set(mock, MOI.ConstraintName(), relentr[1], "relentr")
+            less = MOI.get(mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+            @test length(less) == 1
+            MOI.set(mock, MOI.ConstraintName(), less[1], "less")
+
+            s = """
+            variables: t, x, aux
+            less: 1.0x in MathOptInterface.LessThan(2.0)
+            nonneg: [aux] in MathOptInterface.Nonnegatives(1)
+            relentr: [0.0, x, t + aux] in MathOptInterface.RelativeEntropyCone(3)
+            maxobjective: 2.0t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(mock, model, vcat(var_names, "aux"), ["less", "nonneg", "relentr"])
+        end
+
+        @testset "Test bridged model" begin
+            geomean = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}())
+            @test length(geomean) == 1
+            MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
+            less = MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}())
+            @test length(less) == 1
+            MOI.set(bridged_mock, MOI.ConstraintName(), less[1], "less")
+
+            s = """
+            variables: t, x
+            less: 1.0x in MathOptInterface.LessThan(2.0)
+            geomean: [1.0t, x] in MathOptInterface.GeometricMeanCone(2)
+            maxobjective: 2.0t
+            """
+            model = MOIU.Model{Float64}()
+            MOIU.loadfromstring!(model, s)
+            MOIU.test_models_equal(bridged_mock, model, var_names, ["less", "geomean"])
+        end
+
+        ci = first(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone}()))
+
+        @testset "$attr" for attr in [MOI.ConstraintPrimalStart(), MOI.ConstraintDualStart()]
+            @test MOI.supports(bridged_mock, attr, typeof(ci))
+            value = (attr isa MOI.ConstraintPrimalStart) ? [2, 2] : [-2, 2]
+            MOI.set(bridged_mock, attr, ci, value)
+            @test MOI.get(bridged_mock, attr, ci) ≈ value
+            if attr isa MOI.ConstraintPrimalStart
+                @test MOI.get(mock, MOI.VariablePrimalStart(), aux) == 0
+                @test MOI.get(mock, attr, nonneg[1]) == [0]
+                @test MOI.get(mock, attr, relentr[1]) == [0, 2, 2]
+            else
+                @test MOI.get(mock, attr, nonneg[1]) == [2]
+                @test MOI.get(mock, attr, relentr[1]) == relentr_dual
+            end
+        end
+
+        test_delete_bridge(bridged_mock, ci, 2, (
+            (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 1),
+            (MOI.VectorOfVariables, MOI.Nonnegatives, 0),
+            (MOI.VectorAffineFunction{Float64}, MOI.RelativeEntropyCone, 0)))
+    end
 end

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -107,7 +107,6 @@ struct DummyConstraintAttribute <: MOI.AbstractConstraintAttribute end
         @testset "Bridged variable" begin
             err = ErrorException("Cannot substitute `$x` as it is bridged into `$(1.0fy + 1.0)`.")
             @test_throws err MOI.submit(bridged, sub, [x], [1.0])
-
         end
     end
 

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -882,7 +882,7 @@ MOIU.@model(ModelNoZeroIndicator,
             (MOI.Reals, MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives,
              MOI.NormInfinityCone, MOI.NormOneCone,
              MOI.SecondOrderCone, MOI.RotatedSecondOrderCone,
-             MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone,
+             MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone, MOI.RelativeEntropyCone,
              MOI.NormSpectralCone, MOI.NormNuclearCone,
              MOI.PositiveSemidefiniteConeTriangle, MOI.PositiveSemidefiniteConeSquare,
              MOI.RootDetConeTriangle, MOI.RootDetConeSquare, MOI.LogDetConeTriangle,
@@ -899,7 +899,7 @@ MOIU.@model(ModelNoIndicator,
             (MOI.Reals, MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives,
              MOI.NormInfinityCone, MOI.NormOneCone,
              MOI.SecondOrderCone, MOI.RotatedSecondOrderCone,
-             MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone,
+             MOI.GeometricMeanCone, MOI.ExponentialCone, MOI.DualExponentialCone, MOI.RelativeEntropyCone,
              MOI.NormSpectralCone, MOI.NormNuclearCone,
              MOI.PositiveSemidefiniteConeTriangle, MOI.PositiveSemidefiniteConeSquare,
              MOI.RootDetConeTriangle, MOI.RootDetConeSquare, MOI.LogDetConeTriangle,
@@ -1010,6 +1010,8 @@ end
                                       MOI.PositiveSemidefiniteConeSquare)
         @test MOI.supports_constraint(full_bridged_mock, F,
                                       MOI.GeometricMeanCone)
+        @test MOI.supports_constraint(full_bridged_mock, F,
+                                      MOI.RelativeEntropyCone)
         @test !MOI.supports_constraint(
             greater_nonneg_mock, F, MOI.Nonpositives)
         @test MOI.supports_constraint(


### PR DESCRIPTION
as discussed with @blegat.
relative entropy can bridge to exponential cones, so we have an exponential cone extended formulation for geomean.
can later be extended easily for more general weighted power means from #977.
@blegat the dual transformations here used a bit of guesswork - perhaps you can check them?
I added dual solution tests to geomean1 test.