### PR TITLE
Bump BenchmarkTools version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-BenchmarkTools = "0.4"
+BenchmarkTools = "0.4, 0.5"
 CodecBzip2 = "~0.6"
 CodecZlib = "~0.6"
 JSON = "~0.21"


### PR DESCRIPTION
BenchmarkTools made a semver-breaking release although did not really break anything (just removed Julia 0.7 support and added features).

I could make a PR to add CompatHelper support if that would be desired.