### PR TITLE
Make AbstractModel <: AbstractOptimizer

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -851,8 +851,11 @@ addition to being different between constraints `F`-in-`S` for the same types
 use the the value of the index directly in a dictionary representing a mapping
 between constraint indices and something else.
 
-If `is_optimizer = true`, the resulting stuct is a subtype of
-`MOIU.AbstractOptimizer`, otherwise, it is a subtype of `MOIU.AbstractModelLike`.
+If `is_optimizer = true`, the resulting struct is a subtype of
+of `MOIU.AbstractOptimizer`, which is a subtype of
+[`MathOptInterface.AbstractOptimizer`](@ref), otherwise, it is a subtype of
+`MOIU.AbstractModelLike`, which is a subtype of
+[`MathOptInterface.ModelLike`](@ref).
 
 ### Examples
 
@@ -866,8 +869,8 @@ The model describing an linear program would be:
       (),                                                         # untyped scalar functions
       (MOI.ScalarAffineFunction,),                                #   typed scalar functions
       (MOI.VectorOfVariables,),                                   # untyped vector functions
-      (MOI.VectorAffineFunction,)                                 #   typed vector functions
-      true
+      (MOI.VectorAffineFunction,),                                #   typed vector functions
+      false
     )
 ```
 
@@ -886,7 +889,7 @@ struct LPModelVectorConstraints{T, F <: MOI.AbstractVectorFunction} <: MOIU.Cons
     nonnegatives::Vector{MOIU.ConstraintEntry{F, MOI.Nonnegatives}}
     nonpositives::Vector{MOIU.ConstraintEntry{F, MOI.Nonpositives}}
 end
-mutable struct LPModel{T} <: MOIU.AbstractOptimizer{T}
+mutable struct LPModel{T} <: MOIU.AbstractModel{T}
     name::String
     sense::MOI.OptimizationSense
     objective::Union{MOI.SingleVariable, MOI.ScalarAffineFunction{T}, MOI.ScalarQuadraticFunction{T}}

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -82,7 +82,7 @@ function _getlocr(constrs::Vector{<:ConstraintEntry},
 end
 
 # Implementation of MOI for AbstractModel
-abstract type AbstractModel{T} <: MOI.ModelLike end
+abstract type AbstractModel{T} <: MOI.AbstractOptimizer end
 
 getconstrloc(model::AbstractModel, ci::CI) = model.constrmap[ci.value]
 

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -886,7 +886,7 @@ struct LPModelVectorConstraints{T, F <: MOI.AbstractVectorFunction} <: MOIU.Cons
     nonnegatives::Vector{MOIU.ConstraintEntry{F, MOI.Nonnegatives}}
     nonpositives::Vector{MOIU.ConstraintEntry{F, MOI.Nonpositives}}
 end
-mutable struct LPModel{T} <: MOI.AbstractOptimizer
+mutable struct LPModel{T} <: MOIU.AbstractOptimizer{T}
     name::String
     sense::MOI.OptimizationSense
     objective::Union{MOI.SingleVariable, MOI.ScalarAffineFunction{T}, MOI.ScalarQuadraticFunction{T}}

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -25,7 +25,7 @@ module TestExternalModel
         (NewFunction,),
         (),
         (),
-        (),
+        ()
     )
     MathOptInterface.Utilities.@model(ExternalOptimizer,
         (MathOptInterface.ZeroOne, NewSet,),
@@ -45,8 +45,10 @@ end
     optimizer = TestExternalModel.ExternalOptimizer{Float64}()
     @test isa(model, MOIU.AbstractModelLike{Float64})
     @test !isa(model, MOIU.AbstractOptimizer{Float64})
+    @test !isa(model, MOI.AbstractOptimizer)
     @test !isa(optimizer, MOIU.AbstractModelLike{Float64})
     @test isa(optimizer, MOIU.AbstractOptimizer{Float64})
+    @test isa(optimizer, MOI.AbstractOptimizer)
 end
 
 @testset "External @model" begin

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -25,8 +25,28 @@ module TestExternalModel
         (NewFunction,),
         (),
         (),
-        ()
+        (),
     )
+    MathOptInterface.Utilities.@model(ExternalOptimizer,
+        (MathOptInterface.ZeroOne, NewSet,),
+        (),
+        (),
+        (),
+        (NewFunction,),
+        (),
+        (),
+        (),
+        true
+    )
+end
+
+@testset "Super-types" begin
+    model = TestExternalModel.ExternalModel{Float64}()
+    optimizer = TestExternalModel.ExternalOptimizer{Float64}()
+    @test isa(model, MOIU.AbstractModelLike{Float64})
+    @test !isa(model, MOIU.AbstractOptimizer{Float64})
+    @test !isa(optimizer, MOIU.AbstractModelLike{Float64})
+    @test isa(optimizer, MOIU.AbstractOptimizer{Float64})
 end
 
 @testset "External @model" begin


### PR DESCRIPTION
### Commit 1

One potential fix for #1030 

Pros: this passes tests and is simple.

Cons: 
- we don't define `optimize!`, which might violate the contract of `AbstractOptimizer`. 
- Can this break code? 
I don't think it breaks any of mine. I'm also not aware of any code that assumes that a `@model` is `<: ModelLike`, but not `<: AbstractOptimizer`.

### Commit 2/3

Alternative fix for #1030

Adds a flag to switch between `MOIU.AbstractModelLike` and `MOIU.AbstractOptimizer`.

Pros: flexible.

Cons: will this break code that uses `MOIU.AbstractModel{T}`?