### PR TITLE
Fix add_constrained_variable(s) for a CachingOptimizer with an attached optimizer

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -239,6 +239,68 @@ function MOI.add_variables(m::CachingOptimizer, n)
     return vindices
 end
 
+function MOI.add_constrained_variable(m::CachingOptimizer, set::MOI.AbstractScalarSet)
+    if m.state == MOIU.ATTACHED_OPTIMIZER
+        if m.mode == MOIU.AUTOMATIC
+            try
+                vindex_optimizer, cindex_optimizer =
+                    MOI.add_constrained_variable(m.optimizer, set)
+            catch err
+                if err isa MOI.NotAllowedError
+                    reset_optimizer(m)
+                else
+                    rethrow(err)
+                end
+            end
+        else
+            vindex_optimizer, cindex_optimizer =
+                MOI.add_constrained_variable(m.optimizer, set)
+        end
+    end
+    vindex = MOI.add_variable(m.model_cache)
+    cindex = MOI.add_constraint(m.model_cache, MOI.SingleVariable(vindex), set)
+    if m.state == MOIU.ATTACHED_OPTIMIZER
+        m.model_to_optimizer_map[vindex] = vindex_optimizer
+        m.optimizer_to_model_map[vindex_optimizer] = vindex
+        m.model_to_optimizer_map[cindex] = cindex_optimizer
+        m.optimizer_to_model_map[cindex_optimizer] = cindex
+    end
+    return vindex, cindex
+end
+
+function MOI.add_constrained_variables(m::CachingOptimizer, set::MOI.AbstractVectorSet)
+    if m.state == ATTACHED_OPTIMIZER
+        if m.mode == AUTOMATIC
+            try
+                vindices_optimizer, cindices_optimizer =
+                    MOI.add_constrained_variables(m.optimizer, set)
+            catch err
+                if err isa MOI.NotAllowedError
+                    reset_optimizer(m)
+                else
+                    rethrow(err)
+                end
+            end
+        else
+            vindices_optimizer, cindices_optimizer =
+                MOI.add_constrained_variables(m.optimizer, set)
+        end
+    end
+    vindices = MOI.add_variables(m.model_cache, MOI.dimension(set))
+    cindices = MOI.add_constraint(m.model_cache, MOI.VectorOfVariables(vindices), set)
+    if m.state == ATTACHED_OPTIMIZER
+        for (vindex, vindex_optimizer) in zip(vindices, vindices_optimizer)
+            m.model_to_optimizer_map[vindex] = vindex_optimizer
+            m.optimizer_to_model_map[vindex_optimizer] = vindex
+        end
+        for (cindex, cindex_optimizer) in zip(cindices, cindices_optimizer)
+            m.model_to_optimizer_map[cindex] = cindex_optimizer
+            m.optimizer_to_model_map[cindex_optimizer] = cindex
+        end
+    end
+    return vindices, cindices
+end
+
 function MOI.supports_constraint(m::CachingOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})
     MOI.supports_constraint(m.model_cache, F, S) && (m.state == NO_OPTIMIZER || MOI.supports_constraint(m.optimizer, F, S))
 end

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -272,7 +272,7 @@ function MOI.add_constrained_variables(m::CachingOptimizer, set::MOI.AbstractVec
     if m.state == ATTACHED_OPTIMIZER
         if m.mode == AUTOMATIC
             try
-                vindices_optimizer, cindices_optimizer =
+                vindices_optimizer, cindex_optimizer =
                     MOI.add_constrained_variables(m.optimizer, set)
             catch err
                 if err isa MOI.NotAllowedError

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -282,23 +282,21 @@ function MOI.add_constrained_variables(m::CachingOptimizer, set::MOI.AbstractVec
                 end
             end
         else
-            vindices_optimizer, cindices_optimizer =
+            vindices_optimizer, cindex_optimizer =
                 MOI.add_constrained_variables(m.optimizer, set)
         end
     end
     vindices = MOI.add_variables(m.model_cache, MOI.dimension(set))
-    cindices = MOI.add_constraint(m.model_cache, MOI.VectorOfVariables(vindices), set)
+    cindex = MOI.add_constraint(m.model_cache, MOI.VectorOfVariables(vindices), set)
     if m.state == ATTACHED_OPTIMIZER
         for (vindex, vindex_optimizer) in zip(vindices, vindices_optimizer)
             m.model_to_optimizer_map[vindex] = vindex_optimizer
             m.optimizer_to_model_map[vindex_optimizer] = vindex
         end
-        for (cindex, cindex_optimizer) in zip(cindices, cindices_optimizer)
-            m.model_to_optimizer_map[cindex] = cindex_optimizer
-            m.optimizer_to_model_map[cindex_optimizer] = cindex
-        end
+        m.model_to_optimizer_map[cindex] = cindex_optimizer
+        m.optimizer_to_model_map[cindex_optimizer] = cindex
     end
-    return vindices, cindices
+    return vindices, cindex
 end
 
 function MOI.supports_constraint(m::CachingOptimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})


### PR DESCRIPTION
Resolves #1083 

I have not added any tests yet as I am not sure where it would be best to do so. The "CachingOptimizer MANUAL mode" testset includes adding constraints after the optimizer has been attached, so it could be tested for there. 