### PR TITLE
[SDPA] No scaling of off-diagonal coefficient

### DIFF
--- a/src/FileFormats/SDPA/SDPA.jl
+++ b/src/FileFormats/SDPA/SDPA.jl
@@ -173,17 +173,11 @@ function Base.write(io::IO, model::Model{T}) where {T}
     function _print_entry(matrix, block, psd, k, value)
         if psd
             row, col = index_map[k]
-            if row == col
-                entry = value
-            else
-                entry = value / 2
-            end
         else
             row = k
             col = k
-            entry = value
         end
-        println(io, matrix, ' ', block, ' ', row, ' ', col, ' ', entry)
+        println(io, matrix, ' ', block, ' ', row, ' ', col, ' ', value)
     end
     function _print_constraint(block, psd, ci::MOI.ConstraintIndex)
         func = MOI.Utilities.canonical(con_function(ci))
@@ -314,12 +308,7 @@ function Base.read!(io::IO, model::Model{T}) where T
                 end
                 k = row
             end
-            entry = parse(T, values[5])
-            if col == row
-                coef = entry
-            else
-                coef = entry * 2
-            end
+            coef = parse(T, values[5])
             if iszero(matrix)
                 if !iszero(coef)
                     funcs[block].constants[k] -= coef

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -194,12 +194,12 @@ example_models = [
         variables: x, y
         minobjective: 10x + 20y
         c1: [x + -1, 0, x + -2] in PositiveSemidefiniteConeTriangle(2)
-        c2: [5y + -3, 4y, 6y + -4] in PositiveSemidefiniteConeTriangle(2)
+        c2: [5y + -3, 2y, 6y + -4] in PositiveSemidefiniteConeTriangle(2)
     """),
     ("example_B.sdpa", """
         variables: x
         minobjective: 1x
-        c1: [0, 2x + -2, 0] in PositiveSemidefiniteConeTriangle(2)
+        c1: [0, 1x + -1, 0] in PositiveSemidefiniteConeTriangle(2)
     """),
 ]
 @testset "Read and write/read $model_name" for (model_name, model_string) in example_models


### PR DESCRIPTION
An entry `a` for an offdiagonal entry 1, 2 corresponds to exactly `a` for an the index 2 of PositiveSemidefiniteConeTriangle. I started from the dual version for writing the SDPA format where we should divide by 2 because it's counted twice but I forgot to remove this part.

Closes https://github.com/JuliaOpt/MathOptInterface.jl/issues/1071