### PR TITLE
Fix warning of unsuppoted attribute

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -137,8 +137,8 @@ function _pass_attributes(dest::MOI.ModelLike, src::MOI.ModelLike,
             # As starting values are simply *hints* for the optimization, not
             # supporting them gives a warning, not an error
             if !MOI.supports(dest, attr, supports_args...)
-                @warn("$attr is not supported by $(typeof(dest)). This ",
-                             "information will be discarded.")
+                @warn("$attr is not supported by $(typeof(dest)). This " *
+                      "information will be discarded.")
                 continue
             end
         end


### PR DESCRIPTION
The comma doesn't do what I expected:
```julia
julia> @warn("a", "b")
┌ Warning: a
│   b = "b"
└
```