### PR TITLE
Add tests for semi continuous and semi integer variables

### DIFF
--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -681,7 +681,7 @@ function indicator4_test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
-function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
+function _semitest(model::MOI.ModelLike, config::TestConfig{T}, int::Bool) where T
     atol = config.atol
     rtol = config.rtol
 
@@ -770,129 +770,17 @@ function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.ResultCount()) >= 1
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.5 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.5, 2.5] atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.5
-    end
-
-    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
-
-    if config.solve
-        MOI.optimize!(model)
-
-        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.ResultCount()) >= 1
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0, 3.0] atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
-    end
-
-    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5)))
-
-     if config.solve
-        MOI.optimize!(model)
-
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
-            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
-    end
-end
-
-function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
-    atol = config.atol
-    rtol = config.rtol
-
-    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
-    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
-    @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.Semiinteger{T})
-
-    # 2 variables
-    # min  x
-    # st   x >= y
-    #      x ∈ {0.0} U {2.0} U {3.0}
-    #      y = 0.0
-
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
-
-    v = MOI.add_variables(model, 2)
-    @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
-    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.Semiinteger(T(2), T(3)))
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Semiinteger{T}}()) == 1
-
-    vc2 = MOI.add_constraint(model, MOI.SingleVariable(v[2]), MOI.EqualTo(zero(T)))
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{T}}()) == 1
-
-    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], v), zero(T))
-    c = MOI.add_constraint(model, cf, MOI.GreaterThan(zero(T)))
-    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
-
-    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.0], v), 0.0)
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
-    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
-    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
-
-    if config.solve
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
-        MOI.optimize!(model)
-
-        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.ResultCount()) >= 1
-        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 0] atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ObjectiveBound()) <= 0.0
-    end
-
-    # Change y fixed value
-
-    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(one(T)))
-
-    if config.solve
-        MOI.optimize!(model)
-
-        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.ResultCount()) >= 1
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0, 1.0] atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
-    end
-
-    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(2)))
-
-    if config.solve
-        MOI.optimize!(model)
-
-        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.ResultCount()) >= 1
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0, 2.0] atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
-    end
-
-    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5//2)))
-
-    if config.solve
-        MOI.optimize!(model)
-
-        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-        @test MOI.get(model, MOI.ResultCount()) >= 1
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0, 2.5] atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.5 atol=atol rtol=rtol
-        @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
+        if !int
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.5 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.5, 2.5] atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ObjectiveBound()) <= 2.5
+        else
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0, 2.5] atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.5 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
+        end
     end
 
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
@@ -911,13 +799,16 @@ function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
 
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(4)))
 
-    if config.solve
+     if config.solve
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
             MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
     end
 end
+
+semiconttest(model::MOI.ModelLike, config::TestConfig) = _semitest(model, config, false)
+semiinttest(model::MOI.ModelLike, config::TestConfig) = _semitest(model, config, true)
 
 const intlineartests = Dict("knapsack" => knapsacktest,
                             "int1"     => int1test,

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -724,17 +724,11 @@ function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,0] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 0.0
     end
 
@@ -746,17 +740,11 @@ function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,1.0] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0, 1.0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
     end
 
@@ -766,17 +754,11 @@ function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,2.0] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0, 2.0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
     end
 
@@ -786,17 +768,11 @@ function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.5 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.5,2.5] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.5, 2.5] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 2.5
     end
 
@@ -806,24 +782,17 @@ function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,3.0] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0, 3.0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
     end
 
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5)))
 
      if config.solve
-
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
@@ -874,17 +843,11 @@ function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,0] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 0.0
     end
 
@@ -896,17 +859,11 @@ function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,1.0] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0, 1.0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
     end
 
@@ -916,17 +873,11 @@ function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,2.0] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0, 2.0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
     end
 
@@ -936,17 +887,11 @@ function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,2.5] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0, 2.5] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.5 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
     end
 
@@ -956,17 +901,11 @@ function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
         MOI.optimize!(model)
 
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
-
-        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,3.0] atol=atol rtol=rtol
-
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0, 3.0] atol=atol rtol=rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
     end
 

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -696,16 +696,12 @@ function _semitest(model::MOI.ModelLike, config::TestConfig{T}, int::Bool) where
 
     # 2 variables
     #
-    # If int == false
     # min  x
     # st   x >= y
