### PR TITLE
Feature to read/write integer constraints

### DIFF
--- a/src/FileFormats/SDPA/SDPA.jl
+++ b/src/FileFormats/SDPA/SDPA.jl
@@ -8,7 +8,7 @@ import MathOptInterface
 const MOI = MathOptInterface
 
 MOI.Utilities.@model(Model,
-    (MOI.Integer,),
+    (),
     (),
     (MOI.Nonnegatives, MOI.PositiveSemidefiniteConeTriangle),
     (),
@@ -319,7 +319,7 @@ function Base.read!(io::IO, model::Model{T}) where T
             obj = zero(MOI.ScalarAffineFunction{T})
             for i in eachindex(c)
                 if !iszero(c[i])
-                    push!(obj.terms, MOI.ScalarAffineTerm(c[i], MOI.VariableIndex(i)))
+                    push!(obj.terms, MOI.ScalarAffineTerm(c[i], scalar_vars[i]))
                 end
             end
             MOI.set(model, MOI.ObjectiveFunction{typeof(obj)}(), obj)
@@ -351,7 +351,7 @@ function Base.read!(io::IO, model::Model{T}) where T
             else
                 if !iszero(coef)
                     push!(funcs[block].terms, MOI.VectorAffineTerm(k,
-                        MOI.ScalarAffineTerm(coef, MOI.VariableIndex(matrix))))
+                        MOI.ScalarAffineTerm(coef, scalar_vars[matrix])))
                 end
             end
         end

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -18,6 +18,7 @@ function set_var_and_con_names(model::MOI.ModelLike)
     idx = 0
     constraint_names = String[]
     for i in Iterators.flatten((
+        MOI.get(model, MOI.ListOfConstraintIndices{MOI.SingleVariable, MOI.Integer}()),
         MOI.get(model, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives}()),
         MOI.get(model, MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64}, MOI.PositiveSemidefiniteConeTriangle}())))
         idx += 1
@@ -70,7 +71,6 @@ end
             MOI.Interval(1.0, 2.0),
             MOI.Semiinteger(1.0, 2.0),
             MOI.Semicontinuous(1.0, 2.0),
-            MOI.Integer(),
             MOI.ZeroOne()
         ]
         model_string = """
@@ -200,6 +200,16 @@ example_models = [
         variables: x
         minobjective: 1x
         c1: [0, 1x + -1, 0] in PositiveSemidefiniteConeTriangle(2)
+    """),
+    ("example_integer.sdpa", """
+        variables: x, y, z
+        minobjective: 1x + -2y + -1z
+        c1: [1x, 1y, 1z] in PositiveSemidefiniteConeTriangle(2)
+        c2: [1z, 1x, 2.1] in PositiveSemidefiniteConeTriangle(2)
+        c3: [1x + 1y + 1z + -1, -1x + -1y + -1z + 8] in Nonnegatives(2)
+        c4: x in Integer()
+        c5: y in Integer()
+        c6: z in Integer()
     """),
 ]
 @testset "Read and write/read $model_name" for (model_name, model_string) in example_models

--- a/test/FileFormats/SDPA/models/example_integer.sdpa
+++ b/test/FileFormats/SDPA/models/example_integer.sdpa
@@ -1,0 +1,25 @@
+* Example from http://www.opt.tu-darmstadt.de/scipsdp/downloads/data_format.txt
+3
+3
+2 2 -2
+* the next line gives the objective values in the order of the variables
+1 -2 -1
+* the remaining lines give the nonzeroes of the constraints with variable (0 meaning the constant part) block row column value
+1 1 1 1 1
+2 1 1 2 1
+3 1 2 2 1
+1 2 1 2 1
+3 2 1 1 1
+0 2 2 2 -2.1
+1 3 1 1 1
+2 3 1 1 1
+3 3 1 1 1
+0 3 1 1 1
+1 3 2 2 -1
+2 3 2 2 -1
+3 3 2 2 -1
+0 3 2 2 -8
+*INTEGER
+*1
+*2
+*3


### PR DESCRIPTION
I have added a feature to read/write integer restrictions on single variables. This resolves #1074.
@blegat @odow, it would be great if you can review this PR.

The feature is based on the extension in http://www.opt.tu-darmstadt.de/scipsdp/downloads/data_format.txt and should be backward compatible.