### PR TITLE
Add dual in RelativeEntropyCone docstring

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -326,6 +326,11 @@ end
     RelativeEntropyCone(dimension)
 
 The relative entropy cone ``\\{ (u, v, w) \\in \\mathbb{R}^{1+2n} : u \\ge \\sum_{i=1}^n w_i \\log (\\frac{w_i}{v_i}), v_i \\ge 0, w_i \\ge 0 \\}`` of dimension `dimension```{}=2n+1``.
+
+### Duality note
+
+The dual of the relative entropy cone is
+``\\{ (u, v, w) \\in \\mathbb{R}^{1+2n} : \\forall i, -u \\exp (v_i/u) \\le \\exp(1) w_i, u < 0 \\}`` of dimension `dimension```{}=2n+1``.
 """
 struct RelativeEntropyCone <: AbstractVectorSet
     dimension::Int

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -331,6 +331,7 @@ The relative entropy cone ``\\{ (u, v, w) \\in \\mathbb{R}^{1+2n} : u \\ge \\sum
 
 The dual of the relative entropy cone is
 ``\\{ (u, v, w) \\in \\mathbb{R}^{1+2n} : \\forall i, -u \\exp (v_i/u) \\le \\exp(1) w_i, u < 0 \\}`` of dimension `dimension```{}=2n+1``.
+Note that the inequality is rewritten in terms of ``\\log`` as follows: ``v_i \\le u (\\log(w_i/-u) + 1)``.
 """
 struct RelativeEntropyCone <: AbstractVectorSet
     dimension::Int


### PR DESCRIPTION
It can be obtained from the bridge to exponential cone.
[I 0]^(-1) * RelEntr = [A B]^(-1) [Exp1 x ... x Expn x R+]
so
[I; 0] * RelEntr* = [A'; B'] * [Exp1* x ... x Expn* x R+]
B' * R+ = 0 says that the u_i are all equal.
Then A' * [Exp1* x ... x Expn*] gives the dual exponential cone constraints with the same u_i