-    #      x ∈ {0.0} U [2.0,3.0]
-    #      y = 0.0
-    #
-    # If int == true
-    # min  x
-    # st   x >= y
-    #      x ∈ {0.0} U {2.0} U {3.0}
+    #      if !int
+    #           x ∈ {0.0} U [2.0,3.0]
+    #      if int
+    #           x ∈ {0.0} U {2.0} U {3.0}
     #      y = 0.0
 
     MOI.empty!(model)

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -681,7 +681,7 @@ function indicator4_test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
-function semiconttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
+function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
 
@@ -833,7 +833,7 @@ function semiconttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
     end
 end
 
-function semiinttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
+function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
     atol = config.atol
     rtol = config.rtol
 

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -681,6 +681,307 @@ function indicator4_test(model::MOI.ModelLike, config::TestConfig)
     end
 end
 
+function semiconttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
+    atol = config.atol
+    rtol = config.rtol
+
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.MathOptInterface.Semicontinuous{T})
+
+    # 2 variables
+    # min  x
+    # st   x >= y
+    #      x ∈ {0.0} U [2.0,3.0]
+    #      y = 0.0
+
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+
+    v = MOI.add_variables(model, 2)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.Semicontinuous(T(2), T(3)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Semicontinuous{T}}()) == 1
+
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(v[2]), MOI.EqualTo(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{T}}()) == 1
+
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], v), zero(T))
+    c = MOI.add_constraint(model, cf, MOI.GreaterThan(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
+
+    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.0], v), 0.0)
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
+
+    if config.solve
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 0.0
+    end
+
+    # Change y fixed value
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(one(T)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,1.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(2)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,2.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5//2)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.5 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.5,2.5] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.5
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
+
+    MOI.write_to_file(model.model, "antes3.lp")
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,3.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5)))
+
+     if config.solve
+
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
+    end
+end
+
+function semiinttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
+    atol = config.atol
+    rtol = config.rtol
+
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.MathOptInterface.Semiinteger{T})
+
+    # 2 variables
+    # min  x
+    # st   x >= y
+    #      x ∈ {0.0} U {2.0} U {3.0}
+    #      y = 0.0
+
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+
+    v = MOI.add_variables(model, 2)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.Semiinteger(T(2), T(3)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Semiinteger{T}}()) == 1
+
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(v[2]), MOI.EqualTo(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{T}}()) == 1
+
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], v), zero(T))
+    c = MOI.add_constraint(model, cf, MOI.GreaterThan(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
+
+    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.0], v), 0.0)
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
+
+    if config.solve
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 0.0
+    end
+
+    # Change y fixed value
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(one(T)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,1.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(2)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,2.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5//2)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,2.5] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.5 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,3.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(4)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
+    end
+end
+
 const intlineartests = Dict("knapsack" => knapsacktest,
                             "int1"     => int1test,
                             "int2"     => int2test,
@@ -689,6 +990,8 @@ const intlineartests = Dict("knapsack" => knapsacktest,
                             "indicator2"  => indicator2_test,
                             "indicator3"  => indicator3_test,
                             "indicator4"  => indicator4_test,
+                            "semiconttest" => semiconttest,
+                            "semiinttest" => semiinttest
                            )
 
 @moitestset intlinear

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -688,7 +688,7 @@ function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.MathOptInterface.Semicontinuous{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.Semicontinuous{T})
 
     # 2 variables
     # min  x
@@ -802,8 +802,6 @@ function semiconttest(model::MOI.ModelLike, config::TestConfig{T}) where T
 
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
 
-    MOI.write_to_file(model.model, "antes3.lp")
-
     if config.solve
         MOI.optimize!(model)
 
@@ -840,7 +838,7 @@ function semiinttest(model::MOI.ModelLike, config::TestConfig{T}) where T
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
     @test MOI.supports(model, MOI.ObjectiveSense())
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.MathOptInterface.Semiinteger{T})
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.Semiinteger{T})
 
     # 2 variables
     # min  x

--- a/test/Test/intlinear.jl
+++ b/test/Test/intlinear.jl
@@ -44,48 +44,48 @@ MOIU.set_mock_optimize!(mock,
 MOIT.indicator4_test(mock, config)
 MOIU.set_mock_optimize!(mock,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 0.0)
-    MOIU.mock_optimize!(mock, [0.0,0.0])
+        MOI.set(mock, MOI.ObjectiveBound(), 0.0)
+        MOIU.mock_optimize!(mock, [0.0, 0.0])
     end,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 2.0)
-    MOIU.mock_optimize!(mock, [2.0,1.0])
+        MOI.set(mock, MOI.ObjectiveBound(), 2.0)
+        MOIU.mock_optimize!(mock, [2.0, 1.0])
     end,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 2.0)
