### PR TITLE
[MOF] fix writing NLPBlock

### DIFF
--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -38,6 +38,9 @@ end
 function write_objective(
     object::Object, model::Model, name_map::Dict{MOI.VariableIndex, String}
 )
+    if object["objective"]["sense"] != "feasibility"
+        return  # Objective must have been written from NLPBlock.
+    end
     sense = MOI.get(model, MOI.ObjectiveSense())
     object["objective"] = Object("sense" => moi_to_object(sense))
     if sense != MOI.FEASIBILITY_SENSE

--- a/test/FileFormats/MOF/nlp.mof.json
+++ b/test/FileFormats/MOF/nlp.mof.json
@@ -21,9 +21,60 @@
   "objective": {
     "sense": "min",
     "function": {
-      "head": "ScalarAffineFunction",
-      "terms": [],
-      "constant": 0.0
+      "head": "ScalarNonlinearFunction",
+      "root": {
+        "head": "node",
+        "index": 3
+      },
+      "node_list": [
+        {
+          "head": "+",
+          "args": [
+            {
+              "head": "variable",
+              "name": "var_1"
+            },
+            {
+              "head": "variable",
+              "name": "var_2"
+            },
+            {
+              "head": "variable",
+              "name": "var_3"
+            }
+          ]
+        },
+        {
+          "head": "*",
+          "args": [
+            {
+              "head": "variable",
+              "name": "var_1"
+            },
+            {
+              "head": "variable",
+              "name": "var_4"
+            },
+            {
+              "head": "node",
+              "index": 1
+            }
+          ]
+        },
+        {
+          "head": "+",
+          "args": [
+            {
+              "head": "node",
+              "index": 2
+            },
+            {
+              "head": "variable",
+              "name": "var_3"
+            }
+          ]
+        }
+      ]
     }
   },
   "constraints": [


### PR DESCRIPTION
Two bugs:
1. We were still assuming `NLPBlock` used `x[1]` instead of `x[VariableIndex(1)]`
2. NLP objectives were being overwritten by empty linear/quadratic ones because the JSON file for the test was wrong :(