-    MOIU.mock_optimize!(mock, [2.0,2.0])
+        MOI.set(mock, MOI.ObjectiveBound(), 2.0)
+        MOIU.mock_optimize!(mock, [2.0, 2.0])
     end,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 2.5)
-    MOIU.mock_optimize!(mock, [2.5,2.5])
+        MOI.set(mock, MOI.ObjectiveBound(), 2.5)
+        MOIU.mock_optimize!(mock, [2.5, 2.5])
     end,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 3.0)
-    MOIU.mock_optimize!(mock, [3.0,3.0])
+        MOI.set(mock, MOI.ObjectiveBound(), 3.0)
+        MOIU.mock_optimize!(mock, [3.0, 3.0])
     end,
     (mock::MOIU.MockOptimizer) -> MOI.set(mock, MOI.TerminationStatus(), MOI.INFEASIBLE)
 )
 MOIT.semiconttest(mock,config)
 MOIU.set_mock_optimize!(mock,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 0.0)
-    MOIU.mock_optimize!(mock, [0.0,0.0])
+        MOI.set(mock, MOI.ObjectiveBound(), 0.0)
+        MOIU.mock_optimize!(mock, [0.0, 0.0])
     end,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 2.0)
-    MOIU.mock_optimize!(mock, [2.0,1.0])
+        MOI.set(mock, MOI.ObjectiveBound(), 2.0)
+        MOIU.mock_optimize!(mock, [2.0, 1.0])
     end,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 2.0)
-    MOIU.mock_optimize!(mock, [2.0,2.0])
+        MOI.set(mock, MOI.ObjectiveBound(), 2.0)
+        MOIU.mock_optimize!(mock, [2.0, 2.0])
     end,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 3.0)
-    MOIU.mock_optimize!(mock, [3.0,2.5])
+        MOI.set(mock, MOI.ObjectiveBound(), 3.0)
+        MOIU.mock_optimize!(mock, [3.0, 2.5])
     end,
     (mock::MOIU.MockOptimizer) -> begin
-    MOI.set(mock, MOI.ObjectiveBound(), 3.0)
-    MOIU.mock_optimize!(mock, [3.0,3.0])
+        MOI.set(mock, MOI.ObjectiveBound(), 3.0)
+        MOIU.mock_optimize!(mock, [3.0, 3.0])
     end,
     (mock::MOIU.MockOptimizer) -> MOI.set(mock, MOI.TerminationStatus(), MOI.INFEASIBLE)
 )

--- a/test/Test/intlinear.jl
+++ b/test/Test/intlinear.jl
@@ -42,3 +42,51 @@ MOIU.set_mock_optimize!(mock,
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock, [1.25, 8.75, 0., 1.])
 )
 MOIT.indicator4_test(mock, config)
+MOIU.set_mock_optimize!(mock,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 0.0)
+    MOIU.mock_optimize!(mock, [0.0,0.0])
+    end,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 2.0)
+    MOIU.mock_optimize!(mock, [2.0,1.0])
+    end,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 2.0)
+    MOIU.mock_optimize!(mock, [2.0,2.0])
+    end,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 2.5)
+    MOIU.mock_optimize!(mock, [2.5,2.5])
+    end,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 3.0)
+    MOIU.mock_optimize!(mock, [3.0,3.0])
+    end,
+    (mock::MOIU.MockOptimizer) -> MOI.set(mock, MOI.TerminationStatus(), MOI.INFEASIBLE)
+)
+MOIT.semiconttest(mock,config)
+MOIU.set_mock_optimize!(mock,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 0.0)
+    MOIU.mock_optimize!(mock, [0.0,0.0])
+    end,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 2.0)
+    MOIU.mock_optimize!(mock, [2.0,1.0])
+    end,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 2.0)
+    MOIU.mock_optimize!(mock, [2.0,2.0])
+    end,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 3.0)
+    MOIU.mock_optimize!(mock, [3.0,2.5])
+    end,
+    (mock::MOIU.MockOptimizer) -> begin
+    MOI.set(mock, MOI.ObjectiveBound(), 3.0)
+    MOIU.mock_optimize!(mock, [3.0,3.0])
+    end,
+    (mock::MOIU.MockOptimizer) -> MOI.set(mock, MOI.TerminationStatus(), MOI.INFEASIBLE)
+)
+MOIT.semiinttest(mock,config)


### PR DESCRIPTION
I've added some tests for semi-continuous and semi-integer variables.
It's a simple model:
 min x 
     st   x >= y
           x ∈ {0.0} U [2.0,3.0]
           y = 0.0
And changed the fixed value of y to see the result.
I've tested on both CPLEX and Xpress solvers.